### PR TITLE
docs: hackathon guide — sample prompts, use cases, and web app pitch

### DIFF
--- a/docs/hackathon/README.md
+++ b/docs/hackathon/README.md
@@ -1,0 +1,11 @@
+# OpenStudio MCP — Hackathon Guide
+
+> **Work in progress.** This directory will contain:
+>
+> - Sample prompts and expected outputs for hackathon participants
+> - Use case ideas for LLM + building energy modeling workflows
+> - Web app concept pitch (SPA with sliders → OpenStudio simulation)
+> - Recommendation to use CLI clients (Claude Code, Gemini CLI) for efficiency
+> - Tips on plan mode, context window management, and working fast
+
+See [`docs/examples/`](../examples/) for existing workflow walkthroughs.


### PR DESCRIPTION
## Summary

New `docs/hackathon/` directory with materials for hackathon participants.

### Planned content (WIP)
- Sample prompts and expected tool call / output pairs
- LLM + BEM use case ideas (parametric analysis, code compliance, retrofit, carbon reporting)
- Web app concept pitch: SPA with sliders → OpenStudio simulation → EUI/charts
- Recommendation to use CLI clients (Claude Code, Gemini CLI) over desktop apps for speed and context efficiency
- Tips on plan mode, context window management, and working fast in a hackathon

Split from #51 — content to be added before Monday.