### PR TITLE
fix(arm64): populate /var/oscli + add CI sanity job + clarify README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
             set -euo pipefail
             test -d /opt/comstock-measures
             test -d /opt/common-measures
-            # at least one .rb measure script in each
-            find /opt/comstock-measures -name measure.rb | head -1 | grep -q .
-            find /opt/common-measures   -name measure.rb | head -1 | grep -q .
+            # at least one measure.rb in each (-quit avoids SIGPIPE under pipefail)
+            test -n "$(find /opt/comstock-measures -name measure.rb -print -quit)"
+            test -n "$(find /opt/common-measures   -name measure.rb -print -quit)"
           '
 
       - name: Sanity — python openstudio binding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,21 @@ jobs:
             cd /var/oscli
             bundle list > /tmp/gems.txt
             cat /tmp/gems.txt
-            grep -q openstudio-standards  /tmp/gems.txt
-            grep -q openstudio-extension  /tmp/gems.txt
-            grep -q openstudio-common-measures /tmp/gems.txt
+            grep -q openstudio-standards /tmp/gems.txt
+            grep -q openstudio-extension /tmp/gems.txt
+            grep -q openstudio-workflow  /tmp/gems.txt
+            grep -q openstudio-gems      /tmp/gems.txt
+          '
+
+      - name: Sanity — measure dirs from tarballs
+        run: |
+          docker run --rm openstudio-mcp:arm64 bash -lc '
+            set -euo pipefail
+            test -d /opt/comstock-measures
+            test -d /opt/common-measures
+            # at least one .rb measure script in each
+            find /opt/comstock-measures -name measure.rb | head -1 | grep -q .
+            find /opt/common-measures   -name measure.rb | head -1 | grep -q .
           '
 
       - name: Sanity — python openstudio binding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,71 @@ on:
   pull_request:
 
 jobs:
+  arm64-build:
+    # Validates Dockerfile.arm64 builds end-to-end and /var/oscli is populated
+    # (without it, every measure-based MCP tool fails at runtime). Native arm64
+    # runner — free on public repos, ~5-10x faster than QEMU on amd64.
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.arm64
+          platforms: linux/arm64
+          tags: openstudio-mcp:arm64
+          load: true
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+
+      - name: Sanity — openstudio CLI
+        run: |
+          docker run --rm openstudio-mcp:arm64 bash -lc '
+            set -euo pipefail
+            openstudio --version
+            openstudio openstudio_version | grep -F "3.11.0"
+          '
+
+      - name: Sanity — /var/oscli gems installed
+        run: |
+          docker run --rm openstudio-mcp:arm64 bash -lc '
+            set -euo pipefail
+            test -f /var/oscli/Gemfile.lock
+            test -f /var/oscli/Gemfile
+            test -d /var/oscli/gems
+            cd /var/oscli
+            bundle list > /tmp/gems.txt
+            cat /tmp/gems.txt
+            grep -q openstudio-standards  /tmp/gems.txt
+            grep -q openstudio-extension  /tmp/gems.txt
+            grep -q openstudio-common-measures /tmp/gems.txt
+          '
+
+      - name: Sanity — python openstudio binding
+        run: |
+          docker run --rm openstudio-mcp:arm64 bash -lc '
+            set -euo pipefail
+            python -c "import openstudio; v = openstudio.openStudioVersion(); print(v); assert v == \"3.11.0\", v"
+          '
+
+      - name: Sanity — mcp_server imports
+        run: |
+          docker run --rm openstudio-mcp:arm64 bash -lc '
+            set -euo pipefail
+            python -c "from mcp_server.server import main; print(\"main:\", main)"
+          '
+
+      - name: Sanity — unit tests
+        run: |
+          mkdir -p runs
+          docker run --rm \
+            -v "$PWD:/repo" -v "$PWD/runs:/runs" \
+            openstudio-mcp:arm64 \
+            bash -lc 'cd /repo && pytest -vv -m "not integration" --timeout=60'
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ Add (or merge into) the `mcpServers` block:
 }
 ```
 
+**About the `-v` flags** — each one is `-v <host-path>:<container-path>[:ro]`. Docker exposes the host folder inside the container at the second path, so the MCP server can read/write your files. The optional `:ro` makes it read-only. The `./` prefix is **relative to wherever your MCP host launches `docker` from** — if it doesn't resolve, swap in absolute paths (e.g. `/Users/you/openstudio-mcp/runs:/runs` on macOS, `C:\projects\openstudio-mcp\runs:/runs` on Windows).
+
 - `./tests/assets:/inputs` — mounts the included test models so you can experiment right away. Replace with your own folder (e.g. `~/my-models:/inputs`) when ready.
 - `./runs:/runs` — simulation outputs are written here
-- `./.claude/skills:/skills:ro` — makes workflow guides available via `list_skills()` / `get_skill()` tools
+- `./.claude/skills:/skills:ro` — makes workflow guides available via `list_skills()` / `get_skill()` tools (read-only)
 - **Restart Claude Desktop** after saving the config file
 
 ### Step 3: Verify Connection

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ The server handles all the OpenStudio/EnergyPlus complexity behind MCP tool call
 ```bash
 git clone https://github.com/NatLabRockies/openstudio-mcp.git
 cd openstudio-mcp
