### PR TITLE
Add native arm64 Dockerfile for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ cd openstudio-mcp
 docker build -t openstudio-mcp:dev -f docker/Dockerfile .
 ```
 
+**Apple Silicon (M-series):** the upstream `nrel/openstudio` base image is `amd64`-only, so the command above runs under Rosetta emulation. For a native `arm64` build that uses the official NREL arm64 `.deb`, use the `Dockerfile.arm64` variant instead:
+
+```bash
+docker build --platform linux/arm64 -t openstudio-mcp:arm64 -f docker/Dockerfile.arm64 .
+```
+
+Then reference `openstudio-mcp:arm64` in your MCP host config below.
+
 ### Step 2: Configure Claude Desktop
 
 Open your Claude Desktop config file:

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,84 @@
+# Native arm64 image for Apple Silicon. Mirrors the canonical
+# docker/Dockerfile but bases on ubuntu:24.04 + the official NREL arm64 .deb
+# instead of the amd64-only nrel/openstudio image. Only this file's first
+# stage differs from the canonical Dockerfile; the measure/venv/copy layers
+# below are kept aligned with it.
+
+ARG OPENSTUDIO_VERSION=3.11.0
+ARG OPENSTUDIO_SHA=241b8abb4d
+
+FROM --platform=linux/arm64 ubuntu:24.04
+ARG OPENSTUDIO_VERSION
+ARG OPENSTUDIO_SHA
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-venv python3-pip \
+    ca-certificates curl \
+    libssl-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# OpenStudio arm64 — official NREL .deb. Pulls in Ruby, libstdc++, etc. as deps.
+RUN curl -fSL \
+      "https://github.com/NREL/OpenStudio/releases/download/v${OPENSTUDIO_VERSION}/OpenStudio-${OPENSTUDIO_VERSION}+${OPENSTUDIO_SHA}-Ubuntu-24.04-arm64.deb" \
+      -o /tmp/openstudio.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/openstudio.deb \
+    && rm /tmp/openstudio.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && openstudio --version
+
+# ComStock measures (openstudio-standards-based templates for space types,
+# constructions, HVAC, schedules). Only the measures/ directory is kept (~50 MB).
+ARG COMSTOCK_TAG=2025-3
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && curl -sL https://github.com/NatLabRockies/ComStock/archive/refs/tags/${COMSTOCK_TAG}.tar.gz | \
+       tar xz -C /tmp \
+    && mv /tmp/ComStock-*/resources/measures /opt/comstock-measures \
+    && rm -rf /tmp/ComStock-* \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV COMSTOCK_MEASURES_DIR=/opt/comstock-measures
+
+# Common measures (openstudio-common-measures-gem)
+ARG COMMON_MEASURES_TAG=v0.12.3
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && curl -sL https://github.com/NatLabRockies/openstudio-common-measures-gem/archive/refs/tags/${COMMON_MEASURES_TAG}.tar.gz | \
+       tar xz -C /tmp \
+    && mv /tmp/openstudio-common-measures-gem-*/lib/measures /opt/common-measures \
+    && rm -rf /tmp/openstudio-common-measures-gem-* \
+    && apt-get purge -y curl && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV COMMON_MEASURES_DIR=/opt/common-measures
+
+WORKDIR /repo
+
+# venv (Python 3.12 on Ubuntu 24.04 — pyproject requires >=3.11)
+ENV VENV_PATH=/opt/venv
+RUN python3 -m venv $VENV_PATH
+ENV PATH="$VENV_PATH/bin:$PATH"
+
+# Copy everything needed to install the package
+COPY pyproject.toml /repo/pyproject.toml
+COPY mcp_server /repo/mcp_server
+COPY docker /repo/docker
+
+RUN pip install --no-cache-dir -U pip \
+    && pip install --no-cache-dir -e ".[dev]"
+
+COPY .claude/skills /skills
+COPY scripts /repo/scripts
+COPY tests /repo/tests
+COPY README.md /repo/README.md
+COPY LICENSE.md /repo/LICENSE.md
+COPY .github /repo/.github
+
+ENV OSMCP_RUN_ROOT=/runs
+ENV OSMCP_MAX_CONCURRENCY=1
+ENV OSMCP_CODE_MODE=0
+ENV PYTHONUNBUFFERED=1
+ENV OPENSTUDIO_MCP_MODE=dev
+
+CMD ["openstudio-mcp"]


### PR DESCRIPTION
## Summary

Adds `docker/Dockerfile.arm64`, a build variant that produces a native `arm64` image for Apple Silicon. The upstream `nrel/openstudio` base image is `amd64`-only, so the canonical Dockerfile runs under Rosetta emulation on M-series Macs. This variant instead bases on `ubuntu:24.04` and installs the official NREL OpenStudio 3.11.0 `arm64.deb` directly.

Result on my machine (M-series, Docker Desktop 29.4):
- Image size: 2.95 GB (vs 5.73 GB for the amd64 build)
- `uname -m` in the container reports `aarch64` — no emulation

README Quick Start gains a short paragraph pointing arm64 users at the new file.

## Test plan

- [x] `docker build --platform linux/arm64 -t openstudio-mcp:arm64 -f docker/Dockerfile.arm64 .` succeeds locally.
- [x] `openstudio --version` reports `3.11.0+241b8abb4d`.
- [x] `python3 -c "import openstudio; print(openstudio.openStudioVersion())"` reports `3.11.0` (uses the `manylinux2014_aarch64` wheel from PyPI).
- [x] `from mcp_server.server import main` imports cleanly.
- [x] End-to-end smoke test: Claude Desktop spawns the container and the tools appear in the hammer-icon list.

## Notes

- Base is `ubuntu:24.04` (Python 3.12), not 22.04 (Python 3.10), because `pyproject.toml` requires Python ≥ 3.11. The canonical Dockerfile only gets away with 22.04 because the upstream `nrel/openstudio` image bundles a newer Python — something to consider tidying up separately.
- The arm64 `.deb` populates its own `/var/oscli/`, so no extra `bundle install` step is needed.
- CI is unchanged. Happy to follow up with an arm64 matrix job if maintainers want it.