-docker build -t openstudio-mcp:dev -f docker/Dockerfile .
 ```
 
-**Apple Silicon (M-series):** the upstream `nrel/openstudio` base image is `amd64`-only, so the command above runs under Rosetta emulation. For a native `arm64` build that uses the official NREL arm64 `.deb`, use the `Dockerfile.arm64` variant instead:
+**Pick the right Dockerfile for your machine** — both produce the same `openstudio-mcp:dev` image, so Step 2's config below works either way.
 
-```bash
-docker build --platform linux/arm64 -t openstudio-mcp:arm64 -f docker/Dockerfile.arm64 .
-```
+| Machine | Command |
+|---------|---------|
+| Intel/AMD (Linux, Windows, Intel Mac) | `docker build -t openstudio-mcp:dev -f docker/Dockerfile .` |
+| Apple Silicon (M-series Mac) | `docker build --platform linux/arm64 -t openstudio-mcp:dev -f docker/Dockerfile.arm64 .` |
 
-Then reference `openstudio-mcp:arm64` in your MCP host config below.
+Why two files? The upstream `nrel/openstudio` base image is `amd64`-only. On Apple Silicon, `docker/Dockerfile` runs under slow Rosetta emulation; `docker/Dockerfile.arm64` builds natively from the official NREL arm64 `.deb` and is several times faster at runtime.
 
 ### Step 2: Configure Claude Desktop
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -6,28 +6,52 @@
 
 ARG OPENSTUDIO_VERSION=3.11.0
 ARG OPENSTUDIO_SHA=241b8abb4d
+ARG OS_BUNDLER_VERSION=2.4.10
 
 FROM --platform=linux/arm64 ubuntu:24.04
 ARG OPENSTUDIO_VERSION
 ARG OPENSTUDIO_SHA
+ARG OS_BUNDLER_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Base deps + ruby/bundler toolchain so we can populate /var/oscli below.
+# Mirrors NREL docker-openstudio: ruby-full + libyaml-dev + native build deps,
+# plus gdebi for the .deb install (resolves deps cleanly).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-venv python3-pip \
-    ca-certificates curl \
-    libssl-dev libffi-dev \
+    ca-certificates curl gdebi-core \
+    libssl-dev libffi-dev libsqlite3-dev libyaml-dev zlib1g-dev \
+    build-essential git \
+    ruby-full \
     && rm -rf /var/lib/apt/lists/*
 
-# OpenStudio arm64 — official NREL .deb. Pulls in Ruby, libstdc++, etc. as deps.
+# OpenStudio arm64 — official NREL .deb. Pulls in libstdc++ etc. as deps.
 RUN curl -fSL \
       "https://github.com/NREL/OpenStudio/releases/download/v${OPENSTUDIO_VERSION}/OpenStudio-${OPENSTUDIO_VERSION}+${OPENSTUDIO_SHA}-Ubuntu-24.04-arm64.deb" \
       -o /tmp/openstudio.deb \
     && apt-get update \
-    && apt-get install -y --no-install-recommends /tmp/openstudio.deb \
+    && gdebi -n /tmp/openstudio.deb \
     && rm /tmp/openstudio.deb \
     && rm -rf /var/lib/apt/lists/* \
     && openstudio --version
+
+# /var/oscli — Bundler gems that `openstudio run` loads when executing measures.
+# The nrel/openstudio base image does this; the .deb does not. Without it,
+# every measure-based MCP tool fails at runtime (ComStock, common-measures,
+# apply_measure). Mirrors NREL/docker-openstudio's /var/oscli setup.
+RUN OPENSTUDIO_FOLDER=$(find /usr -maxdepth 2 -name "openstudio-${OPENSTUDIO_VERSION}*" -type d | head -n1) \
+    && test -n "$OPENSTUDIO_FOLDER" || { echo "openstudio install dir not found"; exit 1; } \
+    && echo "OPENSTUDIO_FOLDER=$OPENSTUDIO_FOLDER" \
+    && gem install bundler -v ${OS_BUNDLER_VERSION} --no-document \
+    && gem install zip --no-document \
+    && mkdir -p /var/oscli \
+    && cp "$OPENSTUDIO_FOLDER/Ruby/Gemfile" /var/oscli/ \
+    && cp "$OPENSTUDIO_FOLDER/Ruby/Gemfile.lock" /var/oscli/ \
+    && cp "$OPENSTUDIO_FOLDER/Ruby/openstudio-gems.gemspec" /var/oscli/ \
+    && cd /var/oscli \
+    && bundle _${OS_BUNDLER_VERSION}_ install --path=gems --without=native_ext --jobs=4 --retry=3 \
+    && test -d /var/oscli/gems || { echo "/var/oscli/gems missing after bundle install"; exit 1; }
 
 # ComStock measures (openstudio-standards-based templates for space types,
 # constructions, HVAC, schedules). Only the measures/ directory is kept (~50 MB).


### PR DESCRIPTION
## Summary
- Fix `Dockerfile.arm64` — install Ruby/bundler toolchain and populate `/var/oscli` with the OpenStudio measure gems (openstudio-standards, openstudio-extension, openstudio-workflow, openstudio-gems). The `nrel/openstudio` amd64 base image runs `bundle install` for these; the bare arm64 `.deb` does not, so prior to this fix every measure-based MCP tool (ComStock, common-measures, `apply_measure`) failed at runtime on arm64 builds.
- Add `arm64-build` CI job on `ubuntu-24.04-arm` (native, free for public repos, ~5-10x faster than QEMU). Six sanity checks: build, `openstudio --version`, `/var/oscli` gems list, measure dirs, Python binding, `mcp_server` import, unit-test suite. All green.
- README — unify both Dockerfiles under the same `openstudio-mcp:dev` tag so Step 2's config example works on either architecture without swap. Add a short primer on `-v host:container[:ro]` for new Docker users plus the relative-path gotcha.

## Why
PR #55 introduced `Dockerfile.arm64` but missed the `/var/oscli` step that the upstream `nrel/openstudio` base image bakes in. Tag mismatch in README also forced arm64 users to edit Step 2 JSON.

## Test plan
- [x] CI `arm64-build` green: https://github.com/NatLabRockies/openstudio-mcp/actions/runs/26163308418
- [x] `/var/oscli/gems` populated with openstudio-extension 0.9.7, openstudio-standards 0.8.5, openstudio-workflow 2.5.0, openstudio-gems 3.11.0
- [x] `import openstudio; openStudioVersion() == "3.11.0"` on arm64
- [x] `pytest -m "not integration"` passes inside arm64 image
- [ ] Manual: native build on Apple Silicon (deferred — no hardware here, CI proves the build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)