### PR TITLE
Multi-user remote MCP: HTTP transport, auth, isolation, sim queue, audit, retention (v1.0.0-beta)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             5)
               # HVAC supply sim smoke tests + hvac_validation + bar_building + concurrent regression
               # + sim queue (concurrency cap) & per-user run-dir isolation
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py"
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,8 +208,8 @@ jobs:
               ;;
             5)
               # HVAC supply sim smoke tests + hvac_validation + bar_building + concurrent regression
-              # + sim queue (concurrency cap) & per-user run-dir isolation
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py"
+              # + sim queue (concurrency cap) & per-user run-dir isolation + run retention/cleanup
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,8 @@ jobs:
               ;;
             2)
               # common_measures, hvac_systems, geometry, zone terminal, skill_energy_report
-              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py"
+              # + remote HTTP transport, session isolation & token auth (no-sim, fast)
+              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py"
               EXTRA_ENV=""
               ;;
             3)
@@ -207,7 +208,8 @@ jobs:
               ;;
             5)
               # HVAC supply sim smoke tests + hvac_validation + bar_building + concurrent regression
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py"
+              # + sim queue (concurrency cap) & per-user run-dir isolation
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,8 @@ jobs:
               ;;
             2)
               # common_measures, hvac_systems, geometry, zone terminal, skill_energy_report
-              # + remote HTTP transport, session isolation & token auth (no-sim, fast)
-              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py"
+              # + remote HTTP transport, session isolation, token auth & session eviction (no-sim, fast)
+              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py"
               EXTRA_ENV=""
               ;;
             3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## [1.0.0] - 2026-06-05
+## [1.0.0-beta] - 2026-06-05
 
-First major release: openstudio-mcp can now run as a shared, multi-user remote
-server while the original single-container stdio workflow is unchanged.
+First major release (beta): openstudio-mcp can now run as a shared, multi-user
+remote server while the original single-container stdio workflow is unchanged.
 
 ### Added
 - **Remote multi-user server** over Streamable HTTP (`MCP_TRANSPORT=http`),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [1.0.0] - 2026-06-05
+
+First major release: openstudio-mcp can now run as a shared, multi-user remote
+server while the original single-container stdio workflow is unchanged.
+
+### Added
+- **Remote multi-user server** over Streamable HTTP (`MCP_TRANSPORT=http`),
+  alongside the default stdio transport. Works for Claude Code, Cursor, and VS Code.
+- **Authentication**: bearer-token (`MCP_AUTH=token`, `MCP_TOKENS`) and JWT/IdP
+  (`MCP_AUTH=jwt`, `MCP_JWT_*`); HTTP defaults to fail-closed token auth.
+- **Per-session isolation**: each connection gets its own loaded model, with an
+  LRU cap (`OSMCP_MAX_SESSIONS`) and idle-TTL eviction (`OSMCP_SESSION_TTL`).
+- **Per-user run dirs, path scoping, and run ownership**: a user can't read,
+  write, or query another user's runs/files.
+- **Simulation queue**: global FIFO with a concurrency cap (`OSMCP_MAX_CONCURRENCY`)
+  and optional per-user fairness cap; excess runs queue and start as slots free.
+- **Audit logging**: one structured JSON line per tool call plus the full sim
+  lifecycle and retention events, to stderr and optional `MCP_AUDIT_FILE`.
+- **Run retention / disk GC** (off by default): opt-in background sweeper via
+  `--gc` / `--gc-days N` / `OSMCP_RUN_RETENTION_DAYS`, containment-hardened
+  (no symlink escape, no system roots, run-dirs only); plus `cleanup_runs`,
+  `delete_run`, `pin_run`, `unpin_run` tools (146 tools total).
+- Docs: `docs/remote-multi-user.md`, `docs/run-retention.md`; stress harness
+  `scripts/stress_remote.py`; CI shards for HTTP transport, isolation, auth,
+  eviction, sim queue, audit, and retention.
+
+### Fixed
+- **stdio single-user workflow restored**: stdio resolves to one "local" user
+  owning all of `/runs` (FastMCP's per-connection session id had splintered it
+  into `/runs/<uuid>/` and broken direct `/runs/*.osm` saves).
+- **`run_simulation`** no longer leaves orphan `sim_*` staging dirs — it stages
+  in an ephemeral temp dir, so only the real run dir persists.
+- **`cancel_run`** now persists the `cancelled` status, so cancelled runs are
+  correctly terminal (and reclaimable) across restarts.
+
+### Changed
+- Tool count 142 → 146 (4 run-retention tools).
+
 ## [0.9.0] - 2026-04-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@ always be brutally honest
 ## Project: openstudio-mcp
 MCP server giving AI agents full control of building energy modeling —
 create buildings, author measures, configure HVAC, run EnergyPlus sims, extract
-results — all through 142 MCP tools backed by the OpenStudio SDK.
+results — all through 146 MCP tools backed by the OpenStudio SDK.
 
 ## Critical: Use MCP Tools — Do Not Reinvent
 Always use openstudio-mcp tools for BEM tasks:

--- a/README.md
+++ b/README.md
@@ -2,59 +2,48 @@
 
 [![MCP Badge](https://lobehub.com/badge/mcp/natlabrockies-openstudio-mcp?style=for-the-badge)](https://lobehub.com/mcp/natlabrockies-openstudio-mcp)
 
-**Model Context Protocol (MCP)** server for **OpenStudio** building energy simulation. Enables LLMs and MCP hosts (Claude Desktop, Cursor, Claude Code, etc.) to create, query, and modify OpenStudio models, run EnergyPlus simulations, and inspect results — all through natural language.
+**Model Context Protocol server for [OpenStudio](https://openstudio.net/) building energy simulation.** It lets MCP hosts — Claude Desktop, Claude Code, Cursor, VS Code — create, query, and modify OpenStudio models, run EnergyPlus, and read results, all in plain language. The server handles the OpenStudio/EnergyPlus complexity behind MCP tool calls.
 
-**23 skills &bull; 142 tools &bull; 6 prompts &bull; 4 resources &bull; 480+ integration tests**
+**146 tools · 12 workflow skills · 480+ integration tests**
 
 ---
 
-## What Can It Do?
+## What you can ask for
 
-Ask your AI assistant to do things like:
-
-- *"Create a 10-zone office building with VAV reheat and run an annual simulation"*
+- *"Create a 10-zone office with VAV reheat and run an annual simulation."*
 - *"What's the EUI? Show me the unmet heating hours."*
-- *"Switch the HVAC from VAV to VRF heat pumps and compare energy use"*
-- *"Add R-30 roof insulation and see how it affects the cooling load"*
-- *"Build two adjacent zones from floor plans, match the shared wall, add 40% south glazing"*
-- *"Write a custom measure to set all lights to 8 W/m2, test it, apply it, and compare the EUI"*
-- *"Apply the AEDG Small Office measure from my local measures directory"*
+- *"Switch the HVAC from VAV to VRF heat pumps and compare energy use."*
+- *"Add R-30 roof insulation and see how it affects the cooling load."*
+- *"Build two adjacent zones from floor plans, match the shared wall, add 40% south glazing."*
+- *"Write a measure that sets all lights to 8 W/m², test it, apply it, and compare the EUI."*
 
-The server handles all the OpenStudio/EnergyPlus complexity behind MCP tool calls.
+The AI picks the right tools, calls them in sequence, and summarizes — no scripting.
 
 ---
 
-## Quick Start
+## Quick start (local)
 
-### Prerequisites
+Runs the server locally over stdio — one container per user, launched by your MCP host. For a shared deployment, see [Remote & multi-user](#remote--multi-user-http).
 
-- **Docker Desktop** installed and running ([download](https://www.docker.com/products/docker-desktop/))
-- **An MCP host** — an AI application that can connect to MCP tool servers. [Claude Desktop](https://claude.ai/download) is the recommended starting point.
+**Prerequisites:** [Docker Desktop](https://www.docker.com/products/docker-desktop/) running, and an MCP host ([Claude Desktop](https://claude.ai/download) is the easiest start).
 
-### Step 1: Clone & Build
+### 1. Build the image
 
 ```bash
 git clone https://github.com/NatLabRockies/openstudio-mcp.git
 cd openstudio-mcp
 ```
 
-**Pick the right Dockerfile for your machine** — both produce the same `openstudio-mcp:dev` image, so Step 2's config below works either way.
-
-| Machine | Command |
-|---------|---------|
+| Machine | Build command |
+|---------|---------------|
 | Intel/AMD (Linux, Windows, Intel Mac) | `docker build -t openstudio-mcp:dev -f docker/Dockerfile .` |
-| Apple Silicon (M-series Mac) | `docker build --platform linux/arm64 -t openstudio-mcp:dev -f docker/Dockerfile.arm64 .` |
+| Apple Silicon (M-series) | `docker build --platform linux/arm64 -t openstudio-mcp:dev -f docker/Dockerfile.arm64 .` |
 
-Why two files? The upstream `nrel/openstudio` base image is `amd64`-only. On Apple Silicon, `docker/Dockerfile` runs under slow Rosetta emulation; `docker/Dockerfile.arm64` builds natively from the official NREL arm64 `.deb` and is several times faster at runtime.
+Both produce the same `openstudio-mcp:dev` image. The arm64 Dockerfile builds natively from NREL's arm64 `.deb` (the upstream `nrel/openstudio` base is amd64-only, so plain `Dockerfile` runs under slow emulation on Apple Silicon).
 
-### Step 2: Configure Claude Desktop
+### 2. Configure your host
 
-Open your Claude Desktop config file:
-
-- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-Add (or merge into) the `mcpServers` block:
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, `%APPDATA%\Claude\claude_desktop_config.json` on Windows), then restart Claude Desktop:
 
 ```json
 {
@@ -74,454 +63,437 @@ Add (or merge into) the `mcpServers` block:
 }
 ```
 
-**About the `-v` flags** — each one is `-v <host-path>:<container-path>[:ro]`. Docker exposes the host folder inside the container at the second path, so the MCP server can read/write your files. The optional `:ro` makes it read-only. The `./` prefix is **relative to wherever your MCP host launches `docker` from** — if it doesn't resolve, swap in absolute paths (e.g. `/Users/you/openstudio-mcp/runs:/runs` on macOS, `C:\projects\openstudio-mcp\runs:/runs` on Windows).
+The `-v host:container` mounts expose your folders inside the container: `/inputs` for your models (starts with the bundled test models), `/runs` for simulation outputs, `/skills` for the workflow guides. Use absolute paths if `./` doesn't resolve from where your host launches Docker.
 
-- `./tests/assets:/inputs` — mounts the included test models so you can experiment right away. Replace with your own folder (e.g. `~/my-models:/inputs`) when ready.
-- `./runs:/runs` — simulation outputs are written here
-- `./.claude/skills:/skills:ro` — makes workflow guides available via `list_skills()` / `get_skill()` tools (read-only)
-- **Restart Claude Desktop** after saving the config file
+### 3. Verify and chat
 
-### Step 3: Verify Connection
+Look for the **hammer icon** in Claude Desktop's input — click it to see the openstudio-mcp tools. Then try, in order:
 
-Open Claude Desktop and look for the **hammer icon** (MCP tools indicator) in the chat input area. Click it to see the openstudio-mcp tools listed. If the icon doesn't appear, check that Docker is running and the config JSON is valid.
+> "Create an example model and tell me about it" → "Create a baseline office with ASHRAE System 3 and show me the HVAC components" → "Load /inputs/MyBuilding.osm, apply the 90.1-2019 typical template, and run a simulation"
 
-### Step 4: Start Chatting
+**Use the `/inputs` mount for your own files** rather than uploading through chat — Claude Desktop's upload sandbox can't reach MCP tools, so the AI may fall back to writing scripts. Drop a file in the host folder mapped to `/inputs` and reference it by that path. Simulation outputs in `/runs` are already reachable.
 
-Try these prompts in order of complexity:
-
-> **Simple:** "Create an example model and tell me about it"
-
-> **Medium:** "Create a baseline office with ASHRAE System 3 and show me the HVAC components"
-
-> **Advanced:** "Load my model at /inputs/MyBuilding.osm, apply the 90.1-2019 typical building template, and run a simulation"
-
-The AI reads your prompt, picks the right tools from the 142 available, calls them in sequence, and summarizes the results — no scripting required.
-
-### Working with Your Own Files
-
-**Place files in the `/inputs` mount** (the host folder mapped to `/inputs` in the config above) rather than uploading them through the chat interface. This ensures the MCP tools can access them directly.
-
-```
-# Example: analyzing an EnergyPlus error file
-# 1. Copy to your inputs folder
-cp eplusout.err ./tests/assets/
-
-# 2. Reference by MCP path in your prompt
-"Analyze the warnings in /inputs/eplusout.err and create a measure to fix them"
-```
-
-**Why not upload?** File uploads in Claude Desktop activate an Analysis sandbox that can't communicate with MCP tools. The AI may write scripts to handle the task instead of using the 142 specialized MCP tools available. Placing files in `/inputs` keeps everything in the MCP workflow.
-
-For simulation outputs (results, SQL, HTML reports), these are already in `/runs` and accessible to all MCP tools automatically.
-
-### Other MCP Hosts
-
-[VS Code Copilot](https://code.visualstudio.com/), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Windsurf](https://windsurf.com/), and [Gemini CLI](https://github.com/google-gemini/gemini-cli) also support MCP with similar JSON config. See the [MCP documentation](https://modelcontextprotocol.io/quickstart/user) for host-specific setup.
-
-### Remote & Multi-User (HTTP)
-
-The Quick Start above runs the server locally over stdio (one process per user).
-To host it on one machine and let teammates connect from their own laptops —
-each with an isolated session, run directory, and optional bearer-token auth —
-run it over streamable HTTP instead (`-e MCP_TRANSPORT=http`). Works with Claude
-Code, Cursor, and VS Code.
-
-See **[docs/remote-multi-user.md](docs/remote-multi-user.md)** for server setup,
-client config, auth, and the isolation model.
-
-### Client Compatibility
+**Other hosts:** [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [VS Code Copilot](https://code.visualstudio.com/), [Windsurf](https://windsurf.com/), and [Gemini CLI](https://github.com/google-gemini/gemini-cli) use similar JSON config — see the [MCP docs](https://modelcontextprotocol.io/quickstart/user).
 
 | Client | Status | Notes |
 |--------|--------|-------|
-| Claude Desktop | Full support | All 142 tools available |
-| Claude Code | Full support | ToolSearch auto-defers tools for efficient discovery |
-| VS Code Copilot | Compatible | MCP support via config |
-| Windsurf | Compatible | Under 100-tool limit |
-| Gemini CLI | Compatible | Use includeTools/excludeTools if needed |
-| Cursor | Not compatible | 40-tool hard cap — use Windsurf or Claude Code instead |
-| OpenAI API | Compatible | Use defer_loading for best results |
+| Claude Desktop | ✅ Full | all tools available |
+| Claude Code | ✅ Full | ToolSearch auto-defers tools for efficient discovery |
+| VS Code Copilot | ✅ Compatible | MCP via config |
+| Windsurf | ✅ Compatible | under the 100-tool limit |
+| Gemini CLI | ✅ Compatible | use includeTools/excludeTools if needed |
+| OpenAI API | ✅ Compatible | use defer_loading for best results |
+| Cursor | ⚠️ Limited | 40-tool hard cap — use Claude Code or Windsurf |
 
 ---
 
-## Claude Code Skills
+## Remote & multi-user (HTTP)
 
-When using openstudio-mcp with [Claude Code](https://docs.anthropic.com/en/docs/claude-code), 12 bundled skills provide workflow automation and domain knowledge:
+The quick start runs one container per user over stdio. To host it on one machine and let teammates connect from their own laptops — each with an isolated session, run directory, and optional bearer-token or JWT auth — run it over streamable HTTP (`-e MCP_TRANSPORT=http`). Works with Claude Code, Cursor, and VS Code.
 
-| Skill | Type | Description |
-|-------|------|-------------|
-| `/simulate` | Workflow | One-command simulate + results extraction |
-| `/energy-report` | Workflow | Comprehensive multi-category energy report |
-| `/qaqc` | Task | Pre-simulation model quality check |
-| `/add-hvac` | Task | Guided HVAC system selection |
-| `/new-building` | Workflow | Full model creation from scratch |
-| `/retrofit` | Workflow | Before/after ECM analysis |
-| `/view` | Task | Quick 3D model visualization |
-| `/troubleshoot` | Task | Diagnose simulation failures and unexpected results |
-| `measure-authoring` | Knowledge | Measure creation, SDK method verification, wiring patterns (auto-loaded) |
-| `ashrae-baseline-guide` | Knowledge | ASHRAE 90.1 system selection criteria (auto-loaded) |
-| `openstudio-patterns` | Knowledge | Tool dependencies and model relationships (auto-loaded) |
-| `tool-workflows` | Knowledge | Multi-tool recipes for common operations (auto-loaded) |
-
-Workflow/task skills are invoked with `/skill-name`. Knowledge skills load automatically when relevant.
-
-### Workflow Guides for All MCP Clients
-
-The same workflow guides are also available as MCP tools, so any MCP client (Claude Desktop, Cursor, etc.) can discover them:
-
-- `list_skills()` — see available workflows with descriptions
-- `get_skill(name)` — get step-by-step instructions for a specific workflow
-
-Mount the skills directory when running the container: `-v ./.claude/skills:/skills:ro`
+See **[docs/remote-multi-user.md](docs/remote-multi-user.md)** for setup, auth, the isolation model, and log access — and **[docs/run-retention.md](docs/run-retention.md)** for optional disk garbage-collection.
 
 ---
 
-## Skills & Tools (142 total)
+## Workflow skills
 
-### Skill Discovery (2 tools)
+In Claude Code, 12 bundled skills add workflow automation and domain knowledge:
+
+| Skill | Type | What it does |
+|-------|------|--------------|
+| `/simulate` | Workflow | one-command simulate + results extraction |
+| `/energy-report` | Workflow | comprehensive multi-category energy report |
+| `/new-building` | Workflow | full model creation from scratch |
+| `/retrofit` | Workflow | before/after ECM analysis |
+| `/add-hvac` | Task | guided HVAC system selection |
+| `/qaqc` | Task | pre-simulation model quality check |
+| `/view` | Task | quick 3D model visualization |
+| `/troubleshoot` | Task | diagnose simulation failures |
+| `measure-authoring` | Knowledge | measure creation, SDK verification, wiring patterns |
+| `ashrae-baseline-guide` | Knowledge | ASHRAE 90.1 system selection |
+| `openstudio-patterns` | Knowledge | tool dependencies and model relationships |
+| `tool-workflows` | Knowledge | multi-tool recipes for common operations |
+
+Workflow/task skills are invoked with `/name`; knowledge skills load automatically. Any MCP host can also discover these guides via the `list_skills()` and `get_skill(name)` tools (mount `-v ./.claude/skills:/skills:ro`).
+
+---
+
+## Tool reference
+
+146 tools, grouped by area — expand a group to see its tools. New here? `create_new_building`, `run_simulation`, and `extract_summary_metrics` cover most workflows; `list_skills()` and `recommend_tools(task)` help the AI find the rest.
+
+<details>
+<summary><b>Model creation & management</b> — 13 tools</summary>
+
 | Tool | Description |
 |------|-------------|
-| `list_skills` | List available workflow guides |
-| `get_skill` | Get step-by-step instructions for a workflow |
-
-### Server Info (2 tools)
-| Tool | Description |
-|------|-------------|
-| `get_server_status` | Server health check |
-| `get_versions` | OpenStudio, EnergyPlus, Ruby versions |
-
-### Model Creation (5 tools)
-
-Primary tools for creating building energy models. `create_new_building` is the recommended starting point for most workflows.
-
-| Tool | Description |
-|------|-------------|
-| `create_new_building` | Create complete building end-to-end (geometry + weather + typical template) |
-| `create_bar_building` | Create bar building geometry from building type, floor area, and aspect ratio |
+| `create_new_building` | Create a complete building end-to-end (geometry + weather + typical template) |
+| `create_bar_building` | Create bar-building geometry from type, floor area, aspect ratio |
 | `create_typical_building` | Add constructions, loads, HVAC, SWH to a model with geometry |
-| `create_example_osm` | Create minimal single-zone example (testing/demos) |
-| `create_baseline_osm` | Create 10-zone baseline with ASHRAE system 1-10 (testing/demos) |
-
-### Model Management (4 tools)
-| Tool | Description |
-|------|-------------|
-| `inspect_osm_summary` | Quick structural summary of OSM file |
+| `create_example_osm` | Minimal single-zone example (testing/demos) |
+| `create_baseline_osm` | 10-zone baseline with ASHRAE system 1–10 (testing/demos) |
+| `inspect_osm_summary` | Quick structural summary of an OSM file |
 | `load_osm_model` | Load OSM into memory for querying/editing |
-| `save_osm_model` | Save in-memory model to disk |
-| `list_files` | Discover files in /inputs and /runs (OSM, EPW, results) |
-
-### Building (2 tools)
-
-List building stories via `list_model_objects("BuildingStory")`.
-
-| Tool | Description |
-|------|-------------|
+| `save_osm_model` | Save the in-memory model to disk |
+| `list_files` | Discover files in /inputs and /runs |
 | `get_building_info` | Building name, area, volume, orientation |
 | `get_model_summary` | Object counts by category |
+| `delete_object` | Delete any named object (28+ types) |
+| `rename_object` | Rename any named object |
 
-### Spaces (6 tools)
+</details>
+
+<details>
+<summary><b>Generic object access</b> — 3 tools</summary>
+
+Read/write any OpenStudio object by introspection — covers types without a dedicated tool.
+
 | Tool | Description |
 |------|-------------|
-| `list_spaces` | List all spaces with area/volume |
-| `get_space_details` | Detailed space info (surfaces, loads, zone) |
+| `list_model_objects` | List objects of any type (CamelCase, IDD colon, or underscore) |
+| `get_object_fields` | Read all properties of an object — returns values + available setters |
+| `set_object_property` | Write any property via official setters — auto-coerces types |
+
+</details>
+
+<details>
+<summary><b>Spaces & thermal zones</b> — 6 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `list_spaces` | List spaces with area/volume |
+| `get_space_details` | Surfaces, loads, zone for a space |
 | `list_thermal_zones` | List thermal zones with spaces |
 | `get_thermal_zone_details` | Zone equipment, thermostat, multiplier |
-| `create_space` | Create space with optional story/space type |
-| `create_thermal_zone` | Create thermal zone, assign spaces |
+| `create_space` | Create a space (optional story/space type) |
+| `create_thermal_zone` | Create a thermal zone, assign spaces |
 
-### Geometry (9 tools)
+</details>
+
+<details>
+<summary><b>Geometry</b> — 9 tools</summary>
+
 | Tool | Description |
 |------|-------------|
 | `list_surfaces` | List surfaces (walls, floors, roofs) |
-| `get_surface_details` | Surface vertices, construction, boundary |
+| `get_surface_details` | Vertices, construction, boundary |
 | `list_subsurfaces` | List windows, doors, skylights |
-| `create_surface` | Create surface with explicit 3D vertices |
-| `create_subsurface` | Create window/door on a parent surface |
-| `create_space_from_floor_print` | Extrude floor polygon into space with all surfaces |
+| `create_surface` | Create a surface from explicit 3D vertices |
+| `create_subsurface` | Create a window/door on a parent surface |
+| `create_space_from_floor_print` | Extrude a floor polygon into a space with all surfaces |
 | `match_surfaces` | Intersect + match shared walls between adjacent spaces |
-| `set_window_to_wall_ratio` | Add centered window by glazing ratio (e.g. 0.4 = 40%) |
-| `import_floorspacejs` | Import custom geometry from FloorSpaceJS JSON file |
+| `set_window_to_wall_ratio` | Add a centered window by glazing ratio |
+| `import_floorspacejs` | Import geometry from a FloorSpaceJS JSON file |
 
-### Constructions (5 tools)
+</details>
 
-List constructions via `list_model_objects("Construction")`, construction sets via `list_model_objects("DefaultConstructionSet")`.
+<details>
+<summary><b>Constructions & materials</b> — 5 tools</summary>
+
+List constructions/sets via `list_model_objects("Construction")` / `("DefaultConstructionSet")`.
 
 | Tool | Description |
 |------|-------------|
-| `list_materials` | List materials with thermal properties |
+| `list_materials` | Materials with thermal properties |
 | `get_construction_details` | Construction layers with thermal properties |
-| `create_standard_opaque_material` | Create material with conductivity/density |
-| `create_construction` | Create layered construction from materials |
-| `assign_construction_to_surface` | Assign construction to surface |
+| `create_standard_opaque_material` | Material with conductivity/density |
+| `create_construction` | Layered construction from materials |
+| `assign_construction_to_surface` | Assign a construction to a surface |
 
-### Schedules (2 tools)
+</details>
+
+<details>
+<summary><b>Schedules</b> — 2 tools</summary>
 
 List schedules via `list_model_objects("ScheduleRuleset")`.
 
 | Tool | Description |
 |------|-------------|
 | `get_schedule_details` | Schedule type, values, rules |
-| `create_schedule_ruleset` | Create constant schedule (Fractional/Temp/OnOff) |
+| `create_schedule_ruleset` | Constant schedule (Fractional/Temp/OnOff) |
 
-### HVAC (7 tools)
-| Tool | Description |
-|------|-------------|
-| `list_air_loops` | List air loops with zones served |
-| `get_air_loop_details` | Air loop components, sizing, OA system |
-| `add_air_loop` | Create air loop and connect zones |
-| `list_plant_loops` | List plant loops (heating, cooling, condenser) |
-| `get_plant_loop_details` | Plant loop supply/demand components |
-| `list_zone_hvac_equipment` | List zone-level HVAC equipment |
-| `get_zone_hvac_details` | Zone equipment details |
+</details>
 
-### Loads (6 tools)
+<details>
+<summary><b>Loads</b> — 6 tools</summary>
 
-List loads via `list_model_objects("People")`, `list_model_objects("Lights")`, etc. Use `get_object_fields` for definition details.
+List loads via `list_model_objects("People")`, `("Lights")`, etc.; use `get_object_fields` for definitions.
 
 | Tool | Description |
 |------|-------------|
-| `get_load_details` | Get detailed info for any load by name (type dispatcher) |
-| `create_people_definition` | Create people load (by area or count) |
-| `create_lights_definition` | Create lighting load (by area or wattage) |
-| `create_electric_equipment` | Create electric equipment load |
-| `create_gas_equipment` | Create gas equipment load |
-| `create_infiltration` | Create infiltration (by area or ACH) |
+| `get_load_details` | Detailed info for any load by name |
+| `create_people_definition` | People load (by area or count) |
+| `create_lights_definition` | Lighting load (by area or wattage) |
+| `create_electric_equipment` | Electric equipment load |
+| `create_gas_equipment` | Gas equipment load |
+| `create_infiltration` | Infiltration (by area or ACH) |
 
-### Space Types (1 tool)
+</details>
+
+<details>
+<summary><b>Space types</b> — 1 tool</summary>
 
 List space types via `list_model_objects("SpaceType")`.
 
 | Tool | Description |
 |------|-------------|
-| `get_space_type_details` | Space type loads, schedules, standards |
+| `get_space_type_details` | Space-type loads, schedules, standards |
 
-### Simulation (8 tools)
+</details>
+
+<details>
+<summary><b>HVAC — query & build</b> — 7 tools</summary>
+
 | Tool | Description |
 |------|-------------|
-| `validate_osw` | Validate OSW workflow file |
-| `run_osw` | Run EnergyPlus simulation from an OSW file |
-| `run_simulation` | Run simulation from just an OSM + optional EPW |
-| `get_run_status` | Poll simulation run status |
-| `get_run_logs` | Tail simulation logs |
-| `get_run_artifacts` | List simulation output files |
-| `cancel_run` | Cancel running simulation |
-| `validate_model` | Pre-simulation check: weather, design days, HVAC, constructions |
+| `list_air_loops` | Air loops with zones served |
+| `get_air_loop_details` | Air-loop components, sizing, OA system |
+| `add_air_loop` | Create an air loop and connect zones |
+| `list_plant_loops` | Plant loops (heating, cooling, condenser) |
+| `get_plant_loop_details` | Plant-loop supply/demand components |
+| `list_zone_hvac_equipment` | Zone-level HVAC equipment |
+| `get_zone_hvac_details` | Zone equipment details |
 
-### Results (12 tools)
+</details>
+
+<details>
+<summary><b>HVAC systems (templates)</b> — 8 tools</summary>
+
 | Tool | Description |
 |------|-------------|
-| `extract_summary_metrics` | Extract EUI, energy, unmet hours from results |
-| `read_file` | Read any file by absolute path (all mounts) |
-| `copy_file` | Copy file to host-mounted path |
-| `extract_end_use_breakdown` | Energy breakdown by end use and fuel type (IP/SI) |
-| `extract_envelope_summary` | Opaque + fenestration U-values and areas |
-| `extract_hvac_sizing` | Autosized zone and system HVAC capacities |
-| `extract_zone_summary` | Per-zone areas, conditions, multipliers |
-| `extract_component_sizing` | Autosized HVAC component values (filterable) |
-| `query_timeseries` | Time-series output variable data with date/cap filters |
-| `extract_simulation_errors` | Parse eplusout.err into Fatal/Severe/Warning lists |
-| `list_output_variables` | List available output variables from completed simulation |
-| `compare_runs` | Compare two runs: EUI delta, per-fuel end-use breakdown |
-
-### Simulation Outputs (2 tools)
-| Tool | Description |
-|------|-------------|
-| `add_output_variable` | Add EnergyPlus output variable |
-| `add_output_meter` | Add EnergyPlus output meter |
-
-### HVAC Systems (8 tools)
-| Tool | Description |
-|------|-------------|
-| `add_baseline_system` | Add ASHRAE 90.1 baseline system (types 1-10) |
-| `list_baseline_systems` | List all baseline + modern template types |
-| `get_baseline_system_info` | Get metadata for specific system type |
+| `add_baseline_system` | ASHRAE 90.1 baseline system (types 1–10) |
+| `list_baseline_systems` | All baseline + modern template types |
+| `get_baseline_system_info` | Metadata for a specific system type |
 | `replace_air_terminals` | Replace ALL terminals on an air loop |
-| `replace_zone_terminal` | Replace terminal on a single zone |
-| `add_doas_system` | Add DOAS with fan coils, radiant, or chilled beams |
-| `add_vrf_system` | Add VRF multi-zone heat pump system |
-| `add_radiant_system` | Add low-temperature radiant heating/cooling |
+| `replace_zone_terminal` | Replace the terminal on a single zone |
+| `add_doas_system` | DOAS with fan coils, radiant, or chilled beams |
+| `add_vrf_system` | VRF multi-zone heat-pump system |
+| `add_radiant_system` | Low-temperature radiant heating/cooling |
 
-### Component Properties (10 tools)
+</details>
 
-List HVAC components via `list_model_objects("BoilerHotWater")`, loop detail tools, etc.
+<details>
+<summary><b>HVAC component properties</b> — 10 tools</summary>
+
+List components via `list_model_objects("BoilerHotWater")`, loop detail tools, etc. Covers 15 component types (see [reference](#hvac-component-types)).
 
 | Tool | Description |
 |------|-------------|
 | `get_component_properties` | Read all properties of a named component |
 | `set_component_properties` | Modify properties on a named component |
-| `set_economizer_properties` | Modify OA economizer settings on air loop |
-| `set_sizing_properties` | Modify plant loop sizing (exit temp, delta-T) |
-| `set_sizing_system_properties` | Set air loop SizingSystem properties (SAT, OA, flow methods) |
-| `get_sizing_system_properties` | Read all SizingSystem properties for air loop |
-| `set_sizing_zone_properties` | Set SizingZone properties (bulk, supports zone lists) |
-| `get_sizing_zone_properties` | Read all SizingZone properties for a zone |
-| `get_setpoint_manager_properties` | Read SPM properties (7 types supported) |
-| `set_setpoint_manager_properties` | Modify SPM properties (7 types supported) |
+| `set_economizer_properties` | OA economizer settings on an air loop |
+| `set_sizing_properties` | Plant-loop sizing (exit temp, delta-T) |
+| `set_sizing_system_properties` | Air-loop SizingSystem (SAT, OA, flow methods) |
+| `get_sizing_system_properties` | Read all SizingSystem properties |
+| `set_sizing_zone_properties` | SizingZone properties (supports zone lists) |
+| `get_sizing_zone_properties` | Read all SizingZone properties |
+| `get_setpoint_manager_properties` | Read SPM properties (7 types) |
+| `set_setpoint_manager_properties` | Modify SPM properties (7 types) |
 
-### Loop Operations (9 tools)
+</details>
+
+<details>
+<summary><b>Plant loops & zone equipment</b> — 9 tools</summary>
+
 | Tool | Description |
 |------|-------------|
-| `create_plant_loop` | Create plant loop with pump, bypass, and SPM |
-| `add_supply_equipment` | Add boiler/chiller/tower to plant loop supply |
-| `remove_supply_equipment` | Remove equipment from plant loop supply |
-| `add_demand_component` | Add coil/heater to plant loop demand side |
-| `remove_demand_component` | Remove component from plant loop demand |
-| `add_zone_equipment` | Add baseboard/unit heater to thermal zone |
-| `remove_zone_equipment` | Remove equipment from thermal zone |
-| `remove_all_zone_equipment` | Batch-remove ALL equipment from multiple zones |
-| `set_zone_equipment_priority` | Reorder zone equipment cooling/heating priority |
+| `create_plant_loop` | Plant loop with pump, bypass, SPM |
+| `add_supply_equipment` | Add boiler/chiller/tower to supply side |
+| `remove_supply_equipment` | Remove supply-side equipment |
+| `add_demand_component` | Add coil/heater to the demand side |
+| `remove_demand_component` | Remove a demand-side component |
+| `add_zone_equipment` | Add baseboard/unit heater to a zone |
+| `remove_zone_equipment` | Remove zone equipment |
+| `remove_all_zone_equipment` | Batch-remove all equipment from zones |
+| `set_zone_equipment_priority` | Reorder zone cooling/heating priority |
 
-### Object Management (5 tools)
+</details>
+
+<details>
+<summary><b>Weather & simulation config</b> — 7 tools</summary>
+
 | Tool | Description |
 |------|-------------|
-| `delete_object` | Delete any named object (28+ supported types) |
-| `rename_object` | Rename any named object |
-| `list_model_objects` | List objects of any type (CamelCase, IDD colon, or underscore formats) |
-| `get_object_fields` | Read all properties of any object via introspection — returns values + available setters |
-| `set_object_property` | Write any property on any object via official setters — auto-coerces value types |
-
-### Weather & Simulation Config (7 tools)
-| Tool | Description |
-|------|-------------|
-| `list_weather_files` | List available EPW files with companion .stat/.ddy files |
-| `get_weather_info` | Read weather file info (city, lat, lon, timezone) |
-| `add_design_day` | Add heating/cooling design day |
-| `get_simulation_control` | Read sizing flags and timesteps per hour |
+| `list_weather_files` | Available EPW files (with .stat/.ddy) |
+| `get_weather_info` | City, lat, lon, timezone from a weather file |
+| `add_design_day` | Add a heating/cooling design day |
+| `get_simulation_control` | Read sizing flags and timesteps/hour |
 | `set_simulation_control` | Modify sizing flags and/or timestep |
-| `get_run_period` | Read run period begin/end dates |
-| `set_run_period` | Set run period dates (auto-enables weather file run) |
+| `get_run_period` | Read run-period dates |
+| `set_run_period` | Set run-period dates |
 
-### Measures (2 tools)
-| Tool | Description |
-|------|-------------|
-| `list_measure_arguments` | List measure arguments with defaults and choices |
-| `apply_measure` | Apply OpenStudio measure to in-memory model |
+</details>
 
-### Measure Authoring (4 tools)
-
-Create custom OpenStudio measures with AI-generated code, test them, and apply to models. See [Example 1](docs/examples/01_custom_measure_lighting.md), [Example 2](docs/examples/02_custom_measure_hvac.md), and [Example 19](docs/examples/19_systemd_fourpipebeam_retrofit.md) (full E2E retrofit).
+<details>
+<summary><b>Simulation & outputs</b> — 10 tools</summary>
 
 | Tool | Description |
 |------|-------------|
-| `list_custom_measures` | List all custom measures created with create_measure |
-| `create_measure` | Create custom Ruby/Python ModelMeasure with user-provided code |
-| `test_measure` | Run tests for a custom measure (auto-detects language) |
-| `edit_measure` | Edit an existing custom measure's code or arguments |
+| `run_simulation` | Run a simulation from an OSM + optional EPW |
+| `run_osw` | Run EnergyPlus from an OSW file |
+| `validate_osw` | Validate an OSW workflow file |
+| `validate_model` | Pre-sim check: weather, design days, HVAC, constructions |
+| `get_run_status` | Poll run status |
+| `get_run_logs` | Tail simulation logs |
+| `get_run_artifacts` | List output files |
+| `cancel_run` | Cancel a running simulation |
+| `add_output_variable` | Add an EnergyPlus output variable |
+| `add_output_meter` | Add an EnergyPlus output meter |
 
-### ComStock Measures (1 tool)
+</details>
 
-~61 bundled [ComStock](https://github.com/NREL/ComStock) measures (openstudio-standards-based templates for space types, constructions, HVAC, schedules). Pre-installed in Docker image. Creation tools that use these measures are listed in [Model Creation](#model-creation-5-tools) above.
+<details>
+<summary><b>Run retention</b> — 4 tools</summary>
 
-| Tool | Description |
-|------|-------------|
-| `list_comstock_measures` | List bundled measures with category filter (baseline/upgrade/setup) |
-
-### API Reference (2 tools)
-| Tool | Description |
-|------|-------------|
-| `search_api` | Look up OpenStudio SDK classes and setter/getter methods — verify methods exist before calling |
-| `search_wiring_patterns` | Find Ruby wiring recipes for HVAC components (24 patterns: beams, DOAS, VRF, plant loops, etc.) |
-
-### Tool Router (1 tool)
-| Tool | Description |
-|------|-------------|
-| `recommend_tools` | Given a task description, recommend the relevant tool group |
-
-### Common Measures (20 tools)
-
-~79 bundled [openstudio-common-measures-gem](https://github.com/NREL/openstudio-common-measures-gem) measures (reporting, thermostats, envelope, renewables, visualization, model cleanup). Pre-installed in Docker image. 20 curated measures with 21 dedicated wrapper tools.
+Reclaim disk from old run directories. See [docs/run-retention.md](docs/run-retention.md).
 
 | Tool | Description |
 |------|-------------|
-| `list_common_measures` | List bundled measures with category filter (reporting/thermostat/envelope/loads/renewables/etc.) |
-| `view_model` | Generate interactive 3D Three.js HTML viewer of model geometry |
-| `view_simulation_data` | Generate 3D viewer with simulation data overlaid on surfaces |
-| `generate_results_report` | Comprehensive HTML report (~25 sections: energy, HVAC, envelope, zones) |
-| `run_qaqc_checks` | ASHRAE baseline QA/QC checks (efficiency, capacity, envelope, loads) |
-| `adjust_thermostat_setpoints` | Shift all heating/cooling setpoints by degree offset |
-| `replace_window_constructions` | Bulk-replace all exterior window constructions |
-| `enable_ideal_air_loads` | Enable ideal air loads on all zones (quick sizing studies) |
-| `clean_unused_objects` | Remove orphan objects and unused resources |
-| `change_building_location` | Set weather file + climate zone + design days |
-| `set_thermostat_schedules` | Apply thermostat schedules from library |
+| `cleanup_runs` | Delete old run dirs you own (preview with `dry_run`, then delete) |
+| `delete_run` | Delete one of your run directories |
+| `pin_run` | Protect a run from automatic cleanup |
+| `unpin_run` | Allow a pinned run to be cleaned up again |
+
+</details>
+
+<details>
+<summary><b>Results extraction</b> — 12 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `extract_summary_metrics` | EUI, energy, unmet hours |
+| `extract_end_use_breakdown` | Energy by end use and fuel (IP/SI) |
+| `extract_envelope_summary` | Opaque + fenestration U-values and areas |
+| `extract_hvac_sizing` | Autosized zone/system HVAC capacities |
+| `extract_zone_summary` | Per-zone areas, conditions, multipliers |
+| `extract_component_sizing` | Autosized component values (filterable) |
+| `query_timeseries` | Time-series output data with date/cap filters |
+| `extract_simulation_errors` | Parse eplusout.err into Fatal/Severe/Warning |
+| `list_output_variables` | Output variables from a completed run |
+| `compare_runs` | Compare two runs: EUI delta + end-use breakdown |
+| `read_file` | Read any file by absolute path (mounts only) |
+| `copy_file` | Copy a file to a host-mounted path |
+
+</details>
+
+<details>
+<summary><b>Measures & authoring</b> — 7 tools</summary>
+
+Apply bundled measures, or write/test/apply custom ones. See examples [1](docs/examples/01_custom_measure_lighting.md), [2](docs/examples/02_custom_measure_hvac.md), [19](docs/examples/19_systemd_fourpipebeam_retrofit.md).
+
+| Tool | Description |
+|------|-------------|
+| `apply_measure` | Apply an OpenStudio measure to the in-memory model |
+| `list_measure_arguments` | List a measure's arguments, defaults, choices |
+| `create_measure` | Create a custom Ruby/Python ModelMeasure |
+| `edit_measure` | Edit a custom measure's code or arguments |
+| `test_measure` | Run a custom measure's tests (auto-detects language) |
+| `list_custom_measures` | List custom measures you've created |
+| `list_comstock_measures` | List ~61 bundled [ComStock](https://github.com/NREL/ComStock) measures |
+
+</details>
+
+<details>
+<summary><b>Common measures (curated wrappers)</b> — 20 tools</summary>
+
+Typed wrappers over ~79 bundled [common measures](https://github.com/NREL/openstudio-common-measures-gem) (reporting, envelope, renewables, visualization, cleanup).
+
+| Tool | Description |
+|------|-------------|
+| `list_common_measures` | List bundled measures by category |
+| `view_model` | Interactive 3D Three.js viewer of geometry |
+| `view_simulation_data` | 3D viewer with simulation data on surfaces |
+| `generate_results_report` | ~25-section HTML report |
+| `run_qaqc_checks` | ASHRAE baseline QA/QC checks |
+| `adjust_thermostat_setpoints` | Shift heating/cooling setpoints |
+| `replace_window_constructions` | Bulk-replace exterior window constructions |
+| `enable_ideal_air_loads` | Ideal air loads on all zones (quick sizing) |
+| `clean_unused_objects` | Remove orphan/unused objects |
+| `change_building_location` | Set weather + climate zone + design days |
+| `set_thermostat_schedules` | Apply thermostat schedules from a library |
 | `replace_thermostat_schedules` | Replace existing thermostat schedules |
 | `shift_schedule_time` | Shift schedule profiles by hours |
 | `add_rooftop_pv` | Add rooftop PV panels |
-| `add_pv_to_shading` | Add PV to shading surfaces by type |
-| `add_ev_load` | Add electric vehicle charging load |
-| `add_zone_ventilation` | Add zone ventilation design flow rate |
-| `set_lifecycle_cost_params` | Set lifecycle cost analysis parameters |
-| `add_cost_per_floor_area` | Add cost per floor area to building |
-| `set_adiabatic_boundaries` | Set exterior walls/floors to adiabatic |
+| `add_pv_to_shading` | Add PV to shading surfaces |
+| `add_ev_load` | Add EV charging load |
+| `add_zone_ventilation` | Add zone ventilation design flow |
+| `set_lifecycle_cost_params` | Set lifecycle-cost parameters |
+| `add_cost_per_floor_area` | Add cost per floor area |
+| `set_adiabatic_boundaries` | Set walls/floors adiabatic |
+
+</details>
+
+<details>
+<summary><b>Discovery, info & routing</b> — 7 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `list_skills` | List available workflow guides |
+| `get_skill` | Step-by-step instructions for a workflow |
+| `recommend_tools` | Recommend the relevant tool group for a task |
+| `search_api` | Look up OpenStudio SDK classes + methods (verify before calling) |
+| `search_wiring_patterns` | Ruby wiring recipes for HVAC (24 patterns) |
+| `get_server_status` | Server health check |
+| `get_versions` | OpenStudio, EnergyPlus, Ruby versions |
+
+</details>
 
 ---
 
-## ASHRAE Baseline Systems
+## Reference
 
-All 10 ASHRAE 90.1 Appendix G baseline systems are supported via `add_baseline_system`:
+### ASHRAE baseline systems
 
-| System | Type | Description |
-|--------|------|-------------|
-| 01 | PTAC | Packaged terminal AC (zone-level) |
-| 02 | PTHP | Packaged terminal heat pump (zone-level) |
-| 03 | PSZ-AC | Packaged single-zone rooftop AC |
-| 04 | PSZ-HP | Packaged single-zone heat pump |
-| 05 | Packaged VAV w/ Reheat | VAV with hot water reheat coils |
-| 06 | Packaged VAV w/ PFP Boxes | VAV with parallel fan-powered boxes |
-| 07 | VAV w/ Reheat | Central VAV, chiller + boiler + cooling tower |
-| 08 | VAV w/ PFP Boxes | Central VAV with parallel fan-powered terminal |
-| 09 | Gas Unit Heater | Heating-only (warehouses, garages) |
+All 10 ASHRAE 90.1 Appendix G baseline systems via `add_baseline_system`, plus modern templates **DOAS**, **VRF**, **Radiant**.
+
+| # | Type | Description |
+|---|------|-------------|
+| 1 | PTAC | Packaged terminal AC (zone-level) |
+| 2 | PTHP | Packaged terminal heat pump (zone-level) |
+| 3 | PSZ-AC | Packaged single-zone rooftop AC |
+| 4 | PSZ-HP | Packaged single-zone heat pump |
+| 5 | Packaged VAV w/ Reheat | VAV with hot-water reheat |
+| 6 | Packaged VAV w/ PFP Boxes | VAV with parallel fan-powered boxes |
+| 7 | VAV w/ Reheat | Central VAV, chiller + boiler + tower |
+| 8 | VAV w/ PFP Boxes | Central VAV, parallel fan-powered terminals |
+| 9 | Gas Unit Heater | Heating-only (warehouses, garages) |
 | 10 | Electric Unit Heater | Heating-only, electric |
 
-Plus 3 modern templates: **DOAS**, **VRF**, **Radiant**.
+### HVAC component types
 
----
-
-## Supported HVAC Component Types
-
-The component properties tools can query and modify these 15 HVAC component types:
+The component-properties tools query/modify these 15 types:
 
 | Category | Components |
 |----------|------------|
-| **Coils** | CoilHeatingGas, CoilHeatingElectric, CoilHeatingWater, CoilCoolingWater, CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilHeatingDXSingleSpeed |
-| **Plant** | BoilerHotWater, ChillerElectricEIR, CoolingTowerSingleSpeed |
-| **Fans** | FanConstantVolume, FanVariableVolume, FanOnOff |
-| **Pumps** | PumpConstantSpeed, PumpVariableSpeed |
+| Coils | CoilHeatingGas, CoilHeatingElectric, CoilHeatingWater, CoilCoolingWater, CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilHeatingDXSingleSpeed |
+| Plant | BoilerHotWater, ChillerElectricEIR, CoolingTowerSingleSpeed |
+| Fans | FanConstantVolume, FanVariableVolume, FanOnOff |
+| Pumps | PumpConstantSpeed, PumpVariableSpeed |
 
 ---
 
 ## Examples
 
-19 worked examples with full tool-call sequences — click to expand:
+19 worked examples with full tool-call sequences:
 
-| # | Example | Description |
-|---|---------|-------------|
-| 1 | [Custom Measure: Lighting](docs/examples/01_custom_measure_lighting.md) | Write a measure to reduce lighting, compare before/after EUI |
-| 2 | [Custom Measure: Chilled Beams](docs/examples/02_custom_measure_hvac.md) | Write a complex HVAC measure, replace terminals, compare energy |
-| 3 | [Baseline Comparison](docs/examples/03_baseline_comparison.md) | Compare ASHRAE System 3 vs System 7 EUI |
-| 4 | [HVAC Design Exploration](docs/examples/04_hvac_design_exploration.md) | DOAS + fan coils, tune setpoints, resize components |
-| 5 | [Envelope Retrofit](docs/examples/05_envelope_retrofit.md) | Upgrade wall insulation, measure heating impact |
-| 6 | [Internal Loads](docs/examples/06_internal_loads.md) | People, lighting, plug loads with schedules |
-| 7 | [Full Building Model](docs/examples/07_full_building.md) | Spaces, zones, HVAC, loads, weather, simulate |
-| 8 | [Geometry from Scratch](docs/examples/08_geometry_creation.md) | Floor-print extrusion, surface matching, glazing |
-| 9 | [Fenestration by Orientation](docs/examples/09_fenestration_by_orientation.md) | Per-orientation window-to-wall ratios |
-| 10 | [Typical Building (ComStock)](docs/examples/10_comstock_typical_building.md) | 90.1-2019 template: constructions, loads, HVAC |
-| 11 | [Results Deep Dive](docs/examples/11_results_extraction.md) | End-use breakdown, envelope, HVAC sizing, timeseries |
-| 12 | [`/simulate`](docs/examples/12_simulate.md) | One-command simulate + results |
-| 13 | [`/energy-report`](docs/examples/13_energy_report.md) | Comprehensive multi-category report |
-| 14 | [`/qaqc`](docs/examples/14_qaqc.md) | Pre-simulation model quality check |
-| 15 | [`/add-hvac`](docs/examples/15_add_hvac.md) | Guided ASHRAE system selection |
-| 16 | [`/new-building`](docs/examples/16_new_building.md) | Full model creation from scratch |
-| 17 | [`/retrofit`](docs/examples/17_retrofit.md) | Before/after ECM analysis |
-| 18 | [`/view`](docs/examples/18_view.md) | Interactive 3D model visualization |
-| 19 | [SystemD Four-Pipe Beam Retrofit](docs/examples/19_systemd_fourpipebeam_retrofit.md) | End-to-end: load 44-zone model, baseline sim, author measure, retrofit sim, compare |
+| # | Example | # | Example |
+|---|---------|---|---------|
+| 1 | [Custom Measure: Lighting](docs/examples/01_custom_measure_lighting.md) | 11 | [Results Deep Dive](docs/examples/11_results_extraction.md) |
+| 2 | [Custom Measure: Chilled Beams](docs/examples/02_custom_measure_hvac.md) | 12 | [`/simulate`](docs/examples/12_simulate.md) |
+| 3 | [Baseline Comparison](docs/examples/03_baseline_comparison.md) | 13 | [`/energy-report`](docs/examples/13_energy_report.md) |
+| 4 | [HVAC Design Exploration](docs/examples/04_hvac_design_exploration.md) | 14 | [`/qaqc`](docs/examples/14_qaqc.md) |
+| 5 | [Envelope Retrofit](docs/examples/05_envelope_retrofit.md) | 15 | [`/add-hvac`](docs/examples/15_add_hvac.md) |
+| 6 | [Internal Loads](docs/examples/06_internal_loads.md) | 16 | [`/new-building`](docs/examples/16_new_building.md) |
+| 7 | [Full Building Model](docs/examples/07_full_building.md) | 17 | [`/retrofit`](docs/examples/17_retrofit.md) |
+| 8 | [Geometry from Scratch](docs/examples/08_geometry_creation.md) | 18 | [`/view`](docs/examples/18_view.md) |
+| 9 | [Fenestration by Orientation](docs/examples/09_fenestration_by_orientation.md) | 19 | [Four-Pipe Beam Retrofit (E2E)](docs/examples/19_systemd_fourpipebeam_retrofit.md) |
+| 10 | [Typical Building (ComStock)](docs/examples/10_comstock_typical_building.md) | | |
 
 ---
 
 ## Testing
 
-For the full testing guide — framework details, annotated examples, CI shards, and how to write new tests — see **[`docs/testing/`](docs/testing/README.md)** (or [`docs/testing/testing.md`](docs/testing/testing.md) for the contributor guide).
-
-### Quick start
+Full guide — framework, annotated examples, CI shards, writing tests — in **[docs/testing/](docs/testing/README.md)**.
 
 ```bash
 # Unit tests (no Docker)
@@ -529,7 +501,6 @@ pytest tests/test_skill_registration.py -v
 
 # Integration tests (Docker)
 docker build -t openstudio-mcp:dev -f docker/Dockerfile .
-
 docker run --rm -v "$PWD:/repo" -v "$PWD/runs:/runs" \
   -e RUN_OPENSTUDIO_INTEGRATION=1 -e MCP_SERVER_CMD=openstudio-mcp \
   openstudio-mcp:dev bash -lc 'cd /repo && pytest -vv -s tests/'
@@ -537,72 +508,37 @@ docker run --rm -v "$PWD:/repo" -v "$PWD/runs:/runs" \
 
 ---
 
-## Dev vs Prod Mode
-
-| Mode | Purpose | Behavior |
-|------|---------|----------|
-| `dev` (default) | Local development | FastMCP banner + INFO logs |
-| `prod` | MCP host usage | Banner disabled, quieter logs |
-
-```bash
-# Prod mode (recommended for MCP hosts)
-docker run --rm -i -e OPENSTUDIO_MCP_MODE=prod openstudio-mcp:dev openstudio-mcp
-```
-
-In **prod mode**, stdout is reserved exclusively for MCP JSON-RPC messages. Logs go to stderr.
-
----
-
 ## Architecture
 
-- **Transport:** stdio (container spawned by host)
-- **Protocol:** MCP (JSON-RPC over stdin/stdout)
-- **Model state:** single in-memory model via `model_manager`
-- **Runs:** stored under `/runs/<run_id>/`
-- **Skills pattern:** each skill in `mcp_server/skills/<name>/` with `tools.py` (MCP registration) + `operations.py` (business logic)
+- **Transport:** stdio (default) or streamable HTTP for [remote/multi-user](#remote--multi-user-http)
+- **Protocol:** MCP (JSON-RPC); in stdio prod mode, stdout is reserved for JSON-RPC and logs go to stderr
+- **Skills:** 27 skill modules under `mcp_server/skills/<name>/`, each with `tools.py` (MCP registration) + `operations.py` (business logic); they auto-register
+- **State:** per-session in-memory model via `model_manager`; runs under `/runs/<run_id>/` (or `/runs/<user>/<run_id>/` in HTTP mode)
 
-Full system diagram, security analysis & hardening recommendations: **[docs/architecture.md](docs/architecture.md)**
+Set `OPENSTUDIO_MCP_MODE=prod` for MCP hosts (quiet logs, no banner). Full system diagram, security analysis, and hardening notes: **[docs/architecture.md](docs/architecture.md)**.
 
----
+<details>
+<summary><b>Contributing</b> — adding skills, tools, and component types</summary>
 
-## Contributing
-
-### Adding a new MCP skill
-
+**New MCP skill**
 1. Create `mcp_server/skills/<name>/__init__.py`, `operations.py`, `tools.py`
-2. `operations.py` — pure business logic, returns `{"ok": True/False, ...}` dicts
-3. `tools.py` — exports `register(mcp)`, defines MCP tool schemas
-4. Add tests in `tests/test_<name>.py`
-5. Add CI step in `.github/workflows/ci.yml`
-6. The skill auto-registers via `skills/__init__.py` discovery
-7. Update `EXPECTED_TOOLS` in `tests/test_skill_registration.py`
-8. Update tool counts in `README.md` and `CLAUDE.md`
+2. `operations.py` — pure logic, returns `{"ok": True/False, ...}`
+3. `tools.py` — exports `register(mcp)`, defines tool schemas
+4. Add `tests/test_<name>.py` and a CI step in `.github/workflows/ci.yml`
+5. Auto-registers via `skills/__init__.py`; add names to `EXPECTED_TOOLS` and bump counts in `tests/test_tool_baseline.py`
 
-### Adding a new Claude Code skill (workflow guide)
+**New Claude Code skill (workflow guide)**
+1. Create `.claude/skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`)
+2. Add workflow instructions referencing MCP tool names; `user-invocable: true|false`, `context: fork` for fire-and-forget
+3. Add `tests/test_skill_<name>.py` + a CI shard, an example in `docs/examples/`, and a README row
+4. Auto-appears in `list_skills()` via the `/skills` mount
 
-1. Create `.claude/skills/<name>/SKILL.md` with YAML frontmatter:
-   ```yaml
-   ---
-   name: my-skill
-   description: Short description for discovery
-   ---
-   ```
-2. Add workflow instructions in the markdown body referencing MCP tool names
-3. For user-invocable skills, add `user-invocable: true` (or omit — default)
-4. For background knowledge, add `user-invocable: false`
-5. For fire-and-forget workflows, add `context: fork`
-6. Add integration test in `tests/test_skill_<name>.py` exercising the tool sequence
-7. Add test to a CI shard in `.github/workflows/ci.yml`
-8. Add example doc in `docs/examples/<N>_<name>.md`
-9. Update README examples section and Claude Code Skills table
-10. The skill auto-appears in `list_skills()` / `get_skill()` via the `/skills` mount
+**New HVAC component type**
+1. Add `_get_<type>_props(obj)` / `_set_<type>_props(obj, props)` in `components.py`
+2. Add an entry to `COMPONENT_TYPES`; add a test in `tests/test_component_properties.py`
+3. No dynamic dispatch — every OpenStudio API call must be explicit and grepable
 
-### Adding a new HVAC component type
-
-1. Add `_get_<type>_props(obj)` and `_set_<type>_props(obj, properties)` in `components.py`
-2. Add entry to `COMPONENT_TYPES` dict
-3. Add test in `tests/test_component_properties.py`
-4. No dynamic dispatch — every OpenStudio API call must be explicit and grepable
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ For simulation outputs (results, SQL, HTML reports), these are already in `/runs
 
 [VS Code Copilot](https://code.visualstudio.com/), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Windsurf](https://windsurf.com/), and [Gemini CLI](https://github.com/google-gemini/gemini-cli) also support MCP with similar JSON config. See the [MCP documentation](https://modelcontextprotocol.io/quickstart/user) for host-specific setup.
 
+### Remote & Multi-User (HTTP)
+
+The Quick Start above runs the server locally over stdio (one process per user).
+To host it on one machine and let teammates connect from their own laptops —
+each with an isolated session, run directory, and optional bearer-token auth —
+run it over streamable HTTP instead (`-e MCP_TRANSPORT=http`). Works with Claude
+Code, Cursor, and VS Code.
+
+See **[docs/remote-multi-user.md](docs/remote-multi-user.md)** for server setup,
+client config, auth, and the isolation model.
+
 ### Client Compatibility
 
 | Client | Status | Notes |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,4 +62,8 @@ ENV OSMCP_CODE_MODE=0
 ENV PYTHONUNBUFFERED=1
 ENV OPENSTUDIO_MCP_MODE=dev
 
+# Streamable-HTTP (remote multi-user) listens here; opt in with -e MCP_TRANSPORT=http
+# (default transport is stdio). See docs/plans/multi-user-remote-mcp.md
+EXPOSE 8000
+
 CMD ["openstudio-mcp"]

--- a/docs/plans/multi-user-remote-mcp.md
+++ b/docs/plans/multi-user-remote-mcp.md
@@ -1,0 +1,171 @@
+# Multi-User Remote MCP Server — Design & Implementation Plan
+
+**Branch:** `feat/multi-user-remote-mcp` (off `origin/develop`)
+**Status:** Increment 1 complete + verified. Increments 3–4 in progress.
+
+Lets openstudio-mcp run on one beefy box and serve multiple remote users
+(Claude Code / Cursor / VS Code) over the network, each with an isolated
+session, isolated files, and fair access to simulation compute — while the
+existing local stdio workflow stays byte-for-byte unchanged.
+
+---
+
+## 1. Context & constraints
+
+- **Deploy targets:** (a) NLR LAN behind firewall, reached over NLR's VPN;
+  (b) a small business, reached over Tailscale/WireGuard. Same artifact, only
+  the network around it differs → **Pattern A (private/VPN-fronted)**.
+- **Clients:** Claude Code, Cursor, VS Code — all do native `url` + bearer
+  header HTTP. (Claude Desktop would need `mcp-remote`; out of scope.)
+- **Composability:** a public deployer can add their own perimeter (TLS,
+  OAuth, WAF) *on top* without touching tool code. The server owns
+  *correctness* (isolation, fairness, identity-keying); the deployer owns the
+  *perimeter*. The only hard rule: don't bake in "we are the TLS edge" or
+  "auth is static" — keep both as seams.
+- **No horizontal scale:** model state is a heavy in-memory OpenStudio object,
+  so this is single-box. Multi-box scale-out = future per-user-container
+  topology (same isolation model as stdio-per-user, orchestrated).
+
+## 2. Locked decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Model state keyed per-SESSION** (not per-user) | Two windows of the same user must not stomp each other's working model. Matches stdio (1 process = 1 model). |
+| 2 | **Sim queue = global FIFO** for v1 | Simplest correct enforcement of `MAX_CONCURRENCY`; per-user fairness is a documented follow-up. |
+| 3 | **HTTP auth default = `token`** (secure-by-default) | `MCP_AUTH=none` is an explicit opt-in for trusted VPN. stdio stays `none`. |
+| 4 | **Session eviction = 30min idle TTL + max-sessions LRU cap** | Heavy models can't accumulate unbounded; both env-tunable. LRU cap shipped first (hard RAM backstop); TTL sweep is a follow-up. |
+| 5 | **Shared roots read-only** | Least privilege: `/repo`, measures, `/skills`, `/inputs` are read-only for all; the only per-user writable area is `RUN_ROOT/<user>`. |
+| 6 | **One feature branch**, increments shippable in sequence | — |
+
+## 3. Architecture
+
+```
+User (Claude Code / Cursor / VS Code)
+        │  HTTPS + bearer token
+        ▼
+[ TLS / exposure: VPN or tunnel ]        ← deployer's perimeter (NOT in repo)
+        ▼
+[ FastMCP, transport=http, auth=verifier ]
+        │  identity: session_key() / user_key()  (from get_context())
+        ├── per-session model state (model_manager: dict + lock + LRU)
+        ├── per-user files: RUN_ROOT/<user_key>/...  + path scoping
+        └── global sim queue (FIFO, cap = MAX_CONCURRENCY) → EnergyPlus
+```
+
+**One identity, two keys** (`mcp_server/identity.py`):
+
+| Key | Source | Keys |
+|-----|--------|------|
+| `session_key()` | `ctx.session_id` (HTTP) / `"local"` (stdio/off-request) | ephemeral **model** state |
+| `user_key()` | auth `client_id` → else `session_id` → else `"local"`, sanitized | durable **run dirs + path scope + run ownership** |
+
+All 142 tools call `get_model()` / `is_path_allowed()` unchanged — the keys
+are resolved *inside* those chokepoints, so multi-user is invisible to skills.
+
+**Verified fact:** `get_context().session_id` propagates into FastMCP's
+sync-tool worker threads (FastMCP 3.2.0) — so session-keyed isolation is real.
+
+## 4. Component design
+
+- **`server.py`** — `MCP_TRANSPORT` branch (`stdio` default | `http`).
+  `MCP_HOST/MCP_PORT/MCP_PATH`. `_build_auth()` reads `MCP_AUTH`
+  (`none` | `token` via `StaticTokenVerifier`, `MCP_TOKENS` JSON map).
+  stdout: keep `silence_openstudio_stdout_logger()` always; startup
+  `redirect_c_stdout_to_stderr()` is safe in both modes (one-time, pre-threads;
+  stdout isn't the HTTP protocol channel). No per-request fd ops.
+- **`identity.py`** — `session_key()`, `user_key()`, `_sanitize()`.
+- **`model_manager.py`** — `dict[session_key → _SessionState]` under an
+  `RLock`; LRU evict over `OSMCP_MAX_SESSIONS` (16). Public signatures
+  unchanged. `atexit` clears all (SWIG #5421).
+- **`config.py`** — `user_run_root()` = `RUN_ROOT/<user_key>`.
+  `is_path_allowed(p, *, write=False)`: shared roots read-only; writes only
+  under own run dir.
+- **`skills/simulation/operations.py`** — run dir =
+  `RUN_ROOT/<user_key>/<run_id>`; `RunRecord.user_key`; ownership checks on
+  `get_run_status/logs/artifacts/cancel`. Sim **queue**: `run_osw` enqueues
+  (`status="queued"`); a background daemon dispatcher reaps finished PIDs and
+  launches FIFO up to `MAX_CONCURRENCY`.
+
+## 5. Test strategy
+
+**Harness problem:** stdio spawns one server *process per client*, so "two
+stdio sessions" can't prove session-keying. Real isolation is only provable
+over **HTTP** (one process, two sessions). Added `http_server()` +
+`http_session()` to `conftest.py` (server runs inside the test container; no
+published port needed).
+
+| File | Tier | Validates |
+|------|------|-----------|
+| `test_http_transport.py` | integration | server boots under HTTP; tool round-trips |
+| `test_session_isolation.py` | integration | 2 HTTP sessions, 1 process → independent models |
+| `test_per_user_run_dirs.py` | integration | run dir namespaced; cross-user run_id → not found; cross-user path → not allowed |
+| `test_sim_queue.py` | integration | `MAX_CONCURRENCY=2`, 4 sims → ≤2 running / rest queued → all terminal |
+| `test_sim_queue_unit.py` | unit | queue policy: cap, FIFO, slot-release (mock launch only) |
+| `test_identity_unit.py` | unit | stdio→`local`; mocked session_id; token→user |
+| `test_path_safety.py` (extend) | unit | per-user `is_path_allowed`, write vs read |
+| `test_stdio_smoke.py` (extend) | integration | stdio still single-`local`, model persists |
+
+Mocking confined to *dependencies* (subprocess launch, context) — never the
+unit under test. CI: light integration → shard 4, sims → shard 5, `*_unit` →
+`pytest -m unit` job.
+
+## 6. Increment plan & status
+
+1. **Transport + identity + session-keyed model + HTTP harness** — ✅ DONE,
+   verified (5 tests pass; stdio regression intact; lint clean).
+2. (folded into 1)
+3. **Per-user run dirs + path scoping + run ownership** — ⏳ in progress.
+4. **Sim queue (FIFO, MAX_CONCURRENCY)** — ⏳ in progress.
+5. **Token auth + flip HTTP default to `token`** — pending.
+6. **Session idle-TTL eviction** — pending (LRU cap already shipped).
+7. **CI shards + Dockerfile `EXPOSE` + docs** — pending.
+
+## 7. Risks & honest caveats
+
+- **RAM:** N sessions = N heavy models. LRU cap is the backstop; TTL sweep
+  follows. Cap sized to box RAM.
+- **Intra-session concurrency** on one model is still the client's
+  responsibility (unchanged from today); cross-session is what we isolate.
+- **Session-id API:** uses public `get_context()` (not private
+  `_current_context`); pinned by `test_identity_unit` + isolation test.
+- **No multi-box scale** (in-memory models).
+- **FIFO queue:** one user can fill the queue (no per-user cap in v1) —
+  documented, not silently capped.
+
+## 8. Out of scope for v1 (follow-ups)
+
+- Per-user queue fairness cap.
+- OAuth/JWT (the `auth=` seam already supports swapping `JWTVerifier`).
+- Per-user-container topology for horizontal scale.
+- Quotas / disk accounting per user.
+
+## 9. How to run
+
+**Server (HTTP, trusted VPN):**
+```bash
+docker run -d -p 8000:8000 \
+  -e MCP_TRANSPORT=http -e MCP_AUTH=none \
+  -v /data/runs:/runs openstudio-mcp:dev openstudio-mcp
+```
+
+**Server (HTTP, token auth):**
+```bash
+-e MCP_AUTH=token -e MCP_TOKENS='{"s3cret-abc":"alice","s3cret-xyz":"bob"}'
+```
+
+**Client (Claude Code / Cursor / VS Code):**
+```json
+{ "mcpServers": { "openstudio-mcp": {
+  "type": "http",
+  "url": "http://<box>:8000/mcp",
+  "headers": { "Authorization": "Bearer s3cret-abc" }
+}}}
+```
+
+**Local stdio (unchanged):**
+```json
+{ "mcpServers": { "openstudio-mcp": {
+  "command": "docker",
+  "args": ["run","--rm","-i","-v","C:/.../runs:/runs","openstudio-mcp:dev","openstudio-mcp"]
+}}}
+```

--- a/docs/plans/multi-user-remote-mcp.md
+++ b/docs/plans/multi-user-remote-mcp.md
@@ -116,10 +116,11 @@ unit under test. CI: light integration → shard 4, sims → shard 5, `*_unit` �
 3. **Per-user run dirs + path scoping + run ownership** — ✅ DONE, verified across all changed skills.
 4. **Token auth + HTTP default `token` (secure-by-default)** — ✅ DONE, verified (accept/reject + principal→run-dir).
 5. **CI shards (2 + 5) + Dockerfile `EXPOSE 8000`** — ✅ DONE.
-6. **Session idle-TTL eviction** — follow-up (LRU cap shipped as the RAM backstop).
+6. **Session idle-TTL eviction** (`OSMCP_SESSION_TTL`, default 30 min) + LRU cap — ✅ DONE.
+7. **Setup docs** (`docs/remote-multi-user.md` + README pointer) — ✅ DONE.
 
-Follow-ups (noted in commits): scope the two `MCP_RUNS_DIR` measure-exec temp
-dirs (`measures`/`measure_authoring`) per-user; idle-TTL session eviction.
+Follow-up (noted in commits): scope the two `MCP_RUNS_DIR` measure-exec temp
+dirs (`measures`/`measure_authoring`) per-user.
 
 ## 7. Risks & honest caveats
 

--- a/docs/plans/multi-user-remote-mcp.md
+++ b/docs/plans/multi-user-remote-mcp.md
@@ -111,14 +111,15 @@ unit under test. CI: light integration → shard 4, sims → shard 5, `*_unit` �
 
 ## 6. Increment plan & status
 
-1. **Transport + identity + session-keyed model + HTTP harness** — ✅ DONE,
-   verified (5 tests pass; stdio regression intact; lint clean).
-2. (folded into 1)
-3. **Per-user run dirs + path scoping + run ownership** — ⏳ in progress.
-4. **Sim queue (FIFO, MAX_CONCURRENCY)** — ⏳ in progress.
-5. **Token auth + flip HTTP default to `token`** — pending.
-6. **Session idle-TTL eviction** — pending (LRU cap already shipped).
-7. **CI shards + Dockerfile `EXPOSE` + docs** — pending.
+1. **Transport + identity + session-keyed model + HTTP harness** — ✅ DONE, verified.
+2. **Sim queue (FIFO, MAX_CONCURRENCY)** — ✅ DONE, verified (unit + integration + e2e).
+3. **Per-user run dirs + path scoping + run ownership** — ✅ DONE, verified across all changed skills.
+4. **Token auth + HTTP default `token` (secure-by-default)** — ✅ DONE, verified (accept/reject + principal→run-dir).
+5. **CI shards (2 + 5) + Dockerfile `EXPOSE 8000`** — ✅ DONE.
+6. **Session idle-TTL eviction** — follow-up (LRU cap shipped as the RAM backstop).
+
+Follow-ups (noted in commits): scope the two `MCP_RUNS_DIR` measure-exec temp
+dirs (`measures`/`measure_authoring`) per-user; idle-TTL session eviction.
 
 ## 7. Risks & honest caveats
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -1,0 +1,159 @@
+# Remote & Multi-User Setup (HTTP transport)
+
+By default openstudio-mcp runs over **stdio** — one server process per user,
+launched on demand by the MCP host (the Quick Start in the README). For a
+shared deployment — one beefy machine, many people connecting from their own
+laptops — run it over **streamable HTTP** instead. Same image, one env var.
+
+| | stdio (default) | HTTP (remote/multi-user) |
+|---|---|---|
+| Who launches it | the MCP host, per user | you, once, as a service |
+| Transport | stdin/stdout | `http://<host>:8000/mcp` |
+| Users | one (the local user) | many concurrent, isolated |
+| Auth | none (local trust) | bearer token (default) or none on a VPN |
+| Config key | `command` + `args` | `type: http` + `url` |
+
+Everyone shares the one running server but is **isolated**: each connection gets
+its own loaded model, its own run directory (`/runs/<user>/…`), and can't see
+another user's runs or files. Simulations are queued so the box isn't thrashed.
+
+---
+
+## 1. Run the server in HTTP mode
+
+The server stays single-box (model state is heavy and in-memory). Put it on a
+machine your users can reach — see [Network & security](#4-network--security).
+
+**Trusted network / VPN (no app auth):**
+```bash
+docker run -d --name openstudio-mcp \
+  -p 8000:8000 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_AUTH=none \
+  -v /data/runs:/runs \
+  -v /data/inputs:/inputs \
+  openstudio-mcp:dev openstudio-mcp
+```
+
+**With per-user tokens (default for HTTP):**
+```bash
+docker run -d --name openstudio-mcp \
+  -p 8000:8000 \
+  -e MCP_TRANSPORT=http \
+  -e MCP_AUTH=token \
+  -e MCP_TOKENS='{"s3cret-alice":"alice","s3cret-bob":"bob"}' \
+  -v /data/runs:/runs \
+  openstudio-mcp:dev openstudio-mcp
+```
+
+`MCP_TOKENS` maps each bearer token → a username. That username becomes the
+user's identity: it scopes their run directory and their run ownership. If you
+set `MCP_TRANSPORT=http` and forget `MCP_AUTH`, it defaults to `token` and — with
+no `MCP_TOKENS` — rejects everyone (fail-closed). Use `MCP_AUTH=none` to opt out.
+
+> **Token storage is plaintext** (`StaticTokenVerifier`). Fine for a trusted team
+> behind a VPN. For public/SSO deployments, swap in a JWT verifier via the
+> `auth=` seam in `mcp_server/server.py::_build_auth()`.
+
+---
+
+## 2. Connect a client
+
+`url` points at the server's `/mcp` path; add the bearer header only if you ran
+with `MCP_AUTH=token`. **Claude Code, Cursor, and VS Code** all support this.
+
+**Claude Code** — add to `.mcp.json` (or `claude mcp add`):
+```json
+{
+  "mcpServers": {
+    "openstudio-mcp": {
+      "type": "http",
+      "url": "http://10.0.0.5:8000/mcp",
+      "headers": { "Authorization": "Bearer s3cret-alice" }
+    }
+  }
+}
+```
+
+**Cursor** — `~/.cursor/mcp.json` (or project `.cursor/mcp.json`), same shape:
+```json
+{ "mcpServers": { "openstudio-mcp": {
+  "url": "http://10.0.0.5:8000/mcp",
+  "headers": { "Authorization": "Bearer s3cret-alice" }
+}}}
+```
+
+**VS Code (Copilot)** — `.vscode/mcp.json`:
+```json
+{ "servers": { "openstudio-mcp": {
+  "type": "http",
+  "url": "http://10.0.0.5:8000/mcp",
+  "headers": { "Authorization": "Bearer s3cret-alice" }
+}}}
+```
+
+On a VPN with `MCP_AUTH=none`, drop the `headers` block. The local stdio config
+(README Quick Start) is unchanged and still works for single-user use.
+
+---
+
+## 3. How isolation works
+
+- **Per-session model.** Each connection has its own loaded OSM model. Two
+  windows (even the same user) never overwrite each other's working model.
+  Idle sessions are dropped after `OSMCP_SESSION_TTL` (default 30 min); a hard
+  cap (`OSMCP_MAX_SESSIONS`, default 16) bounds resident models.
+- **Per-user files.** Everything a user creates lives under `/runs/<user>/…`.
+  Tool path arguments are scoped: a user can't read or write another user's run
+  area; shared reference dirs (measures, `/inputs`) are read-only. `list_files`
+  with `/runs` shows only the caller's own runs.
+- **Run ownership.** `get_run_status` / `get_run_logs` / `get_run_artifacts` /
+  `cancel_run` only work on the caller's own runs — another user's `run_id`
+  returns "unknown run_id".
+- **Simulation queue.** Runs are FIFO-queued; at most `OSMCP_MAX_CONCURRENCY`
+  (default 1) EnergyPlus simulations execute at once. Excess runs report
+  `status: "queued"` and start automatically as slots free.
+
+---
+
+## 4. Network & security
+
+The server is **not** the TLS edge — it speaks plain HTTP and trusts the network
+around it. Pick one:
+
+- **VPN (recommended).** Bind it inside a corporate LAN/firewall or a
+  Tailscale/WireGuard tailnet; users connect to a private IP. With the network as
+  the boundary you can run `MCP_AUTH=none`.
+- **Reverse proxy for TLS.** Front it with Caddy/nginx/Traefik (or a Cloudflare
+  Tunnel) terminating HTTPS and forwarding to `:8000`. Keep `MCP_AUTH=token`.
+
+Don't expose port 8000 to the public internet directly.
+
+---
+
+## 5. Environment variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `MCP_TRANSPORT` | `stdio` | `http` (or `streamable-http`) to serve remotely |
+| `MCP_HOST` | `0.0.0.0` | bind address (HTTP mode) |
+| `MCP_PORT` | `8000` | listen port (HTTP mode) |
+| `MCP_PATH` | `/mcp` | URL path of the MCP endpoint |
+| `MCP_AUTH` | `token` on HTTP, else `none` | `none` (open) or `token` |
+| `MCP_TOKENS` | `{}` | JSON map `{"<bearer-token>":"<username>"}` |
+| `OSMCP_MAX_CONCURRENCY` | `1` | max simultaneous EnergyPlus simulations |
+| `OSMCP_MAX_SESSIONS` | `16` | LRU cap on resident per-session models |
+| `OSMCP_SESSION_TTL` | `1800` | idle seconds before a session model is dropped (`0` disables) |
+| `OSMCP_RUN_ROOT` | `/runs` | base directory for per-user run dirs |
+
+---
+
+## 6. Limitations / not yet
+
+- **Single box only** — in-memory model state isn't shared across machines.
+  Horizontal scale would need a per-user-container topology behind a router.
+- **Plaintext token auth** — swap in `JWTVerifier` (OAuth/SSO) for public use.
+- Two internal measure-execution temp dirs still write to shared `/runs`
+  (no cross-user read exposure) — to be scoped per-user in a follow-up.
+
+See `docs/plans/multi-user-remote-mcp.md` for the full design rationale.

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -181,3 +181,11 @@ burst), `heavy` (64 sessions + sims). Override any knob with
 `--users N --calls K --cap C --sims/--no-sims --max-sessions M` — a tiny
 `--max-sessions` forces LRU/TTL eviction so you can watch that path too.
 
+By default Phase 2 launches the sims, checks the cap + ownership, and cancels
+them (fast). Add **`--drain`** to instead run them to completion with a live
+`queued/running/success` readout — e.g. watch the cap throttle real work:
+
+```bash
+python scripts/stress_remote.py --users 6 --cap 2 --drain
+```
+

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -162,3 +162,22 @@ Don't expose port 8000 to the public internet directly.
   (no cross-user read exposure) — to be scoped per-user in a follow-up.
 
 See `docs/plans/multi-user-remote-mcp.md` for the full design rationale.
+
+---
+
+## 7. Stress testing locally
+
+`scripts/stress_remote.py` drives many concurrent sessions at one server and
+asserts the multi-user invariants under load — session isolation, the sim
+concurrency cap, cross-user run ownership, and bounded memory:
+
+```bash
+docker run --rm -v "$PWD:/repo" -v "$PWD/runs:/runs" openstudio-mcp:dev \
+  bash -lc "cd /repo && python scripts/stress_remote.py --profile moderate"
+```
+
+Profiles: `smoke` (8 sessions, fast, no sims), `moderate` (24 sessions + a sim
+burst), `heavy` (64 sessions + sims). Override any knob with
+`--users N --calls K --cap C --sims/--no-sims --max-sessions M` — a tiny
+`--max-sessions` forces LRU/TTL eviction so you can watch that path too.
+

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -51,6 +51,14 @@ user's identity: it scopes their run directory and their run ownership. If you
 set `MCP_TRANSPORT=http` and forget `MCP_AUTH`, it defaults to `token` and — with
 no `MCP_TOKENS` — rejects everyone (fail-closed). Use `MCP_AUTH=none` to opt out.
 
+**You issue the tokens.** There is no self-service signup: the operator generates
+a strong random string per user (e.g. `openssl rand -hex 24`), adds it to
+`MCP_TOKENS`, and hands it to that user out-of-band — treat it like a password.
+The server verifies the `Authorization: Bearer …` header on **every** request
+before any tool runs; a missing or unknown token is rejected (401). Rotate or
+revoke by editing `MCP_TOKENS` and restarting. For `jwt` mode, tokens are minted
+and signed by your IdP instead, and the server only verifies them.
+
 > **Token storage is plaintext** (`StaticTokenVerifier`). Fine for a trusted team
 > behind a VPN. For SSO/public deployments use `MCP_AUTH=jwt` and point it at your
 > IdP's verifying key (`MCP_JWT_PUBLIC_KEY`, a PEM) or JWKS endpoint
@@ -136,6 +144,21 @@ lines — to stderr (`docker logs`) and, if `MCP_AUDIT_FILE` is set, to that fil
 ```
 
 So you can answer "who ran what, when, did it succeed". Disable with `MCP_AUDIT=off`.
+
+**Who can access logs.** Two audiences, two boundaries — enforced in code:
+
+- **End users (through the MCP API)** see only their *own* run logs:
+  `get_run_logs` / `get_run_artifacts` (and `read_file` on their run dir) are
+  run-ownership scoped, so another user's `run_id` returns "unknown". **No tool
+  exposes the audit log** or any other user's logs — there is no API path to them.
+- **Operators (host/container access)** see everything: the audit JSON and server
+  logs via `docker logs <container>`, and the `MCP_AUDIT_FILE` on the mounted
+  volume. This is the only way to read the cross-user audit trail — guard host
+  and `docker` access accordingly.
+- **Keep `MCP_AUDIT_FILE` off any user-reachable path.** Top-level
+  `/runs/audit.log` is already safe in HTTP mode — it sits outside every user's
+  `/runs/<user>/` scope, so `read_file` / `list_files` deny it — but never point
+  it *inside* a user's run area, or that user could read the whole audit trail.
 
 ---
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -114,11 +114,13 @@ On a VPN with `MCP_AUTH=none`, drop the `headers` block. The local stdio config
 - **Simulation queue.** Runs are FIFO-queued; at most `OSMCP_MAX_CONCURRENCY`
   (default 1) EnergyPlus simulations execute at once. Excess runs report
   `status: "queued"` and start automatically as slots free.
-- **Run retention (disk).** Finished run dirs (~40 MB each) are reclaimed
-  automatically: a background sweeper deletes runs older than
-  `OSMCP_RUN_RETENTION_DAYS` (default 7, `0` = keep forever), skipping pinned and
-  queued/running runs. Only run dirs are swept — saved models under `examples/`
-  are never touched. On demand, agents can `cleanup_runs` (preview with
+- **Run retention (disk).** Finished run dirs (~40 MB each) can be reclaimed by a
+  background sweeper — but it is **off by default**. Enable it explicitly with the
+  `--gc` / `--gc-days N` CLI flag or by setting `OSMCP_RUN_RETENTION_DAYS>0`; it
+  then deletes runs older than that window, skipping pinned and queued/running
+  runs. Only run dirs are swept — saved models under `examples/` are never
+  touched, and it never follows symlinks or runs against a system root. On demand
+  (regardless of the daemon), agents can `cleanup_runs` (preview with
   `dry_run=True`, then delete), `delete_run`, and `pin_run` / `unpin_run` to
   exempt a reference run. Every reclaim is audit-logged as `run_evicted`.
 
@@ -169,8 +171,12 @@ Don't expose port 8000 to the public internet directly.
 | `OSMCP_MAX_SESSIONS` | `16` | LRU cap on resident per-session models |
 | `OSMCP_SESSION_TTL` | `1800` | idle seconds before a session model is dropped (`0` disables) |
 | `OSMCP_RUN_ROOT` | `/runs` | base directory for per-user run dirs |
-| `OSMCP_RUN_RETENTION_DAYS` | `7` | auto-delete finished run dirs older than N days (`0` = keep forever) |
+| `OSMCP_RUN_RETENTION_DAYS` | `0` (off) | enable auto-GC: delete finished run dirs older than N days (`0` = off) |
 | `OSMCP_RETENTION_SWEEP_SECONDS` | `3600` | how often the retention daemon sweeps (60s floor) |
+
+Auto-GC is **off by default**. Enable it with a CLI flag on the server command —
+`openstudio-mcp --gc` (default 7-day window) or `openstudio-mcp --gc-days 14` — or
+via `OSMCP_RUN_RETENTION_DAYS=14`. The CLI flag wins over the env value.
 | `MCP_AUDIT` | `on` | structured audit logging (tool calls + sim lifecycle); `off` to disable |
 | `MCP_AUDIT_FILE` | — | also append audit JSON lines to this file (e.g. `/runs/audit.log`) |
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -142,6 +142,7 @@ Don't expose port 8000 to the public internet directly.
 | `MCP_AUTH` | `token` on HTTP, else `none` | `none` (open) or `token` |
 | `MCP_TOKENS` | `{}` | JSON map `{"<bearer-token>":"<username>"}` |
 | `OSMCP_MAX_CONCURRENCY` | `1` | max simultaneous EnergyPlus simulations |
+| `OSMCP_MAX_CONCURRENCY_PER_USER` | `0` | per-user sim cap for fairness (`0` = no limit) |
 | `OSMCP_MAX_SESSIONS` | `16` | LRU cap on resident per-session models |
 | `OSMCP_SESSION_TTL` | `1800` | idle seconds before a session model is dropped (`0` disables) |
 | `OSMCP_RUN_ROOT` | `/runs` | base directory for per-user run dirs |

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -52,8 +52,9 @@ set `MCP_TRANSPORT=http` and forget `MCP_AUTH`, it defaults to `token` and — w
 no `MCP_TOKENS` — rejects everyone (fail-closed). Use `MCP_AUTH=none` to opt out.
 
 > **Token storage is plaintext** (`StaticTokenVerifier`). Fine for a trusted team
-> behind a VPN. For public/SSO deployments, swap in a JWT verifier via the
-> `auth=` seam in `mcp_server/server.py::_build_auth()`.
+> behind a VPN. For SSO/public deployments use `MCP_AUTH=jwt` and point it at your
+> IdP's verifying key (`MCP_JWT_PUBLIC_KEY`, a PEM) or JWKS endpoint
+> (`MCP_JWT_JWKS_URI`), optionally constraining `MCP_JWT_ISSUER` / `MCP_JWT_AUDIENCE`.
 
 ---
 
@@ -139,8 +140,10 @@ Don't expose port 8000 to the public internet directly.
 | `MCP_HOST` | `0.0.0.0` | bind address (HTTP mode) |
 | `MCP_PORT` | `8000` | listen port (HTTP mode) |
 | `MCP_PATH` | `/mcp` | URL path of the MCP endpoint |
-| `MCP_AUTH` | `token` on HTTP, else `none` | `none` (open) or `token` |
-| `MCP_TOKENS` | `{}` | JSON map `{"<bearer-token>":"<username>"}` |
+| `MCP_AUTH` | `token` on HTTP, else `none` | `none` (open), `token`, or `jwt` |
+| `MCP_TOKENS` | `{}` | JSON map `{"<bearer-token>":"<username>"}` (token mode) |
+| `MCP_JWT_PUBLIC_KEY` / `MCP_JWT_JWKS_URI` | — | verifying key (PEM) or JWKS endpoint (jwt mode) |
+| `MCP_JWT_ISSUER` / `MCP_JWT_AUDIENCE` | — | optional JWT issuer/audience checks |
 | `OSMCP_MAX_CONCURRENCY` | `1` | max simultaneous EnergyPlus simulations |
 | `OSMCP_MAX_CONCURRENCY_PER_USER` | `0` | per-user sim cap for fairness (`0` = no limit) |
 | `OSMCP_MAX_SESSIONS` | `16` | LRU cap on resident per-session models |
@@ -153,7 +156,8 @@ Don't expose port 8000 to the public internet directly.
 
 - **Single box only** — in-memory model state isn't shared across machines.
   Horizontal scale would need a per-user-container topology behind a router.
-- **Plaintext token auth** — swap in `JWTVerifier` (OAuth/SSO) for public use.
+- **Static token auth is plaintext** — use `MCP_AUTH=jwt` (IdP-signed JWTs) for
+  SSO/public deployments.
 - Two internal measure-execution temp dirs still write to shared `/runs`
   (no cross-user read exposure) — to be scoped per-user in a follow-up.
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -115,6 +115,18 @@ On a VPN with `MCP_AUTH=none`, drop the `headers` block. The local stdio config
   (default 1) EnergyPlus simulations execute at once. Excess runs report
   `status: "queued"` and start automatically as slots free.
 
+**Audit log.** Every tool call and the full sim lifecycle are recorded as JSON
+lines — to stderr (`docker logs`) and, if `MCP_AUDIT_FILE` is set, to that file:
+
+```jsonc
+{"ts":1717532001.2, "event":"tool_call",   "user":"alice", "tool":"run_simulation", "ok":true, "ms":38}
+{"ts":1717532001.3, "event":"sim_queued",   "run_id":"…", "user":"alice"}
+{"ts":1717532001.4, "event":"sim_launched", "run_id":"…", "user":"alice", "pid":123}
+{"ts":1717532019.9, "event":"sim_finished", "run_id":"…", "user":"alice", "status":"success"}
+```
+
+So you can answer "who ran what, when, did it succeed". Disable with `MCP_AUDIT=off`.
+
 ---
 
 ## 4. Network & security
@@ -149,6 +161,8 @@ Don't expose port 8000 to the public internet directly.
 | `OSMCP_MAX_SESSIONS` | `16` | LRU cap on resident per-session models |
 | `OSMCP_SESSION_TTL` | `1800` | idle seconds before a session model is dropped (`0` disables) |
 | `OSMCP_RUN_ROOT` | `/runs` | base directory for per-user run dirs |
+| `MCP_AUDIT` | `on` | structured audit logging (tool calls + sim lifecycle); `off` to disable |
+| `MCP_AUDIT_FILE` | — | also append audit JSON lines to this file (e.g. `/runs/audit.log`) |
 
 ---
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -114,6 +114,13 @@ On a VPN with `MCP_AUTH=none`, drop the `headers` block. The local stdio config
 - **Simulation queue.** Runs are FIFO-queued; at most `OSMCP_MAX_CONCURRENCY`
   (default 1) EnergyPlus simulations execute at once. Excess runs report
   `status: "queued"` and start automatically as slots free.
+- **Run retention (disk).** Finished run dirs (~40 MB each) are reclaimed
+  automatically: a background sweeper deletes runs older than
+  `OSMCP_RUN_RETENTION_DAYS` (default 7, `0` = keep forever), skipping pinned and
+  queued/running runs. Only run dirs are swept — saved models under `examples/`
+  are never touched. On demand, agents can `cleanup_runs` (preview with
+  `dry_run=True`, then delete), `delete_run`, and `pin_run` / `unpin_run` to
+  exempt a reference run. Every reclaim is audit-logged as `run_evicted`.
 
 **Audit log.** Every tool call and the full sim lifecycle are recorded as JSON
 lines — to stderr (`docker logs`) and, if `MCP_AUDIT_FILE` is set, to that file:
@@ -123,6 +130,7 @@ lines — to stderr (`docker logs`) and, if `MCP_AUDIT_FILE` is set, to that fil
 {"ts":1717532001.3, "event":"sim_queued",   "run_id":"…", "user":"alice"}
 {"ts":1717532001.4, "event":"sim_launched", "run_id":"…", "user":"alice", "pid":123}
 {"ts":1717532019.9, "event":"sim_finished", "run_id":"…", "user":"alice", "status":"success"}
+{"ts":1718136600.0, "event":"run_evicted",  "run_id":"…", "user":"alice", "reason":"gc", "age_days":8.2, "freed_mb":50.2}
 ```
 
 So you can answer "who ran what, when, did it succeed". Disable with `MCP_AUDIT=off`.
@@ -161,6 +169,8 @@ Don't expose port 8000 to the public internet directly.
 | `OSMCP_MAX_SESSIONS` | `16` | LRU cap on resident per-session models |
 | `OSMCP_SESSION_TTL` | `1800` | idle seconds before a session model is dropped (`0` disables) |
 | `OSMCP_RUN_ROOT` | `/runs` | base directory for per-user run dirs |
+| `OSMCP_RUN_RETENTION_DAYS` | `7` | auto-delete finished run dirs older than N days (`0` = keep forever) |
+| `OSMCP_RETENTION_SWEEP_SECONDS` | `3600` | how often the retention daemon sweeps (60s floor) |
 | `MCP_AUDIT` | `on` | structured audit logging (tool calls + sim lifecycle); `off` to disable |
 | `MCP_AUDIT_FILE` | — | also append audit JSON lines to this file (e.g. `/runs/audit.log`) |
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -173,12 +173,14 @@ Don't expose port 8000 to the public internet directly.
 | `OSMCP_RUN_ROOT` | `/runs` | base directory for per-user run dirs |
 | `OSMCP_RUN_RETENTION_DAYS` | `0` (off) | enable auto-GC: delete finished run dirs older than N days (`0` = off) |
 | `OSMCP_RETENTION_SWEEP_SECONDS` | `3600` | how often the retention daemon sweeps (60s floor) |
-
-Auto-GC is **off by default**. Enable it with a CLI flag on the server command —
-`openstudio-mcp --gc` (default 7-day window) or `openstudio-mcp --gc-days 14` — or
-via `OSMCP_RUN_RETENTION_DAYS=14`. The CLI flag wins over the env value.
 | `MCP_AUDIT` | `on` | structured audit logging (tool calls + sim lifecycle); `off` to disable |
 | `MCP_AUDIT_FILE` | — | also append audit JSON lines to this file (e.g. `/runs/audit.log`) |
+
+Auto-GC of old run dirs is **off by default**. Enable it with `openstudio-mcp --gc`
+(7-day window), `openstudio-mcp --gc-days 14`, or `OSMCP_RUN_RETENTION_DAYS=14`
+(CLI wins over env). See **[Run retention & garbage collection](run-retention.md)**
+for the full setup, safety model, and the `cleanup_runs` / `delete_run` /
+`pin_run` tools.
 
 ---
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -213,8 +213,6 @@ for the full setup, safety model, and the `cleanup_runs` / `delete_run` /
   Horizontal scale would need a per-user-container topology behind a router.
 - **Static token auth is plaintext** — use `MCP_AUTH=jwt` (IdP-signed JWTs) for
   SSO/public deployments.
-- Two internal measure-execution temp dirs still write to shared `/runs`
-  (no cross-user read exposure) — to be scoped per-user in a follow-up.
 
 See `docs/plans/multi-user-remote-mcp.md` for the full design rationale.
 

--- a/docs/run-retention.md
+++ b/docs/run-retention.md
@@ -1,0 +1,168 @@
+# Run retention & garbage collection
+
+Every simulation leaves a run directory under the run root — roughly **40 MB**
+each (the 23 MB `eplusout.sql`, plus `.eso`/`.mtr`, the HTML tables, logs). Left
+alone they accumulate forever. Retention reclaims them. It is **off by default**
+and only ever touches simulation run directories.
+
+There are two halves:
+
+- a **background daemon** that auto-deletes old run dirs (opt-in), and
+- four **MCP tools** the agent calls on demand (`cleanup_runs`, `delete_run`,
+  `pin_run`, `unpin_run`) — these work whether or not the daemon is enabled.
+
+---
+
+## 1. Enabling the auto-GC daemon
+
+Off by default — nothing is deleted automatically until you turn it on. The
+daemon is started in `server.main()`; it spawns a background thread
+(`sim-retention`) only when the effective window is greater than 0.
+
+Three ways to turn it on (CLI wins over env):
+
+| Method | Effect |
+|---|---|
+| `openstudio-mcp --gc` | enable with a 7-day window (or the env window, if set) |
+| `openstudio-mcp --gc-days 14` | enable with an explicit 14-day window |
+| `OSMCP_RUN_RETENTION_DAYS=14` | enable via env (docker `-e`, mcp.json `env`) |
+| *(nothing)* | **off** |
+
+Precedence: `--gc-days N` > `--gc` > `OSMCP_RUN_RETENTION_DAYS` > off.
+`--gc-days 0` is an explicit "stay off".
+
+```bash
+# HTTP server, GC on at 14 days
+docker run -d -p 8000:8000 -e MCP_TRANSPORT=http -v /data/runs:/runs \
+  openstudio-mcp:dev openstudio-mcp --gc-days 14
+```
+```jsonc
+// stdio (mcp.json): enable GC for the local container
+{ "mcpServers": { "openstudio-mcp": {
+  "command": "docker",
+  "args": ["run","-i","--rm","-v","C:/runs:/runs","openstudio-mcp:dev","openstudio-mcp","--gc"]
+}}}
+```
+
+The daemon sweeps every `OSMCP_RETENTION_SWEEP_SECONDS` (default `3600`, **60s
+floor**), starting with one sweep at boot.
+
+---
+
+## 2. What gets deleted
+
+A directory is removed only if it passes **every** gate — miss one and it is
+skipped:
+
+1. **It's a real directory, not a symlink.** Symlinks are never followed or removed.
+2. **It physically sits at `RUN_ROOT/<user>/<run>`** (or `RUN_ROOT/<run>` for the
+   local single user) — verified against the *resolved* path, so nothing whose
+   real location is outside the run root can be touched.
+3. **It looks like a run** — contains `run_record.json`, `out.osw`, or a `run/`
+   subdir. A plain saved `.osm` model has none of these and is never a target.
+4. **It isn't a working dir** — directories named `examples/` or `exports/` are
+   excluded by name (your saved models and exports are safe).
+5. **It isn't pinned** — no `.pinned` marker (see [Pinning](#4-pinning)).
+6. **It isn't active** — `run_record.json` status is terminal. A `queued` run, or
+   a `running` run whose PID is still alive, is skipped. An unreadable record is
+   treated as active (fail-safe).
+7. **It's old enough** — age ≥ the window. Age is taken from the run record's
+   `ended_at` (when the sim finished), falling back to the directory's mtime.
+
+So: a real, non-symlink run directory, in the right place, with a sim-output
+fingerprint, terminal, unpinned, and past the window.
+
+---
+
+## 3. Safety guarantees
+
+The GC is confined so a bug or misconfiguration can't reach beyond run dirs:
+
+- **No escape from the run root.** Before any delete, the resolved path must be a
+  genuine child of the swept root (`_is_real_child`). A run-shaped **symlink**, or
+  any entry resolving outside the tree, is rejected — deletion never follows a
+  link out of `RUN_ROOT`.
+- **No system roots.** The daemon refuses to start or sweep if `RUN_ROOT` resolves
+  to `/`, `/home`, `/etc`, `/tmp`, `/usr`, `/var`, … (`_run_root_is_sane`); it logs
+  `retention_disabled(reason=unsafe_run_root)` instead. Guards against a bad
+  `OSMCP_RUN_ROOT`.
+- **Run dirs only.** The fingerprint + name exclusions mean saved models, exports,
+  inputs, measures, and `/repo` are never deletion candidates — the sweep only
+  iterates inside `RUN_ROOT`.
+- **Two levels deep, max.** The daemon walks `RUN_ROOT/<user>/<run>` (and, for the
+  local single-user layout, `RUN_ROOT/<run>`) — never a deep recursive walk.
+
+---
+
+## 4. Pinning
+
+Pin a run to keep it indefinitely, exempt from auto-GC:
+
+```text
+pin_run(run_id)     → writes a .pinned marker in the run dir
+unpin_run(run_id)   → removes it, run is eligible again
+```
+
+Use it for reference baselines you want to revisit after the window.
+
+---
+
+## 5. On-demand cleanup (works with the daemon off)
+
+The agent can reclaim disk deliberately, scoped to the caller's own runs:
+
+| Tool | What it does |
+|---|---|
+| `cleanup_runs(older_than_days=None, dry_run=True)` | Preview, then delete. Defaults to the active GC window (or 7 days if GC is off). `dry_run=True` lists candidates + MB without deleting; `dry_run=False` deletes. `older_than_days=0` = all terminal runs. |
+| `delete_run(run_id)` | Delete one run dir (refuses while queued/running — cancel first). |
+| `pin_run` / `unpin_run` | Protect / unprotect a run from auto-GC. |
+
+A typical flow: `cleanup_runs(dry_run=True)` → see "would free 4.2 GB / 130 runs"
+→ `cleanup_runs(dry_run=False)`.
+
+---
+
+## 6. Storage layout
+
+Where run dirs live depends on the transport (identity):
+
+| Mode | Run root | Run dir |
+|---|---|---|
+| stdio (single local user) | `RUN_ROOT` (`/runs`) | `/runs/<run_id>/` |
+| HTTP (per session/principal) | `RUN_ROOT/<user>` | `/runs/<user>/<run_id>/` |
+
+The GC handles both: it sweeps `RUN_ROOT`'s direct-child run dirs (local layout)
+and descends into each `RUN_ROOT/<user>` dir (multi-user layout). User container
+dirs aren't runs (no fingerprint), so they're never deleted as a unit.
+
+---
+
+## 7. Audit trail
+
+Every reclaim and pin is logged as one JSON line (stderr, and `MCP_AUDIT_FILE` if
+set) — so "who/what was reclaimed, when" is answerable:
+
+```jsonc
+{"ts":1718136600.0,"event":"run_evicted","reason":"gc",      "run_id":"…","user":"alice","age_days":8.2,"freed_mb":50.2}
+{"ts":1718140000.0,"event":"run_evicted","reason":"cleanup", "run_id":"…","user":"bob","age_days":3.1,"freed_mb":41.0}
+{"ts":1718140100.0,"event":"run_deleted",                    "run_id":"…","user":"bob","freed_mb":39.8}
+{"ts":1718140200.0,"event":"run_pinned",                     "run_id":"…","user":"alice"}
+```
+
+`reason` is `gc` for the daemon and `cleanup` for the `cleanup_runs` tool.
+
+---
+
+## 8. Configuration reference
+
+| Var / flag | Default | Purpose |
+|---|---|---|
+| `--gc` (CLI) | — | enable auto-GC with a 7-day window (or the env window) |
+| `--gc-days N` (CLI) | — | enable auto-GC with an N-day window (`0` = off) |
+| `OSMCP_RUN_RETENTION_DAYS` | `0` (off) | enable auto-GC via env; window in days |
+| `OSMCP_RETENTION_SWEEP_SECONDS` | `3600` | sweep interval (60s floor) |
+| `OSMCP_RUN_ROOT` | `/runs` | base directory for run dirs |
+| `MCP_AUDIT` / `MCP_AUDIT_FILE` | `on` / — | audit logging of evictions |
+
+Recommended posture: leave GC **off** for single-user/dev; for a shared HTTP box,
+enable `--gc-days 7` (or longer) and `pin_run` the baselines you want to keep.

--- a/mcp_server/audit.py
+++ b/mcp_server/audit.py
@@ -1,0 +1,112 @@
+"""Structured audit logging — who ran what, when, with what outcome.
+
+One JSON line per event, to stderr (-> `docker logs`) and, when MCP_AUDIT_FILE is
+set, appended to that file too. Disable entirely with MCP_AUDIT=off.
+
+Two sources of events:
+  - AuditMiddleware: one `tool_call` line per MCP tool invocation (user, session,
+    tool, args preview, ok, duration). One chokepoint — the 142 tools are untouched.
+  - simulation ops: `sim_queued` / `sim_launched` / `sim_finished` / `sim_cancelled`
+    (these complete in a background thread that no request/middleware sees).
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import sys
+import time
+
+from fastmcp.server.middleware import Middleware
+
+_ENABLED = os.environ.get("MCP_AUDIT", "on").lower() not in ("0", "off", "false", "no")
+_logger = logging.getLogger("openstudio-mcp.audit")
+_configured = False
+
+
+def _configure() -> None:
+    global _configured
+    if _configured:
+        return
+    _configured = True
+    _logger.setLevel(logging.INFO)
+    _logger.propagate = False
+    fmt = logging.Formatter("%(message)s")
+    sh = logging.StreamHandler(sys.stderr)  # stderr is never the JSON-RPC channel
+    sh.setFormatter(fmt)
+    _logger.addHandler(sh)
+    path = os.environ.get("MCP_AUDIT_FILE")
+    if path:
+        try:
+            fh = logging.FileHandler(path)
+            fh.setFormatter(fmt)
+            _logger.addHandler(fh)
+        except Exception:
+            pass
+
+
+def audit(event: str, **fields) -> None:
+    """Emit one structured audit line (no-op when MCP_AUDIT=off)."""
+    if not _ENABLED:
+        return
+    _configure()
+    rec = {"ts": round(time.time(), 3), "event": event}
+    rec.update({k: v for k, v in fields.items() if v is not None})
+    with contextlib.suppress(Exception):
+        _logger.info(json.dumps(rec, default=str))
+
+
+def _truncate(s: str, n: int = 300) -> str:
+    return s if len(s) <= n else s[:n] + "..."
+
+
+def _result_ok(result) -> bool | None:
+    """Best-effort extract of the tool's {"ok": ...} from a ToolResult."""
+    for attr in ("structured_content", "structuredContent"):
+        sc = getattr(result, attr, None)
+        if isinstance(sc, dict) and "ok" in sc:
+            return bool(sc["ok"])
+    content = getattr(result, "content", None)
+    if content:
+        text = getattr(content[0], "text", None)
+        if text:
+            try:
+                d = json.loads(text)
+                if isinstance(d, dict) and "ok" in d:
+                    return bool(d["ok"])
+            except Exception:
+                pass
+    if getattr(result, "is_error", False) or getattr(result, "isError", False):
+        return False
+    return None
+
+
+class AuditMiddleware(Middleware):
+    """Logs one `tool_call` audit line per MCP tool invocation."""
+
+    async def on_call_tool(self, context, call_next):
+        if not _ENABLED:
+            return await call_next(context)
+        from mcp_server.identity import session_key, user_key
+
+        name = getattr(context.message, "name", "?")
+        args = getattr(context.message, "arguments", None)
+        t0 = time.perf_counter()
+        ok: bool | None = None
+        err: str | None = None
+        try:
+            result = await call_next(context)
+            ok = _result_ok(result)
+            return result
+        except Exception as e:
+            ok, err = False, f"{type(e).__name__}: {e}"
+            raise
+        finally:
+            audit(
+                "tool_call",
+                user=user_key(), session=session_key(), tool=name, ok=ok,
+                ms=round((time.perf_counter() - t0) * 1000, 1),
+                args=_truncate(json.dumps(args, default=str)) if args else None,
+                error=err,
+            )

--- a/mcp_server/audit.py
+++ b/mcp_server/audit.py
@@ -5,7 +5,7 @@ set, appended to that file too. Disable entirely with MCP_AUDIT=off.
 
 Sources of events:
   - AuditMiddleware: one `tool_call` line per MCP tool invocation (user, session,
-    tool, args preview, ok, duration). One chokepoint — the 142 tools are untouched.
+    tool, args preview, ok, duration). One chokepoint — the tools are untouched.
   - simulation ops: `sim_queued` / `sim_launched` / `sim_finished` / `sim_cancelled`
     (these complete in a background thread that no request/middleware sees).
   - retention: `run_evicted` (background GC daemon) / `run_deleted` / `run_pinned`

--- a/mcp_server/audit.py
+++ b/mcp_server/audit.py
@@ -3,11 +3,13 @@
 One JSON line per event, to stderr (-> `docker logs`) and, when MCP_AUDIT_FILE is
 set, appended to that file too. Disable entirely with MCP_AUDIT=off.
 
-Two sources of events:
+Sources of events:
   - AuditMiddleware: one `tool_call` line per MCP tool invocation (user, session,
     tool, args preview, ok, duration). One chokepoint — the 142 tools are untouched.
   - simulation ops: `sim_queued` / `sim_launched` / `sim_finished` / `sim_cancelled`
     (these complete in a background thread that no request/middleware sees).
+  - retention: `run_evicted` (background GC daemon) / `run_deleted` / `run_pinned`
+    / `run_unpinned` (explicit cleanup tools).
 """
 from __future__ import annotations
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -70,13 +70,16 @@ _SHARED_READ_ROOTS = [
 
 
 def user_run_root() -> Path:
-    """The caller's private run root (RUN_ROOT/<user_key>), created if missing.
+    """The caller's private run root, created if missing.
 
-    Identity is resolved per-call, so one code path serves every user. In stdio
-    / off-request contexts user_key() is "local" — single-user behavior unchanged.
+    Identity is resolved per-call, so one code path serves every user. The local
+    single-user (stdio / off-request) owns the whole RUN_ROOT — preserving the
+    original /runs/<run_id> layout — while each HTTP user is scoped to
+    RUN_ROOT/<user_key>.
     """
-    from mcp_server.identity import user_key
-    root = (RUN_ROOT / user_key()).resolve()
+    from mcp_server.identity import LOCAL, user_key
+    key = user_key()
+    root = (RUN_ROOT if key == LOCAL else RUN_ROOT / key).resolve()
     root.mkdir(parents=True, exist_ok=True)
     return root
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -12,6 +12,12 @@ def _safe_int(env_val: str, default: int) -> int:
     except (ValueError, TypeError):
         return default
 
+def _safe_float(env_val: str, default: float) -> float:
+    try:
+        return float(env_val)
+    except (ValueError, TypeError):
+        return default
+
 _raw_concurrency = os.environ.get("OPENSTUDIO_MCP_MAX_CONCURRENCY", os.environ.get("OSMCP_MAX_CONCURRENCY", "1"))
 MAX_CONCURRENCY = _safe_int(_raw_concurrency, 1)
 
@@ -24,6 +30,21 @@ MAX_CONCURRENCY_PER_USER = _safe_int(_raw_per_user, 0)
 
 _raw_tail = os.environ.get("OPENSTUDIO_MCP_DEFAULT_LOG_TAIL", os.environ.get("OSMCP_LOG_TAIL_DEFAULT", "200"))
 LOG_TAIL_DEFAULT = _safe_int(_raw_tail, 200)
+
+# Run-dir retention (whole-container garbage collection). A background sweeper
+# deletes run directories older than RUN_RETENTION_DAYS. Age = run_record.json
+# `ended_at` (fallback: dir mtime). 0 disables auto-GC entirely (runs kept until
+# pruned by cleanup_runs/delete_run). Pinned and queued/running runs are never
+# swept. Only run dirs are targeted — saved models under examples/ are left alone.
+_raw_retention = os.environ.get(
+    "OPENSTUDIO_MCP_RUN_RETENTION_DAYS", os.environ.get("OSMCP_RUN_RETENTION_DAYS", "7"),
+)
+RUN_RETENTION_DAYS = _safe_float(_raw_retention, 7.0)
+
+_raw_sweep = os.environ.get(
+    "OPENSTUDIO_MCP_RETENTION_SWEEP_SECONDS", os.environ.get("OSMCP_RETENTION_SWEEP_SECONDS", "3600"),
+)
+RETENTION_SWEEP_SECONDS = _safe_float(_raw_sweep, 3600.0)
 
 OSCLI_GEMFILE = os.environ.get("OSCLI_GEMFILE", "/var/oscli/Gemfile")
 OSCLI_GEM_PATH = os.environ.get("OSCLI_GEM_PATH", "/var/oscli/gems")

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -31,15 +31,16 @@ MAX_CONCURRENCY_PER_USER = _safe_int(_raw_per_user, 0)
 _raw_tail = os.environ.get("OPENSTUDIO_MCP_DEFAULT_LOG_TAIL", os.environ.get("OSMCP_LOG_TAIL_DEFAULT", "200"))
 LOG_TAIL_DEFAULT = _safe_int(_raw_tail, 200)
 
-# Run-dir retention (whole-container garbage collection). A background sweeper
-# deletes run directories older than RUN_RETENTION_DAYS. Age = run_record.json
-# `ended_at` (fallback: dir mtime). 0 disables auto-GC entirely (runs kept until
-# pruned by cleanup_runs/delete_run). Pinned and queued/running runs are never
-# swept. Only run dirs are targeted — saved models under examples/ are left alone.
+# Run-dir retention (whole-container garbage collection). OFF by default — the
+# background sweeper only runs when explicitly enabled, via the `--gc` / `--gc-days`
+# CLI flag or by setting RUN_RETENTION_DAYS > 0. When on, it deletes run dirs older
+# than RUN_RETENTION_DAYS. Age = run_record.json `ended_at` (fallback: dir mtime).
+# Pinned and queued/running runs are never swept. Only run dirs are targeted —
+# saved models under examples/ are left alone.
 _raw_retention = os.environ.get(
-    "OPENSTUDIO_MCP_RUN_RETENTION_DAYS", os.environ.get("OSMCP_RUN_RETENTION_DAYS", "7"),
+    "OPENSTUDIO_MCP_RUN_RETENTION_DAYS", os.environ.get("OSMCP_RUN_RETENTION_DAYS", "0"),
 )
-RUN_RETENTION_DAYS = _safe_float(_raw_retention, 7.0)
+RUN_RETENTION_DAYS = _safe_float(_raw_retention, 0.0)
 
 _raw_sweep = os.environ.get(
     "OPENSTUDIO_MCP_RETENTION_SWEEP_SECONDS", os.environ.get("OSMCP_RETENTION_SWEEP_SECONDS", "3600"),

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -29,15 +29,45 @@ INPUT_ROOT = Path(os.environ.get("OPENSTUDIO_MCP_INPUT_ROOT", "/inputs")).resolv
 
 ENABLE_CODE_MODE = os.environ.get("OSMCP_CODE_MODE", "").lower() in ("1", "true")
 
-ALLOWED_PATH_ROOTS = [
+# Shared roots are read-only for everyone; the only per-user writable area is
+# RUN_ROOT/<user_key> (see user_run_root). Writes elsewhere are denied.
+_SHARED_READ_ROOTS = [
     Path("/repo").resolve(),
-    RUN_ROOT,
     INPUT_ROOT,
-    COMSTOCK_MEASURES_DIR,
-    COMMON_MEASURES_DIR,
-    SKILLS_DIR,
+    COMSTOCK_MEASURES_DIR.resolve(),
+    COMMON_MEASURES_DIR.resolve(),
+    SKILLS_DIR.resolve(),
 ]
 
-def is_path_allowed(p: Path) -> bool:
+
+def user_run_root() -> Path:
+    """The caller's private run root (RUN_ROOT/<user_key>), created if missing.
+
+    Identity is resolved per-call, so one code path serves every user. In stdio
+    / off-request contexts user_key() is "local" — single-user behavior unchanged.
+    """
+    from mcp_server.identity import user_key
+    root = (RUN_ROOT / user_key()).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _under(p: Path, root: Path) -> bool:
+    return p == root or str(p).startswith(str(root) + os.sep)
+
+
+def is_path_allowed(p: Path, *, write: bool = False) -> bool:
+    """Whether the caller may access path `p`.
+
+    - Own run root (RUN_ROOT/<user_key>): read + write.
+    - Elsewhere under RUN_ROOT (another user's runs): always denied.
+    - Shared roots (repo, inputs, measures, skills): read-only.
+    """
     rp = p.resolve()
-    return any(str(rp).startswith(str(root) + os.sep) or rp == root for root in ALLOWED_PATH_ROOTS)
+    if _under(rp, user_run_root()):
+        return True
+    if _under(rp, RUN_ROOT):
+        return False  # another user's run area
+    if write:
+        return False  # shared roots are read-only
+    return any(_under(rp, root) for root in _SHARED_READ_ROOTS)

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -15,6 +15,13 @@ def _safe_int(env_val: str, default: int) -> int:
 _raw_concurrency = os.environ.get("OPENSTUDIO_MCP_MAX_CONCURRENCY", os.environ.get("OSMCP_MAX_CONCURRENCY", "1"))
 MAX_CONCURRENCY = _safe_int(_raw_concurrency, 1)
 
+# Optional per-user fairness cap on simultaneous sims (0 = no per-user limit).
+_raw_per_user = os.environ.get(
+    "OPENSTUDIO_MCP_MAX_CONCURRENCY_PER_USER",
+    os.environ.get("OSMCP_MAX_CONCURRENCY_PER_USER", "0"),
+)
+MAX_CONCURRENCY_PER_USER = _safe_int(_raw_per_user, 0)
+
 _raw_tail = os.environ.get("OPENSTUDIO_MCP_DEFAULT_LOG_TAIL", os.environ.get("OSMCP_LOG_TAIL_DEFAULT", "200"))
 LOG_TAIL_DEFAULT = _safe_int(_raw_tail, 200)
 

--- a/mcp_server/identity.py
+++ b/mcp_server/identity.py
@@ -1,0 +1,55 @@
+"""Caller identity for multi-user isolation.
+
+Two keys, both safe to call from any tool body or off-request:
+
+  session_key() — per-connection. Keys ephemeral *model* state, so two AI
+                  windows (even same user) never stomp each other's model.
+  user_key()    — per-authenticated-user. Keys durable run dirs + path scope,
+                  so a user sees their own runs across sessions.
+
+stdio (single local user) and off-request callers (unit tests, atexit)
+collapse to "local", preserving today's single-user behavior unchanged.
+"""
+from __future__ import annotations
+
+import re
+
+LOCAL = "local"
+
+
+def _ctx():
+    """Current FastMCP request context, or None when off-request/stdio-less."""
+    try:
+        from fastmcp.server.dependencies import get_context
+
+        return get_context()
+    except Exception:
+        return None
+
+
+def session_key() -> str:
+    """Stable key for the current connection's model state."""
+    ctx = _ctx()
+    if ctx is None:
+        return LOCAL
+    sid = getattr(ctx, "session_id", None)
+    return sid or LOCAL
+
+
+def user_key() -> str:
+    """Filesystem-safe key identifying the user (auth principal, else session)."""
+    ctx = _ctx()
+    if ctx is None:
+        return LOCAL
+    # StaticTokenVerifier / JWTVerifier populate client_id with the principal.
+    cid = getattr(ctx, "client_id", None)
+    if cid:
+        return _sanitize(cid)
+    sid = getattr(ctx, "session_id", None)
+    return _sanitize(sid) if sid else LOCAL
+
+
+def _sanitize(key: str) -> str:
+    """Reduce an identity to a safe directory-name component."""
+    s = re.sub(r"[^A-Za-z0-9_.-]", "_", str(key)).strip("._")
+    return s or LOCAL

--- a/mcp_server/identity.py
+++ b/mcp_server/identity.py
@@ -46,13 +46,28 @@ def _access_token():
         return None
 
 
+def _is_http_transport() -> bool:
+    """True only for the remote/multi-user HTTP server (else stdio = single user)."""
+    import os
+    return os.environ.get("MCP_TRANSPORT", "stdio").lower() in ("http", "streamable-http")
+
+
 def user_key() -> str:
-    """Filesystem-safe key identifying the user (auth principal, else session)."""
+    """Filesystem-safe key identifying the user (auth principal, else session).
+
+    stdio is inherently single-user (one local process per client), so it always
+    resolves to "local" — which owns the whole run root, preserving the original
+    single-container workflow. Only the HTTP server scopes per session/principal.
+    """
     # With auth, the verified token's client_id is the principal (StaticToken/JWT).
     tok = _access_token()
     cid = getattr(tok, "client_id", None) if tok is not None else None
     if cid:
         return _sanitize(cid)
+    # Non-HTTP transport = one local user; FastMCP still assigns stdio a session
+    # id, but that must not splinter the single user's run root per connection.
+    if not _is_http_transport():
+        return LOCAL
     ctx = _ctx()
     if ctx is None:
         return LOCAL

--- a/mcp_server/identity.py
+++ b/mcp_server/identity.py
@@ -36,15 +36,26 @@ def session_key() -> str:
     return sid or LOCAL
 
 
+def _access_token():
+    """The verified access token for this request, or None (no auth / off-request)."""
+    try:
+        from fastmcp.server.dependencies import get_access_token
+
+        return get_access_token()
+    except Exception:
+        return None
+
+
 def user_key() -> str:
     """Filesystem-safe key identifying the user (auth principal, else session)."""
+    # With auth, the verified token's client_id is the principal (StaticToken/JWT).
+    tok = _access_token()
+    cid = getattr(tok, "client_id", None) if tok is not None else None
+    if cid:
+        return _sanitize(cid)
     ctx = _ctx()
     if ctx is None:
         return LOCAL
-    # StaticTokenVerifier / JWTVerifier populate client_id with the principal.
-    cid = getattr(ctx, "client_id", None)
-    if cid:
-        return _sanitize(cid)
     sid = getattr(ctx, "session_id", None)
     return _sanitize(sid) if sid else LOCAL
 

--- a/mcp_server/model_manager.py
+++ b/mcp_server/model_manager.py
@@ -4,6 +4,10 @@ Each MCP session (one connection) gets its own loaded OpenStudio model,
 keyed by identity.session_key(). stdio / off-request callers collapse to a
 single "local" session, so single-user behavior is unchanged.
 
+Idle sessions are evicted after OSMCP_SESSION_TTL seconds (swept on the next
+access); a hard LRU cap (OSMCP_MAX_SESSIONS) bounds resident heavy models
+regardless of activity.
+
 All model-querying skills call get_model() — they never see the session key,
 so the 100+ call sites are untouched by the multi-user refactor.
 """
@@ -12,6 +16,7 @@ from __future__ import annotations
 import atexit
 import os
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -21,26 +26,38 @@ from mcp_server.identity import session_key
 from mcp_server.stdout_suppression import suppress_openstudio_warnings
 
 # Hard RAM backstop: heavy OSM models must not accumulate unbounded across
-# sessions. Idle-TTL eviction is a follow-up; this LRU cap is the safety net.
+# sessions. Idle sessions are swept after the TTL; the LRU cap is the floor.
 MAX_SESSIONS = max(1, int(os.environ.get("OSMCP_MAX_SESSIONS", "16")))
+# Idle timeout (seconds) before a session's model is dropped. 0 disables TTL.
+SESSION_TTL_SECONDS = float(os.environ.get("OSMCP_SESSION_TTL", "1800"))
 
 
 @dataclass
 class _SessionState:
     model: openstudio.model.Model | None = None
     path: Path | None = None
-    last_access: int = 0
+    last_access: float = 0.0  # time.monotonic() of last touch
 
 
 _lock = threading.RLock()
 _sessions: dict[str, _SessionState] = {}
-_tick = 0
+
+
+def _now() -> float:
+    return time.monotonic()
 
 
 def _touch(state: _SessionState) -> None:
-    global _tick
-    _tick += 1
-    state.last_access = _tick
+    state.last_access = _now()
+
+
+def _sweep_idle() -> None:
+    """Drop sessions idle longer than the TTL. Caller holds _lock."""
+    if SESSION_TTL_SECONDS <= 0:
+        return
+    cutoff = _now() - SESSION_TTL_SECONDS
+    for key in [k for k, st in _sessions.items() if st.last_access < cutoff]:
+        _sessions.pop(key, None)  # drop Model ref -> GC
 
 
 def _evict_if_needed(keep: str) -> None:
@@ -69,6 +86,7 @@ def load_model(osm_path: Path, version_translate: bool = True) -> openstudio.mod
         model = loaded.get()
     key = session_key()
     with _lock:
+        _sweep_idle()
         _evict_if_needed(keep=key)
         st = _sessions.setdefault(key, _SessionState())
         st.model = model
@@ -81,6 +99,7 @@ def save_model(save_path: Path | None = None) -> Path:
     """Save current session's model. Returns the path saved to."""
     key = session_key()
     with _lock:
+        _sweep_idle()
         st = _sessions.get(key)
         if st is None or st.model is None:
             raise RuntimeError("No model loaded.")
@@ -98,6 +117,7 @@ def get_model() -> openstudio.model.Model:
     """Get the currently loaded model for this session, or raise."""
     key = session_key()
     with _lock:
+        _sweep_idle()
         st = _sessions.get(key)
         if st is None or st.model is None:
             raise RuntimeError("No model loaded. Call load_osm_model first.")
@@ -108,15 +128,23 @@ def get_model() -> openstudio.model.Model:
 def get_model_path() -> Path | None:
     """Return the file path of the current session's model, or None."""
     with _lock:
+        _sweep_idle()
         st = _sessions.get(session_key())
-        return st.path if st else None
+        if st is None:
+            return None
+        _touch(st)
+        return st.path
 
 
 def get_model_if_loaded() -> openstudio.model.Model | None:
     """Return the current session's model without raising, or None."""
     with _lock:
+        _sweep_idle()
         st = _sessions.get(session_key())
-        return st.model if st else None
+        if st is None:
+            return None
+        _touch(st)
+        return st.model
 
 
 def clear_model() -> None:

--- a/mcp_server/model_manager.py
+++ b/mcp_server/model_manager.py
@@ -1,76 +1,134 @@
-"""Shared model state for the current MCP session.
+"""Per-session model state for multi-user isolation.
 
-All model-querying skills call get_model() to access
-the currently loaded OpenStudio model.
+Each MCP session (one connection) gets its own loaded OpenStudio model,
+keyed by identity.session_key(). stdio / off-request callers collapse to a
+single "local" session, so single-user behavior is unchanged.
+
+All model-querying skills call get_model() — they never see the session key,
+so the 100+ call sites are untouched by the multi-user refactor.
 """
 from __future__ import annotations
 
 import atexit
+import os
+import threading
+from dataclasses import dataclass
 from pathlib import Path
 
 import openstudio
 
+from mcp_server.identity import session_key
 from mcp_server.stdout_suppression import suppress_openstudio_warnings
 
-_current_model: openstudio.model.Model | None = None
-_current_model_path: Path | None = None
+# Hard RAM backstop: heavy OSM models must not accumulate unbounded across
+# sessions. Idle-TTL eviction is a follow-up; this LRU cap is the safety net.
+MAX_SESSIONS = max(1, int(os.environ.get("OSMCP_MAX_SESSIONS", "16")))
+
+
+@dataclass
+class _SessionState:
+    model: openstudio.model.Model | None = None
+    path: Path | None = None
+    last_access: int = 0
+
+
+_lock = threading.RLock()
+_sessions: dict[str, _SessionState] = {}
+_tick = 0
+
+
+def _touch(state: _SessionState) -> None:
+    global _tick
+    _tick += 1
+    state.last_access = _tick
+
+
+def _evict_if_needed(keep: str) -> None:
+    """Evict least-recently-used sessions until under cap (never `keep`)."""
+    while len(_sessions) >= MAX_SESSIONS:
+        victim = min(
+            (k for k in _sessions if k != keep),
+            key=lambda k: _sessions[k].last_access,
+            default=None,
+        )
+        if victim is None:
+            return
+        _sessions.pop(victim, None)  # drop Model ref -> GC
 
 
 def load_model(osm_path: Path, version_translate: bool = True) -> openstudio.model.Model:
-    """Load an OSM file and set it as the current model."""
-    global _current_model, _current_model_path
-    abs_path = str(osm_path.resolve())
-
+    """Load an OSM file and set it as the current session's model."""
+    abs_path = str(Path(osm_path).resolve())
     with suppress_openstudio_warnings():
         if version_translate:
-            vt = openstudio.osversion.VersionTranslator()
-            loaded = vt.loadModel(abs_path)
+            loaded = openstudio.osversion.VersionTranslator().loadModel(abs_path)
         else:
             loaded = openstudio.model.Model.load(abs_path)
-
         if not loaded.is_initialized():
             raise ValueError(f"Failed to load OSM: {osm_path}")
-        _current_model = loaded.get()
-        _current_model_path = osm_path
-    return _current_model
+        model = loaded.get()
+    key = session_key()
+    with _lock:
+        _evict_if_needed(keep=key)
+        st = _sessions.setdefault(key, _SessionState())
+        st.model = model
+        st.path = Path(osm_path)
+        _touch(st)
+    return model
 
 
 def save_model(save_path: Path | None = None) -> Path:
-    """Save current model. Returns path saved to."""
-    if _current_model is None:
-        raise RuntimeError("No model loaded.")
-    path = save_path or _current_model_path
-    if path is None:
-        raise RuntimeError("No save path specified and no current path.")
+    """Save current session's model. Returns the path saved to."""
+    key = session_key()
+    with _lock:
+        st = _sessions.get(key)
+        if st is None or st.model is None:
+            raise RuntimeError("No model loaded.")
+        path = save_path or st.path
+        if path is None:
+            raise RuntimeError("No save path specified and no current path.")
+        model = st.model
+        _touch(st)
     with suppress_openstudio_warnings():
-        _current_model.save(str(path), True)
+        model.save(str(path), True)
     return path
 
 
 def get_model() -> openstudio.model.Model:
-    """Get the currently loaded model, or raise."""
-    if _current_model is None:
-        raise RuntimeError("No model loaded. Call load_osm_model first.")
-    return _current_model
+    """Get the currently loaded model for this session, or raise."""
+    key = session_key()
+    with _lock:
+        st = _sessions.get(key)
+        if st is None or st.model is None:
+            raise RuntimeError("No model loaded. Call load_osm_model first.")
+        _touch(st)
+        return st.model
 
 
 def get_model_path() -> Path | None:
-    """Return the file path of the currently loaded model, or None."""
-    return _current_model_path
+    """Return the file path of the current session's model, or None."""
+    with _lock:
+        st = _sessions.get(session_key())
+        return st.path if st else None
 
 
 def get_model_if_loaded() -> openstudio.model.Model | None:
-    """Return the current model without raising, or None if not loaded."""
-    return _current_model
+    """Return the current session's model without raising, or None."""
+    with _lock:
+        st = _sessions.get(session_key())
+        return st.model if st else None
 
 
 def clear_model() -> None:
-    """Clear current model state (mainly for testing)."""
-    global _current_model, _current_model_path
-    _current_model = None
-    _current_model_path = None
+    """Clear the current session's model state (mainly for testing)."""
+    with _lock:
+        _sessions.pop(session_key(), None)
 
 
-# Release SWIG Model* before interpreter shutdown to avoid
-# "swig/python detected a memory leak" warning (openstudio#5421)
-atexit.register(clear_model)
+def _clear_all() -> None:
+    with _lock:
+        _sessions.clear()
+
+
+# Release SWIG Model* refs before interpreter shutdown (openstudio#5421)
+atexit.register(_clear_all)

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -18,6 +18,8 @@ def _build_auth():
     Default: HTTP transport requires a token (secure-by-default); stdio stays open.
     MCP_AUTH=none   — no app auth; identity falls back to session id (use on a VPN).
     MCP_AUTH=token  — StaticTokenVerifier; MCP_TOKENS={"<token>":"<user>"}.
+    MCP_AUTH=jwt    — JWTVerifier; MCP_JWT_PUBLIC_KEY or MCP_JWT_JWKS_URI
+                      (+ optional MCP_JWT_ISSUER / MCP_JWT_AUDIENCE) for IdP/SSO.
     """
     http = os.environ.get("MCP_TRANSPORT", "stdio").lower() in ("http", "streamable-http")
     mode = os.environ.get("MCP_AUTH", "token" if http else "none").lower()
@@ -31,6 +33,15 @@ def _build_auth():
         mapping = json.loads(os.environ.get("MCP_TOKENS", "") or "{}")
         tokens = {t: {"client_id": u, "scopes": []} for t, u in mapping.items()}
         return StaticTokenVerifier(tokens=tokens)
+    if mode == "jwt":
+        from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+        return JWTVerifier(
+            public_key=os.environ.get("MCP_JWT_PUBLIC_KEY") or None,
+            jwks_uri=os.environ.get("MCP_JWT_JWKS_URI") or None,
+            issuer=os.environ.get("MCP_JWT_ISSUER") or None,
+            audience=os.environ.get("MCP_JWT_AUDIENCE") or None,
+        )
     raise ValueError(f"Unknown MCP_AUTH mode: {mode!r}")
 
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -4,6 +4,7 @@ import os
 
 from fastmcp import FastMCP
 
+from mcp_server.audit import AuditMiddleware
 from mcp_server.config import ENABLE_CODE_MODE
 from mcp_server.skills import register_all_skills
 from mcp_server.stdout_suppression import (
@@ -86,6 +87,7 @@ mcp = FastMCP(
 )
 
 register_all_skills(mcp)
+mcp.add_middleware(AuditMiddleware())
 
 if ENABLE_CODE_MODE:
     from fastmcp.experimental.transforms.code_mode import CodeMode

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from fastmcp import FastMCP
 
 from mcp_server.config import ENABLE_CODE_MODE
@@ -8,6 +10,27 @@ from mcp_server.stdout_suppression import (
     redirect_c_stdout_to_stderr,
     silence_openstudio_stdout_logger,
 )
+
+
+def _build_auth():
+    """Auth verifier from MCP_AUTH env, or None (open server).
+
+    MCP_AUTH=none (default) — no app auth; identity falls back to session id.
+    MCP_AUTH=token          — StaticTokenVerifier; MCP_TOKENS={"<token>":"<user>"}.
+    """
+    mode = os.environ.get("MCP_AUTH", "none").lower()
+    if mode in ("", "none"):
+        return None
+    if mode == "token":
+        import json
+
+        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+        mapping = json.loads(os.environ.get("MCP_TOKENS", "") or "{}")
+        tokens = {t: {"client_id": u, "scopes": []} for t, u in mapping.items()}
+        return StaticTokenVerifier(tokens=tokens)
+    raise ValueError(f"Unknown MCP_AUTH mode: {mode!r}")
+
 
 mcp = FastMCP(
     "openstudio-mcp",
@@ -46,6 +69,7 @@ mcp = FastMCP(
         "When polling get_run_status, wait at least 1-2 minutes between calls. "
         "For multi-step workflows, call list_skills() first."
     ),
+    auth=_build_auth(),
 )
 
 register_all_skills(mcp)
@@ -58,7 +82,16 @@ if ENABLE_CODE_MODE:
 def main():
     silence_openstudio_stdout_logger()
     redirect_c_stdout_to_stderr()
-    mcp.run()
+    transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
+    if transport in ("http", "streamable-http"):
+        mcp.run(
+            transport="http",
+            host=os.environ.get("MCP_HOST", "0.0.0.0"),  # noqa: S104 - container binds all interfaces; lock down via VPN/proxy
+            port=int(os.environ.get("MCP_PORT", "8000")),
+            path=os.environ.get("MCP_PATH", "/mcp"),
+        )
+    else:
+        mcp.run()
 
 
 if __name__ == "__main__":

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -31,7 +31,15 @@ def _build_auth():
 
         from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 
-        mapping = json.loads(os.environ.get("MCP_TOKENS", "") or "{}")
+        try:
+            mapping = json.loads(os.environ.get("MCP_TOKENS", "") or "{}")
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                'MCP_TOKENS must be valid JSON mapping token -> username, '
+                f'e.g. {{"s3cret":"alice"}} — got invalid JSON: {e}',
+            ) from e
+        if not isinstance(mapping, dict):
+            raise ValueError("MCP_TOKENS must be a JSON object mapping token -> username")
         tokens = {t: {"client_id": u, "scopes": []} for t, u in mapping.items()}
         return StaticTokenVerifier(tokens=tokens)
     if mode == "jwt":

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -95,11 +95,15 @@ if ENABLE_CODE_MODE:
 
 
 def main():
+    import sys
+
     silence_openstudio_stdout_logger()
     redirect_c_stdout_to_stderr()
-    # Background daemon: reclaim run dirs older than the retention window.
-    from mcp_server.skills.simulation.retention import start_retention_gc
-    start_retention_gc()
+    # Run-dir garbage collection is OFF by default. Enable explicitly with the
+    # --gc / --gc-days CLI flag, or by setting OSMCP_RUN_RETENTION_DAYS>0.
+    from mcp_server.config import RUN_RETENTION_DAYS
+    from mcp_server.skills.simulation.retention import resolve_gc_days, start_retention_gc
+    start_retention_gc(days=resolve_gc_days(sys.argv[1:], RUN_RETENTION_DAYS))
     transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
     if transport in ("http", "streamable-http"):
         mcp.run(

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -49,7 +49,7 @@ def _build_auth():
 mcp = FastMCP(
     "openstudio-mcp",
     instructions=(
-        "Building energy simulation server (OpenStudio SDK) with 142 tools for "
+        "Building energy simulation server (OpenStudio SDK) with 146 tools for "
         "creating, modifying, simulating, and analyzing building energy models. "
         "Use these tools for all building energy modeling tasks — if no tool "
         "exists for a task, ask the user before writing code. "

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -97,6 +97,9 @@ if ENABLE_CODE_MODE:
 def main():
     silence_openstudio_stdout_logger()
     redirect_c_stdout_to_stderr()
+    # Background daemon: reclaim run dirs older than the retention window.
+    from mcp_server.skills.simulation.retention import start_retention_gc
+    start_retention_gc()
     transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
     if transport in ("http", "streamable-http"):
         mcp.run(

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -15,10 +15,12 @@ from mcp_server.stdout_suppression import (
 def _build_auth():
     """Auth verifier from MCP_AUTH env, or None (open server).
 
-    MCP_AUTH=none (default) — no app auth; identity falls back to session id.
-    MCP_AUTH=token          — StaticTokenVerifier; MCP_TOKENS={"<token>":"<user>"}.
+    Default: HTTP transport requires a token (secure-by-default); stdio stays open.
+    MCP_AUTH=none   — no app auth; identity falls back to session id (use on a VPN).
+    MCP_AUTH=token  — StaticTokenVerifier; MCP_TOKENS={"<token>":"<user>"}.
     """
-    mode = os.environ.get("MCP_AUTH", "none").lower()
+    http = os.environ.get("MCP_TRANSPORT", "stdio").lower() in ("http", "streamable-http")
+    mode = os.environ.get("MCP_AUTH", "token" if http else "none").lower()
     if mode in ("", "none"):
         return None
     if mode == "token":

--- a/mcp_server/skills/comstock/operations.py
+++ b/mcp_server/skills/comstock/operations.py
@@ -15,7 +15,7 @@ from typing import Any
 import openstudio
 
 from mcp_server import model_manager
-from mcp_server.config import RUN_ROOT
+from mcp_server.config import user_run_root
 from mcp_server.model_manager import get_model
 from mcp_server.skills.measures.operations import apply_measure
 
@@ -290,7 +290,7 @@ def _create_empty_model() -> Path:
 
     Returns the path to the saved OSM file.
     """
-    run_dir = RUN_ROOT / "examples" / "bar_building"
+    run_dir = user_run_root() / "examples" / "bar_building"
     run_dir.mkdir(parents=True, exist_ok=True)
     osm_path = run_dir / "empty.osm"
     empty = openstudio.model.Model()

--- a/mcp_server/skills/geometry/operations.py
+++ b/mcp_server/skills/geometry/operations.py
@@ -13,12 +13,11 @@ from typing import Any
 import openstudio
 
 from mcp_server import model_manager
-from mcp_server.config import RUN_ROOT, is_path_allowed
+from mcp_server.config import is_path_allowed, user_run_root
 from mcp_server.model_manager import get_model
 from mcp_server.osm_helpers import (
     build_list_response,
     fetch_object,
-    list_all_as_dicts,
     list_paginated,
     optional_name,
 )
@@ -541,7 +540,7 @@ def import_floorspacejs(
                     matched += 1
 
         # Save model and load into model_manager
-        run_dir = RUN_ROOT / "examples" / "floorspacejs"
+        run_dir = user_run_root() / "examples" / "floorspacejs"
         run_dir.mkdir(parents=True, exist_ok=True)
         osm_path = run_dir / "imported.osm"
         model.save(str(osm_path), True)

--- a/mcp_server/skills/measure_authoring/operations.py
+++ b/mcp_server/skills/measure_authoring/operations.py
@@ -1236,7 +1236,7 @@ def edit_measure_op(
 
 
 def list_custom_measures_op() -> dict[str, Any]:
-    """List all custom measures in /runs/custom_measures/."""
+    """List all custom measures under the caller's run root (custom_measures/)."""
     try:
         cm_dir = custom_measures_dir()
         if not cm_dir.is_dir():

--- a/mcp_server/skills/measure_authoring/operations.py
+++ b/mcp_server/skills/measure_authoring/operations.py
@@ -871,7 +871,7 @@ def _test_reporting_measure_with_run(
 
     # Build temp run dir
     test_run_id = _uuid.uuid4().hex[:12]
-    runs_dir = Path(os.environ.get("MCP_RUNS_DIR", "/runs"))
+    runs_dir = Path(os.environ["MCP_RUNS_DIR"]) if "MCP_RUNS_DIR" in os.environ else user_run_root()
     run_dir = runs_dir / f"measure_test_{test_run_id}"
     run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/mcp_server/skills/measure_authoring/operations.py
+++ b/mcp_server/skills/measure_authoring/operations.py
@@ -13,9 +13,12 @@ from typing import Any
 
 import openstudio
 
-from mcp_server.config import INPUT_ROOT, RUN_ROOT
+from mcp_server.config import INPUT_ROOT, user_run_root
 
-CUSTOM_MEASURES_DIR = RUN_ROOT / "custom_measures"
+
+def custom_measures_dir() -> Path:
+    """The caller's private custom-measures directory (RUN_ROOT/<user_key>/custom_measures)."""
+    return user_run_root() / "custom_measures"
 
 # Default test model for measure tests — rich model with HVAC, plant loops,
 # constructions, schedules.  Searched in order; first hit wins.
@@ -59,7 +62,7 @@ def _find_test_model() -> Path | None:
     try:
         from mcp_server.model_manager import get_model
         model = get_model()
-        tmp = CUSTOM_MEASURES_DIR / "_test_model.osm"
+        tmp = custom_measures_dir() / "_test_model.osm"
         tmp.parent.mkdir(parents=True, exist_ok=True)
         model.save(openstudio.toPath(str(tmp)), True)
         return tmp
@@ -764,7 +767,7 @@ def create_measure_op(
 
         args = arguments or []
         class_name = _to_class_name(name)
-        measure_dir = CUSTOM_MEASURES_DIR / name
+        measure_dir = custom_measures_dir() / name
         # Clean existing dir for idempotent re-creation (safe: name is validated)
         if measure_dir.exists():
             shutil.rmtree(measure_dir)
@@ -854,11 +857,11 @@ def _test_reporting_measure_with_run(
     import os
     import uuid as _uuid
 
-    from mcp_server.config import OSCLI_GEM_PATH, OSCLI_GEMFILE, RUN_ROOT
+    from mcp_server.config import OSCLI_GEM_PATH, OSCLI_GEMFILE, user_run_root
     from mcp_server.util import resolve_run_dir
 
     try:
-        sim_dir = resolve_run_dir(RUN_ROOT, run_id)
+        sim_dir = resolve_run_dir(user_run_root(), run_id)
     except FileNotFoundError:
         return {"ok": False, "error": f"Simulation run not found: {run_id}"}
 
@@ -1088,7 +1091,7 @@ def edit_measure_op(
         err = _validate_measure_name(measure_name)
         if err:
             return {"ok": False, "error": err}
-        measure_dir = CUSTOM_MEASURES_DIR / measure_name
+        measure_dir = custom_measures_dir() / measure_name
         if not measure_dir.is_dir():
             return {"ok": False, "error": f"Measure not found: {measure_name}"}
 
@@ -1235,11 +1238,12 @@ def edit_measure_op(
 def list_custom_measures_op() -> dict[str, Any]:
     """List all custom measures in /runs/custom_measures/."""
     try:
-        if not CUSTOM_MEASURES_DIR.is_dir():
+        cm_dir = custom_measures_dir()
+        if not cm_dir.is_dir():
             return {"ok": True, "count": 0, "measures": []}
 
         measures = []
-        for d in sorted(CUSTOM_MEASURES_DIR.iterdir()):
+        for d in sorted(cm_dir.iterdir()):
             if not d.is_dir():
                 continue
             has_rb = (d / "measure.rb").is_file()

--- a/mcp_server/skills/measure_authoring/tools.py
+++ b/mcp_server/skills/measure_authoring/tools.py
@@ -14,7 +14,7 @@ from mcp_server.skills.measure_authoring.operations import (
 def register(mcp):
     @mcp.tool(tags={"measures"}, name="list_custom_measures")
     def list_custom_measures_tool():
-        """List custom measures in /runs/custom_measures/ created with create_measure.
+        """List custom measures (under your run root, custom_measures/) created with create_measure.
 
         Returns name, language, and measure_dir for each. Use measure_dir
         with test_measure or apply_measure. Use name with edit_measure.
@@ -42,7 +42,7 @@ def register(mcp):
         search_wiring_patterns for working connection code.
 
         Scaffolds via SDK, then injects arguments() and run() body. Output
-        dir: /runs/custom_measures/<name>/. Idempotent — overwrites if exists.
+        dir: <your run root>/custom_measures/<name>/. Idempotent — overwrites if exists.
 
         Workflow: create_measure → test_measure → apply_measure.
 
@@ -221,7 +221,7 @@ def register(mcp):
 
         TIP: call get_skill('measure-authoring') first for templates, API patterns, and common pitfalls.
 
-        Looks up /runs/custom_measures/<measure_name>/. Replaces run() body
+        Looks up custom_measures/<measure_name>/ under your run root. Replaces run() body
         between markers, regenerates arguments() method, updates test file.
         Use list_custom_measures to find available measure names.
 

--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import openstudio
 
-from mcp_server.config import OSCLI_GEM_PATH, OSCLI_GEMFILE, RUN_ROOT
+from mcp_server.config import OSCLI_GEM_PATH, OSCLI_GEMFILE, user_run_root
 from mcp_server.model_manager import get_model, load_model
 from mcp_server.util import resolve_run_dir
 
@@ -220,7 +220,7 @@ def apply_measure(
         postprocess = False
         if run_id:
             try:
-                sim_dir = resolve_run_dir(RUN_ROOT, run_id)
+                sim_dir = resolve_run_dir(user_run_root(), run_id)
             except FileNotFoundError:
                 return {"ok": False, "error": f"Simulation run not found: {run_id}"}
             sql_src = sim_dir / "run" / "eplusout.sql"

--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -150,7 +150,7 @@ def apply_measure(
 
         # Create temp directory for the run
         measure_run_id = uuid.uuid4().hex[:12]
-        runs_dir = Path(os.environ.get("MCP_RUNS_DIR", "/runs"))
+        runs_dir = Path(os.environ["MCP_RUNS_DIR"]) if "MCP_RUNS_DIR" in os.environ else user_run_root()
         run_dir = runs_dir / f"measure_{measure_run_id}"
         run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/mcp_server/skills/model_management/operations.py
+++ b/mcp_server/skills/model_management/operations.py
@@ -8,7 +8,7 @@ from typing import Any
 import openstudio
 
 from mcp_server import model_manager
-from mcp_server.config import INPUT_ROOT, RUN_ROOT, is_path_allowed
+from mcp_server.config import INPUT_ROOT, RUN_ROOT, is_path_allowed, user_run_root
 from mcp_server.skills.model_management.baseline_model import create_baseline_model
 
 
@@ -24,14 +24,14 @@ def _os_path(p: Path):
 def create_example_osm(name: str | None = None, out_dir: str | None = None) -> dict[str, Any]:
     """Create the built-in OpenStudio example model and save it as an OSM."""
     safe = _safe_name(name or "example_model")
-    base_dir = Path(out_dir) if out_dir else (RUN_ROOT / "examples")
+    base_dir = Path(out_dir) if out_dir else (user_run_root() / "examples")
     base_dir = base_dir.resolve()
 
-    if not is_path_allowed(base_dir):
+    if not is_path_allowed(base_dir, write=True):
         return {"ok": False, "error": f"Output directory is not allowed: {base_dir}"}
 
     model_dir = (base_dir / safe).resolve()
-    if not is_path_allowed(model_dir):
+    if not is_path_allowed(model_dir, write=True):
         return {"ok": False, "error": f"Output directory is not allowed after resolution: {model_dir}"}
 
     osm_path = model_dir / "example_model.osm"
@@ -201,7 +201,7 @@ def save_osm_model(osm_path: str | None = None) -> dict[str, Any]:
         p = current_path.resolve()
 
     # Validate path
-    if not is_path_allowed(p):
+    if not is_path_allowed(p, write=True):
         return {"ok": False, "error": f"Save path is not allowed: {p}"}
 
     # Ensure parent directory exists
@@ -246,11 +246,14 @@ def list_files(
     """
     import fnmatch
 
-    _allowed_roots = [INPUT_ROOT, RUN_ROOT]
+    _allowed_roots = [INPUT_ROOT, user_run_root()]
 
     # Determine which directories to scan
     if directory:
         d = Path(directory).resolve()
+        # A bare "/runs" request means the caller's own run area (per-user scoping)
+        if d == RUN_ROOT:
+            d = user_run_root()
         # Restrict to /inputs and /runs only
         if not any(str(d).startswith(str(root)) or d == root for root in _allowed_roots):
             return {"ok": False, "error": f"Directory not allowed: {d}. list_files is restricted to /inputs and /runs."}
@@ -314,14 +317,14 @@ def create_baseline_osm(
 ) -> dict[str, Any]:
     """Create a baseline 10-zone commercial building model and save as OSM."""
     safe = _safe_name(name or "baseline_model")
-    base_dir = Path(out_dir) if out_dir else (RUN_ROOT / "examples")
+    base_dir = Path(out_dir) if out_dir else (user_run_root() / "examples")
     base_dir = base_dir.resolve()
 
-    if not is_path_allowed(base_dir):
+    if not is_path_allowed(base_dir, write=True):
         return {"ok": False, "error": f"Output directory not allowed: {base_dir}"}
 
     model_dir = (base_dir / safe).resolve()
-    if not is_path_allowed(model_dir):
+    if not is_path_allowed(model_dir, write=True):
         return {"ok": False, "error": f"Output directory not allowed: {model_dir}"}
 
     osm_path = model_dir / "baseline_model.osm"

--- a/mcp_server/skills/results/operations.py
+++ b/mcp_server/skills/results/operations.py
@@ -8,7 +8,7 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from mcp_server.config import RUN_ROOT
+from mcp_server.config import user_run_root
 from mcp_server.util import resolve_run_dir, safe_read_text  # resolve_run_dir still used by extract_* ops
 
 
@@ -106,7 +106,7 @@ def _to_kbtu(value: float, units: str | None) -> float | None:
 def extract_summary_metrics(run_id: str, include_raw: bool = False) -> dict[str, Any]:
     """Extract headline metrics from a completed run (restart-safe)."""
     try:
-        run_dir = resolve_run_dir(RUN_ROOT, run_id)
+        run_dir = resolve_run_dir(user_run_root(), run_id)
     except FileNotFoundError:
         return {"ok": False, "error": "run_not_found", "message": f"Unknown run_id: {run_id}"}
 
@@ -270,7 +270,7 @@ def read_file(
 def _resolve_sql(run_id: str) -> tuple[Path | None, dict | None]:
     """Resolve run_dir and find eplusout.sql. Returns (sql_path, error_dict)."""
     try:
-        run_dir = resolve_run_dir(RUN_ROOT, run_id)
+        run_dir = resolve_run_dir(user_run_root(), run_id)
     except FileNotFoundError:
         return None, {"ok": False, "error": "run_not_found", "message": f"Unknown run_id: {run_id}"}
     sql_path = _find_first_existing(run_dir, ["run/eplusout.sql", "eplusout.sql"])
@@ -353,7 +353,7 @@ def extract_simulation_errors_op(run_id: str) -> dict[str, Any]:
     """Parse eplusout.err into categorized Fatal/Severe/Warning lists."""
     from mcp_server.skills.results.err_parser import parse_err_file
     try:
-        run_dir = resolve_run_dir(RUN_ROOT, run_id)
+        run_dir = resolve_run_dir(user_run_root(), run_id)
     except FileNotFoundError:
         return {"ok": False, "error": "run_not_found", "message": f"Unknown run_id: {run_id}"}
 
@@ -495,7 +495,7 @@ def compare_runs_op(baseline_run_id: str, retrofit_run_id: str) -> dict[str, Any
     }
 
 
-def copy_file(file_path: str, destination: str = "/runs/exports") -> dict[str, Any]:
+def copy_file(file_path: str, destination: str | None = None) -> dict[str, Any]:
     """Copy a file or directory to an accessible location.
 
     Bypasses the MCP 1MB transport limit for large files like HTML reports.
@@ -514,8 +514,8 @@ def copy_file(file_path: str, destination: str = "/runs/exports") -> dict[str, A
     if not full.exists():
         return {"ok": False, "error": "not_found", "message": f"Not found: {file_path}"}
 
-    dest_dir = Path(destination)
-    if not is_path_allowed(dest_dir):
+    dest_dir = Path(destination) if destination else (user_run_root() / "exports")
+    if not is_path_allowed(dest_dir, write=True):
         return {
             "ok": False, "error": "invalid_destination",
             "message": f"Destination not in allowed roots: {destination}",

--- a/mcp_server/skills/results/tools.py
+++ b/mcp_server/skills/results/tools.py
@@ -55,15 +55,15 @@ def register(mcp):
         return extract_summary_metrics(run_id, include_raw=include_raw)
 
     @mcp.tool(tags={"results"}, name="copy_file")
-    def copy_file_tool(file_path: str, destination: str = "/runs/exports"):
-        """Copy a file or directory to an accessible path under /runs.
+    def copy_file_tool(file_path: str, destination: str | None = None):
+        """Copy a file or directory to an accessible path under your run dir.
         Use to export files to the host. To read file contents, use read_file instead.
 
         Supports both individual files and entire directories (e.g. measure dirs).
 
         Args:
             file_path: Absolute path to the source file or directory
-            destination: Target directory (default /runs/exports/)
+            destination: Target directory (default: your run dir's exports/)
         """
         return copy_file(file_path=file_path, destination=destination)
 

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -16,7 +16,8 @@ from typing import Any, Literal
 
 import psutil
 
-from mcp_server.config import LOG_TAIL_DEFAULT, MAX_CONCURRENCY, OSCLI_GEM_PATH, OSCLI_GEMFILE, RUN_ROOT
+from mcp_server.config import LOG_TAIL_DEFAULT, MAX_CONCURRENCY, OSCLI_GEM_PATH, OSCLI_GEMFILE, user_run_root
+from mcp_server.identity import user_key
 from mcp_server.util import resolve_run_dir
 
 # Where the MCP server stores runs inside the container
@@ -28,6 +29,7 @@ LogStream = Literal["openstudio", "energyplus"]
 @dataclass
 class RunRecord:
     run_id: str
+    user_key: str
     name: str
     status: Literal["queued", "running", "success", "failed", "cancelled"]
     created_at: float
@@ -63,6 +65,7 @@ def _persist_run_record(rec: RunRecord) -> None:
         rec.run_dir.mkdir(parents=True, exist_ok=True)
         data = {
             "run_id": rec.run_id,
+            "user_key": rec.user_key,
             "name": rec.name,
             "status": rec.status,
             "created_at": rec.created_at,
@@ -84,7 +87,7 @@ def _persist_run_record(rec: RunRecord) -> None:
 def _load_run_record_from_disk(run_id: str) -> RunRecord | None:
     """Load run metadata from disk if present."""
     try:
-        run_dir = resolve_run_dir(RUN_ROOT, run_id)
+        run_dir = resolve_run_dir(user_run_root(), run_id)
     except FileNotFoundError:
         return None
 
@@ -95,6 +98,7 @@ def _load_run_record_from_disk(run_id: str) -> RunRecord | None:
         data = json.loads(meta_path.read_text())
         return RunRecord(
             run_id=data["run_id"],
+            user_key=data.get("user_key") or user_key(),
             name=data.get("name") or run_id,
             status=data.get("status") or "unknown",
             created_at=float(data.get("created_at") or 0.0),
@@ -112,14 +116,16 @@ def _load_run_record_from_disk(run_id: str) -> RunRecord | None:
 
 
 def _get_run_record(run_id: str) -> RunRecord | None:
-    """Look up a run record by ID, checking memory first then disk."""
+    """Look up a run record owned by the caller, checking memory then disk."""
+    me = user_key()
     rec = _RUNS.get(run_id)
-    if rec:
-        return rec
-    rec = _load_run_record_from_disk(run_id)
-    if rec:
+    if rec is not None:
+        return rec if rec.user_key == me else None
+    rec = _load_run_record_from_disk(run_id)  # disk lookup is already user-scoped
+    if rec is not None and rec.user_key == me:
         _RUNS[run_id] = rec
-    return rec
+        return rec
+    return None
 
 
 
@@ -334,7 +340,7 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None)
 
     # Create run directory
     run_id = uuid.uuid4().hex
-    run_dir = (RUN_ROOT / run_id).resolve()
+    run_dir = (user_run_root() / run_id).resolve()
     run_dir.mkdir(parents=True, exist_ok=True)
 
     # Stage OSW directory contents
@@ -381,6 +387,7 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None)
 
     rec = RunRecord(
         run_id=run_id,
+        user_key=user_key(),
         name=run_name,
         status="queued",
         created_at=_now(),
@@ -548,7 +555,7 @@ def get_run_artifacts(run_id: str) -> dict[str, Any]:
     else:
         # Fall back to filesystem lookup — measure runs aren't registered
         try:
-            run_dir = resolve_run_dir(RUN_ROOT, run_id)
+            run_dir = resolve_run_dir(user_run_root(), run_id)
         except FileNotFoundError:
             return {"ok": False, "error": f"Unknown run_id: {run_id}"}
     candidates = [
@@ -699,7 +706,7 @@ def run_simulation(osm_path: str, epw_path: str | None = None, name: str | None 
 
     # Create a temporary OSW alongside the OSM
     run_id = uuid.uuid4().hex[:12]
-    osw_dir = RUN_ROOT / f"sim_{run_id}"
+    osw_dir = user_run_root() / f"sim_{run_id}"
     osw_dir.mkdir(parents=True, exist_ok=True)
 
     # Copy OSM into the run dir so OSW can reference it by relative path

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -1,19 +1,22 @@
 # mcp_server/tools/workflow_tools.py
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 import subprocess
+import threading
 import time
 import uuid
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
 import psutil
 
-from mcp_server.config import LOG_TAIL_DEFAULT, OSCLI_GEM_PATH, OSCLI_GEMFILE, RUN_ROOT
+from mcp_server.config import LOG_TAIL_DEFAULT, MAX_CONCURRENCY, OSCLI_GEM_PATH, OSCLI_GEMFILE, RUN_ROOT
 from mcp_server.util import resolve_run_dir
 
 # Where the MCP server stores runs inside the container
@@ -40,6 +43,13 @@ class RunRecord:
 
 # In-memory registry (good enough for one-container dev right now)
 _RUNS: dict[str, RunRecord] = {}
+
+# Global FIFO scheduling + concurrency cap. run_osw enqueues (status="queued");
+# a daemon dispatcher launches up to MAX_CONCURRENCY and drains as sims finish,
+# so queued runs start without needing another tool call.
+_sim_lock = threading.RLock()
+_queue: deque[str] = deque()
+_dispatcher_started = False
 
 
 def _run_record_path(run_dir: Path) -> Path:
@@ -216,6 +226,83 @@ def validate_osw(osw_path: str, epw_path: str | None = None) -> dict[str, Any]:
     return {"ok": len(fatal_issues) == 0, "issues": issues, "osw_dir": str(base), "osw": osw}
 
 
+def _pid_alive(pid: int) -> bool:
+    """True if the process is still running (not a reaped/zombie process)."""
+    try:
+        p = psutil.Process(pid)
+        return p.is_running() and p.status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
+
+
+def _build_run_cmd(osw_path: Path) -> list[str]:
+    """openstudio CLI command to run a staged OSW (with bundle flags)."""
+    return [
+        "openstudio",
+        "--bundle", OSCLI_GEMFILE,
+        "--bundle_path", OSCLI_GEM_PATH,
+        "--bundle_without", "native_ext",
+        "run", "-w", str(osw_path),
+    ]
+
+
+def _launch(rec: RunRecord) -> None:
+    """Start the EnergyPlus subprocess for a queued run. Caller holds _sim_lock."""
+    log = rec.run_dir / "openstudio.log"
+    proc = subprocess.Popen(  # noqa: S603 - cmd built from trusted config + staged OSW path
+        _build_run_cmd(rec.osw_path),
+        cwd=str(rec.run_dir),
+        stdout=log.open("w", encoding="utf-8"),
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+    )
+    rec.pid = proc.pid
+    rec.status = "running"
+    rec.started_at = _now()
+
+
+def _running_count() -> int:
+    """Number of currently-executing runs. Caller holds _sim_lock."""
+    return sum(1 for r in _RUNS.values() if r.status == "running")
+
+
+def _dispatch_once() -> None:
+    """Reap finished runs and launch queued ones up to MAX_CONCURRENCY (global FIFO)."""
+    with _sim_lock:
+        for rec in _RUNS.values():
+            if rec.status == "running" and rec.pid is not None and not _pid_alive(rec.pid):
+                _refresh_status(rec)
+                _persist_run_record(rec)
+        while _queue and _running_count() < MAX_CONCURRENCY:
+            run_id = _queue.popleft()
+            rec = _RUNS.get(run_id)
+            if rec is not None and rec.status == "queued":
+                _launch(rec)
+                _persist_run_record(rec)
+
+
+def _dispatch_loop() -> None:
+    while True:
+        with contextlib.suppress(Exception):
+            _dispatch_once()
+        time.sleep(0.5)
+
+
+def _ensure_dispatcher() -> None:
+    """Start the background dispatcher thread once (drains queue as slots free)."""
+    global _dispatcher_started
+    with _sim_lock:
+        if _dispatcher_started:
+            return
+        _dispatcher_started = True
+    threading.Thread(target=_dispatch_loop, daemon=True, name="sim-dispatcher").start()
+
+
+def _enqueue(run_id: str) -> None:
+    with _sim_lock:
+        _queue.append(run_id)
+
+
 def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None) -> dict[str, Any]:
     """
     Stage the OSW + referenced files into /runs/<run_id>/ and execute:
@@ -289,47 +376,34 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None)
     # Determine run display name
     run_name = _safe_name(name or osw.get("name") or src_osw.stem)
 
-    # Create log files
-    openstudio_log = run_dir / "openstudio.log"
-
-    # Kick off openstudio run with bundle flags for gem dependencies
-    # Note: use Popen so it can run async.
-    cmd = [
-        "openstudio",
-        "--bundle", OSCLI_GEMFILE,
-        "--bundle_path", OSCLI_GEM_PATH,
-        "--bundle_without", "native_ext",
-        "run", "-w", str(staged_osw),
-    ]
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(run_dir),
-        stdout=open(openstudio_log, "w", encoding="utf-8"),
-        stderr=open(openstudio_log, "a", encoding="utf-8"),
-        env=os.environ.copy(),
-    )
+    # Build the run command (executed later by the dispatcher when a slot frees)
+    cmd = _build_run_cmd(staged_osw)
 
     rec = RunRecord(
         run_id=run_id,
         name=run_name,
-        status="running",
+        status="queued",
         created_at=_now(),
-        started_at=_now(),
+        started_at=None,
         ended_at=None,
-        pid=proc.pid,
+        pid=None,
         run_dir=run_dir,
         osw_path=staged_osw,
         epw_path=staged_epw,
         exit_code=None,
         error=None,
     )
-    _RUNS[run_id] = rec
+    with _sim_lock:
+        _RUNS[run_id] = rec
+    _enqueue(run_id)
+    _ensure_dispatcher()
+    _dispatch_once()  # launch immediately if under the concurrency cap
 
-    # Return immediately
     return {
         "ok": True,
         "run_id": run_id,
         "name": run_name,
+        "status": rec.status,
         "run_dir": str(run_dir),
         "osw_path": str(staged_osw),
         "epw_path": str(staged_epw) if staged_epw else None,
@@ -365,10 +439,7 @@ def _refresh_status(rec: RunRecord) -> RunRecord:
     if out_osw.exists():
         try:
             out = _load_json(out_osw)
-            if out.get("completed_status") == "Success":
-                status = "success"
-            else:
-                status = "failed"
+            status = "success" if out.get("completed_status") == "Success" else "failed"
         except Exception as e:
             err = f"Failed to parse out.osw: {e}"
 
@@ -393,9 +464,10 @@ def get_run_status(run_id: str) -> dict[str, Any]:
                     "simulation run directories, or run_simulation() to create one.",
         }
 
-    rec = _refresh_status(rec)
-    _RUNS[run_id] = rec
-    _persist_run_record(rec)
+    with _sim_lock:
+        rec = _refresh_status(rec)
+        _RUNS[run_id] = rec
+        _persist_run_record(rec)
 
     run_dict = {
         "run_id": rec.run_id,
@@ -517,26 +589,31 @@ def cancel_run(run_id: str) -> dict[str, Any]:
     if not rec:
         return {"ok": False, "error": f"Unknown run_id: {run_id}"}
 
-    if rec.pid is None:
-        rec.status = "cancelled"
-        rec.ended_at = rec.ended_at or _now()
-        _RUNS[run_id] = rec
+    pid = rec.pid
+    if pid is None:
+        # Queued (or never started) — mark cancelled; dispatcher skips non-queued.
+        with _sim_lock:
+            rec.status = "cancelled"
+            rec.ended_at = rec.ended_at or _now()
+            _RUNS[run_id] = rec
         return {"ok": True, "run_id": run_id, "cancelled": True}
 
     try:
-        p = psutil.Process(rec.pid)
+        p = psutil.Process(pid)
         p.terminate()
         try:
             p.wait(timeout=5)
         except psutil.TimeoutExpired:
             p.kill()
-        rec.status = "cancelled"
-        rec.ended_at = rec.ended_at or _now()
-        _RUNS[run_id] = rec
+        with _sim_lock:
+            rec.status = "cancelled"
+            rec.ended_at = rec.ended_at or _now()
+            _RUNS[run_id] = rec
         return {"ok": True, "run_id": run_id, "cancelled": True}
     except psutil.NoSuchProcess:
-        rec = _refresh_status(rec)
-        _RUNS[run_id] = rec
+        with _sim_lock:
+            rec = _refresh_status(rec)
+            _RUNS[run_id] = rec
         return {"ok": True, "run_id": run_id, "cancelled": False, "status": rec.status}
     except Exception as e:
         return {"ok": False, "run_id": run_id, "error": str(e)}

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -639,6 +639,7 @@ def cancel_run(run_id: str) -> dict[str, Any]:
             rec.status = "cancelled"
             rec.ended_at = rec.ended_at or _now()
             _RUNS[run_id] = rec
+        _persist_run_record(rec)  # disk record must read 'cancelled' so GC can reclaim it
         audit("sim_cancelled", run_id=run_id, user=rec.user_key)
         return {"ok": True, "run_id": run_id, "cancelled": True}
 
@@ -653,6 +654,7 @@ def cancel_run(run_id: str) -> dict[str, Any]:
             rec.status = "cancelled"
             rec.ended_at = rec.ended_at or _now()
             _RUNS[run_id] = rec
+        _persist_run_record(rec)  # disk record must read 'cancelled' so GC can reclaim it
         audit("sim_cancelled", run_id=run_id, user=rec.user_key)
         return {"ok": True, "run_id": run_id, "cancelled": True}
     except psutil.NoSuchProcess:

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -453,6 +453,11 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None)
 def _refresh_status(rec: RunRecord) -> RunRecord:
     """Check if the OS process has ended and update run status accordingly."""
     _prev = rec.status
+    if rec.status in _TERMINAL:
+        # Already terminal (incl. cancelled) — never reclassify. Keeps a cancelled
+        # run sticky (a dead pid would otherwise be read as "failed") and makes
+        # refresh idempotent.
+        return rec
     if rec.pid is None:
         return rec
 
@@ -482,10 +487,6 @@ def _refresh_status(rec: RunRecord) -> RunRecord:
             status = "success" if out.get("completed_status") == "Success" else "failed"
         except Exception as e:
             err = f"Failed to parse out.osw: {e}"
-
-    # If we couldn't parse out.osw and exit_code is known non-zero, keep failed.
-    if status != "success" and rec.status != "cancelled":
-        status = "failed"
 
     rec.status = status  # type: ignore[assignment]
     rec.ended_at = rec.ended_at or _now()

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 import psutil
 
+from mcp_server.audit import audit
 from mcp_server.config import (
     LOG_TAIL_DEFAULT,
     MAX_CONCURRENCY,
@@ -59,6 +60,7 @@ _RUNS: dict[str, RunRecord] = {}
 _sim_lock = threading.RLock()
 _queue: deque[str] = deque()
 _dispatcher_started = False
+_TERMINAL = frozenset({"success", "failed", "cancelled", "error"})
 
 
 def _run_record_path(run_dir: Path) -> Path:
@@ -272,6 +274,7 @@ def _launch(rec: RunRecord) -> None:
     rec.pid = proc.pid
     rec.status = "running"
     rec.started_at = _now()
+    audit("sim_launched", run_id=rec.run_id, user=rec.user_key, name=rec.name, pid=rec.pid)
 
 
 def _dispatch_once() -> None:
@@ -429,6 +432,7 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None)
     )
     with _sim_lock:
         _RUNS[run_id] = rec
+    audit("sim_queued", run_id=run_id, user=rec.user_key, name=run_name)
     _enqueue(run_id)
     _ensure_dispatcher()
     _dispatch_once()  # launch immediately if under the concurrency cap
@@ -447,6 +451,7 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None)
 
 def _refresh_status(rec: RunRecord) -> RunRecord:
     """Check if the OS process has ended and update run status accordingly."""
+    _prev = rec.status
     if rec.pid is None:
         return rec
 
@@ -485,6 +490,9 @@ def _refresh_status(rec: RunRecord) -> RunRecord:
     rec.ended_at = rec.ended_at or _now()
     rec.exit_code = exit_code if exit_code is not None else rec.exit_code
     rec.error = err or rec.error
+    if _prev not in _TERMINAL and rec.status in _TERMINAL:
+        audit("sim_finished", run_id=rec.run_id, user=rec.user_key,
+              status=rec.status, exit_code=rec.exit_code)
     return rec
 
 
@@ -630,6 +638,7 @@ def cancel_run(run_id: str) -> dict[str, Any]:
             rec.status = "cancelled"
             rec.ended_at = rec.ended_at or _now()
             _RUNS[run_id] = rec
+        audit("sim_cancelled", run_id=run_id, user=rec.user_key)
         return {"ok": True, "run_id": run_id, "cancelled": True}
 
     try:
@@ -643,6 +652,7 @@ def cancel_run(run_id: str) -> dict[str, Any]:
             rec.status = "cancelled"
             rec.ended_at = rec.ended_at or _now()
             _RUNS[run_id] = rec
+        audit("sim_cancelled", run_id=run_id, user=rec.user_key)
         return {"ok": True, "run_id": run_id, "cancelled": True}
     except psutil.NoSuchProcess:
         with _sim_lock:

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -502,8 +503,8 @@ def get_run_status(run_id: str) -> dict[str, Any]:
         return {
             "ok": False,
             "error": f"Unknown run_id: {run_id}",
-            "hint": "Use list_files(directory='/runs', pattern='sim_*') to find "
-                    "simulation run directories, or run_simulation() to create one.",
+            "hint": "Use list_files(directory='/runs') to find simulation run "
+                    "directories, or run_simulation() to create one.",
         }
 
     with _sim_lock:
@@ -555,8 +556,8 @@ def get_run_logs(run_id: str, tail: int | None = None, stream: LogStream = "open
         return {
             "ok": False,
             "error": f"Unknown run_id: {run_id}",
-            "hint": "Use list_files(directory='/runs', pattern='sim_*') to find "
-                    "simulation run directories, or run_simulation() to create one.",
+            "hint": "Use list_files(directory='/runs') to find simulation run "
+                    "directories, or run_simulation() to create one.",
         }
 
     try:
@@ -741,23 +742,6 @@ def run_simulation(osm_path: str, epw_path: str | None = None, name: str | None 
     if not osm.exists():
         return {"ok": False, "error": f"OSM file not found: {osm_path}"}
 
-    # Create a temporary OSW alongside the OSM
-    run_id = uuid.uuid4().hex[:12]
-    osw_dir = user_run_root() / f"sim_{run_id}"
-    osw_dir.mkdir(parents=True, exist_ok=True)
-
-    # Copy OSM into the run dir so OSW can reference it by relative path
-    staged_osm = osw_dir / osm.name
-    shutil.copy2(str(osm), str(staged_osm))
-
-    # Build minimal OSW
-    osw: dict[str, Any] = {
-        "seed_file": osm.name,
-        "file_paths": [],
-        "measure_paths": [],
-        "steps": [],
-    }
-
     # Validate EPW path upfront if provided
     epw_abs: str | None = None
     if epw_path:
@@ -766,8 +750,22 @@ def run_simulation(osm_path: str, epw_path: str | None = None, name: str | None 
             return {"ok": False, "error": f"EPW file not found: {epw_path}"}
         epw_abs = str(epw.resolve())
 
-    osw_path_out = osw_dir / "workflow.osw"
-    osw_path_out.write_text(json.dumps(osw, indent=2), encoding="utf-8")
+    # Stage the minimal OSW in a throwaway temp dir. run_osw() copies the staged
+    # files into the real per-user run dir before it returns, so nothing here
+    # needs to persist — this avoids leaving an orphan sim_* dir under /runs.
+    with tempfile.TemporaryDirectory(prefix="osw_stage_") as tmp:
+        stage = Path(tmp)
+        staged_osm = stage / osm.name
+        shutil.copy2(str(osm), str(staged_osm))
 
-    # Delegate to run_osw — pass epw_path so it handles staging into files/
-    return run_osw(osw_path=str(osw_path_out), epw_path=epw_abs, name=name)
+        osw: dict[str, Any] = {
+            "seed_file": osm.name,
+            "file_paths": [],
+            "measure_paths": [],
+            "steps": [],
+        }
+        osw_path_out = stage / "workflow.osw"
+        osw_path_out.write_text(json.dumps(osw, indent=2), encoding="utf-8")
+
+        # Delegate to run_osw — pass epw_path so it handles staging into files/
+        return run_osw(osw_path=str(osw_path_out), epw_path=epw_abs, name=name)

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -16,7 +16,14 @@ from typing import Any, Literal
 
 import psutil
 
-from mcp_server.config import LOG_TAIL_DEFAULT, MAX_CONCURRENCY, OSCLI_GEM_PATH, OSCLI_GEMFILE, user_run_root
+from mcp_server.config import (
+    LOG_TAIL_DEFAULT,
+    MAX_CONCURRENCY,
+    MAX_CONCURRENCY_PER_USER,
+    OSCLI_GEM_PATH,
+    OSCLI_GEMFILE,
+    user_run_root,
+)
 from mcp_server.identity import user_key
 from mcp_server.util import resolve_run_dir
 
@@ -267,24 +274,44 @@ def _launch(rec: RunRecord) -> None:
     rec.started_at = _now()
 
 
-def _running_count() -> int:
-    """Number of currently-executing runs. Caller holds _sim_lock."""
-    return sum(1 for r in _RUNS.values() if r.status == "running")
-
-
 def _dispatch_once() -> None:
-    """Reap finished runs and launch queued ones up to MAX_CONCURRENCY (global FIFO)."""
+    """Reap finished runs and launch queued ones, respecting the global cap and
+    (when set) the per-user cap. FIFO, but a user already at their per-user limit
+    is skipped so they can't monopolize the queue."""
     with _sim_lock:
+        # Reap finished processes to free slots.
         for rec in _RUNS.values():
             if rec.status == "running" and rec.pid is not None and not _pid_alive(rec.pid):
                 _refresh_status(rec)
                 _persist_run_record(rec)
-        while _queue and _running_count() < MAX_CONCURRENCY:
-            run_id = _queue.popleft()
+
+        # Tally what's running, globally and per user.
+        per_user: dict[str, int] = {}
+        for rec in _RUNS.values():
+            if rec.status == "running":
+                per_user[rec.user_key] = per_user.get(rec.user_key, 0) + 1
+        running_total = sum(per_user.values())
+
+        # Walk the queue in order: launch runnable runs, drop stale/cancelled ones,
+        # leave per-user-capped runs queued for a later pass.
+        drop: list[str] = []
+        for run_id in list(_queue):
+            if running_total >= MAX_CONCURRENCY:
+                break
             rec = _RUNS.get(run_id)
-            if rec is not None and rec.status == "queued":
-                _launch(rec)
-                _persist_run_record(rec)
+            if rec is None or rec.status != "queued":
+                drop.append(run_id)  # cancelled or vanished
+                continue
+            if MAX_CONCURRENCY_PER_USER > 0 and per_user.get(rec.user_key, 0) >= MAX_CONCURRENCY_PER_USER:
+                continue  # this user is at their cap; try the next run
+            _launch(rec)
+            _persist_run_record(rec)
+            per_user[rec.user_key] = per_user.get(rec.user_key, 0) + 1
+            running_total += 1
+            drop.append(run_id)
+        for run_id in drop:
+            with contextlib.suppress(ValueError):
+                _queue.remove(run_id)
 
 
 def _dispatch_loop() -> None:

--- a/mcp_server/skills/simulation/retention.py
+++ b/mcp_server/skills/simulation/retention.py
@@ -207,10 +207,16 @@ def _gc_sweep_all(now: float | None = None) -> dict[str, Any]:
     max_age_s = _retention_days * 86400.0
     deleted: list[dict] = []
     freed = 0
+    # Local single-user layout: run dirs live directly under RUN_ROOT.
+    recs, f = _sweep_user_root(RUN_ROOT, "local", max_age_s, now, dry_run=False, reason="gc")
+    deleted.extend(recs)
+    freed += f
+    # Multi-user layout: RUN_ROOT/<user>/<run>. Skip children that are themselves
+    # run dirs (already handled above) so we don't descend into a run's internals.
     for user_dir in sorted(RUN_ROOT.iterdir()):
         if user_dir.is_symlink() or not user_dir.is_dir():
             continue
-        if not _is_real_child(user_dir, RUN_ROOT):  # only genuine RUN_ROOT/<user> dirs
+        if not _is_real_child(user_dir, RUN_ROOT) or _is_run_dir(user_dir):
             continue
         recs, f = _sweep_user_root(
             user_dir, user_dir.name, max_age_s, now, dry_run=False, reason="gc")

--- a/mcp_server/skills/simulation/retention.py
+++ b/mcp_server/skills/simulation/retention.py
@@ -37,6 +37,37 @@ from mcp_server.util import resolve_run_dir
 PIN_MARKER = ".pinned"
 _NOT_A_RUN = {"examples", "exports"}  # user working dirs, never GC'd
 
+# GC refuses to operate if RUN_ROOT is (mis)configured to a system location —
+# a backstop against a catastrophic OSMCP_RUN_ROOT value wiping real data.
+_FORBIDDEN_ROOTS = {
+    "/", "/home", "/root", "/usr", "/etc", "/var", "/bin", "/lib", "/lib64",
+    "/opt", "/tmp", "/boot", "/dev", "/proc", "/sys", "/srv", "/mnt", "/media",  # noqa: S108 — denylist, not temp usage
+}
+
+
+def _run_root_is_sane(root: Path) -> bool:
+    """False if RUN_ROOT is a filesystem/system root we must never sweep."""
+    try:
+        r = root.resolve()
+    except OSError:
+        return False
+    if len(r.parts) < 2:  # "/" or a bare drive root
+        return False
+    return str(r) not in _FORBIDDEN_ROOTS
+
+
+def _is_real_child(d: Path, parent: Path) -> bool:
+    """True only if d is a genuine, non-symlink direct child of parent (resolved).
+
+    Defeats symlink escape: a symlinked entry — or anything whose resolved path
+    leaves `parent` — is rejected, so deletion can never follow a link out of the
+    swept tree.
+    """
+    try:
+        return (not d.is_symlink()) and d.resolve().parent == parent.resolve()
+    except OSError:
+        return False
+
 
 def _is_run_dir(d: Path) -> bool:
     """A dir is a run iff it holds a run record / OpenStudio output / run subdir."""
@@ -119,7 +150,9 @@ def _sweep_user_root(
     if not user_root.exists():
         return out, freed
     for d in sorted(user_root.iterdir()):
-        if not d.is_dir() or not _is_run_dir(d):
+        if d.is_symlink() or not d.is_dir() or not _is_run_dir(d):
+            continue
+        if not _is_real_child(d, user_root):  # never follow a link out of the tree
             continue
         if (d / PIN_MARKER).exists() or _is_active(d):
             continue
@@ -144,14 +177,16 @@ def _sweep_user_root(
 
 def _gc_sweep_all(now: float | None = None) -> dict[str, Any]:
     """One whole-container sweep across every user's runs (used by the daemon)."""
-    if RUN_RETENTION_DAYS <= 0 or not RUN_ROOT.exists():
+    if RUN_RETENTION_DAYS <= 0 or not RUN_ROOT.exists() or not _run_root_is_sane(RUN_ROOT):
         return {"deleted": [], "freed_mb": 0.0}
     now = time.time() if now is None else now
     max_age_s = RUN_RETENTION_DAYS * 86400.0
     deleted: list[dict] = []
     freed = 0
     for user_dir in sorted(RUN_ROOT.iterdir()):
-        if not user_dir.is_dir():
+        if user_dir.is_symlink() or not user_dir.is_dir():
+            continue
+        if not _is_real_child(user_dir, RUN_ROOT):  # only genuine RUN_ROOT/<user> dirs
             continue
         recs, f = _sweep_user_root(
             user_dir, user_dir.name, max_age_s, now, dry_run=False, reason="gc")
@@ -173,9 +208,13 @@ _start_lock = threading.Lock()
 
 
 def start_retention_gc() -> bool:
-    """Start the background retention daemon once. No-op if GC is disabled."""
+    """Start the background retention daemon once. No-op if GC is disabled or the
+    configured RUN_ROOT is unsafe to sweep."""
     global _started
     if RUN_RETENTION_DAYS <= 0:
+        return False
+    if not _run_root_is_sane(RUN_ROOT):
+        audit("retention_disabled", reason="unsafe_run_root", run_root=str(RUN_ROOT))
         return False
     with _start_lock:
         if _started:
@@ -211,6 +250,8 @@ def delete_run(run_id: str) -> dict[str, Any]:
         return {"ok": False, "error": f"Unknown run_id: {run_id}"}
     if _is_active(run_dir):
         return {"ok": False, "error": f"Run {run_id} is queued/running — cancel_run first."}
+    if not _is_real_child(run_dir, user_run_root()):  # never delete via a symlink/escape
+        return {"ok": False, "error": f"Refusing to delete {run_id}: not a real run dir."}
     freed = round(_dir_size_bytes(run_dir) / 1e6, 1)
     shutil.rmtree(run_dir, ignore_errors=True)
     _forget(run_id)

--- a/mcp_server/skills/simulation/retention.py
+++ b/mcp_server/skills/simulation/retention.py
@@ -56,10 +56,10 @@ def resolve_gc_days(argv: list[str], env_days: float) -> float:
     ap.add_argument("--gc-days", type=float, default=None)
     ns, _ = ap.parse_known_args(argv)
     if ns.gc_days is not None:
-        return ns.gc_days
+        return max(0.0, ns.gc_days)  # negative window = off (fail-safe, never "delete all")
     if ns.gc:
         return env_days if env_days > 0 else 7.0
-    return env_days
+    return max(0.0, env_days)
 
 # GC refuses to operate if RUN_ROOT is (mis)configured to a system location —
 # a backstop against a catastrophic OSMCP_RUN_ROOT value wiping real data.

--- a/mcp_server/skills/simulation/retention.py
+++ b/mcp_server/skills/simulation/retention.py
@@ -36,6 +36,30 @@ from mcp_server.util import resolve_run_dir
 
 PIN_MARKER = ".pinned"
 _NOT_A_RUN = {"examples", "exports"}  # user working dirs, never GC'd
+_CLEANUP_FALLBACK_DAYS = 7.0  # manual cleanup_runs default window when GC is off
+
+# Effective retention window for the auto-GC daemon. Starts from the env value
+# (RUN_RETENTION_DAYS, default 0 = off) and may be raised at startup by the
+# --gc / --gc-days CLI flag via start_retention_gc(days=...). 0 = daemon disabled.
+_retention_days = RUN_RETENTION_DAYS
+
+
+def resolve_gc_days(argv: list[str], env_days: float) -> float:
+    """Resolve the effective auto-GC window from CLI args + the env default.
+
+    Precedence: --gc-days N  >  --gc (env window, else 7)  >  env_days (default 0).
+    Returns 0.0 when GC should stay off — the off-by-default contract.
+    """
+    import argparse
+    ap = argparse.ArgumentParser(add_help=False)
+    ap.add_argument("--gc", action="store_true")
+    ap.add_argument("--gc-days", type=float, default=None)
+    ns, _ = ap.parse_known_args(argv)
+    if ns.gc_days is not None:
+        return ns.gc_days
+    if ns.gc:
+        return env_days if env_days > 0 else 7.0
+    return env_days
 
 # GC refuses to operate if RUN_ROOT is (mis)configured to a system location —
 # a backstop against a catastrophic OSMCP_RUN_ROOT value wiping real data.
@@ -177,10 +201,10 @@ def _sweep_user_root(
 
 def _gc_sweep_all(now: float | None = None) -> dict[str, Any]:
     """One whole-container sweep across every user's runs (used by the daemon)."""
-    if RUN_RETENTION_DAYS <= 0 or not RUN_ROOT.exists() or not _run_root_is_sane(RUN_ROOT):
+    if _retention_days <= 0 or not RUN_ROOT.exists() or not _run_root_is_sane(RUN_ROOT):
         return {"deleted": [], "freed_mb": 0.0}
     now = time.time() if now is None else now
-    max_age_s = RUN_RETENTION_DAYS * 86400.0
+    max_age_s = _retention_days * 86400.0
     deleted: list[dict] = []
     freed = 0
     for user_dir in sorted(RUN_ROOT.iterdir()):
@@ -207,11 +231,18 @@ _started = False
 _start_lock = threading.Lock()
 
 
-def start_retention_gc() -> bool:
-    """Start the background retention daemon once. No-op if GC is disabled or the
-    configured RUN_ROOT is unsafe to sweep."""
-    global _started
-    if RUN_RETENTION_DAYS <= 0:
+def start_retention_gc(days: float | None = None) -> bool:
+    """Start the background retention daemon once. Off by default: returns False
+    (no daemon) unless an effective window > 0 is given here or via the env. Also
+    refuses if the configured RUN_ROOT is unsafe to sweep.
+
+    `days` is the resolved CLI/env window (see resolve_gc_days); None keeps the
+    env-derived default.
+    """
+    global _started, _retention_days
+    if days is not None:
+        _retention_days = days
+    if _retention_days <= 0:
         return False
     if not _run_root_is_sane(RUN_ROOT):
         audit("retention_disabled", reason="unsafe_run_root", run_root=str(RUN_ROOT))
@@ -230,9 +261,15 @@ def start_retention_gc() -> bool:
 
 def cleanup_runs(older_than_days: float | None = None, dry_run: bool = True) -> dict[str, Any]:
     """Delete the caller's run dirs older than `older_than_days` (default: the
-    server retention window). dry_run previews without deleting. 0 days = all
-    terminal runs. Pinned and queued/running runs are skipped."""
-    days = RUN_RETENTION_DAYS if older_than_days is None else float(older_than_days)
+    active GC window, or 7 days when auto-GC is off). dry_run previews without
+    deleting. 0 days = all terminal runs. Pinned and queued/running runs are
+    skipped. Works regardless of whether the background daemon is enabled."""
+    if older_than_days is None:
+        # Default to the active GC window, or a safe 7-day fallback when GC is off
+        # (so the no-arg call never means "delete everything").
+        days = _retention_days if _retention_days > 0 else _CLEANUP_FALLBACK_DAYS
+    else:
+        days = float(older_than_days)
     max_age_s = max(0.0, days) * 86400.0
     recs, freed = _sweep_user_root(
         user_run_root(), user_key(), max_age_s, time.time(),

--- a/mcp_server/skills/simulation/retention.py
+++ b/mcp_server/skills/simulation/retention.py
@@ -1,0 +1,242 @@
+"""Run-directory retention: automatic age-based GC + explicit cleanup tools.
+
+Two callers share one sweep:
+  - start_retention_gc(): a background daemon (started in server.main()) that
+    sweeps the WHOLE container (every user's runs) on an interval, deleting run
+    dirs older than RUN_RETENTION_DAYS. Nobody calls it — it's infrastructure,
+    like the sim dispatcher. Emits a `run_evicted` audit line per deletion.
+  - cleanup_runs / delete_run / pin_run / unpin_run: MCP tools the agent invokes
+    on the user's request, scoped to the caller's own runs.
+
+Age = run_record.json `ended_at` (fallback: dir mtime). Pinned (`.pinned` marker)
+and queued/running runs are never deleted. Only run dirs are targeted — a dir
+counts as a run iff it holds run_record.json / out.osw / a run/ subdir, so saved
+models under examples/ and exports/ are left alone.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import shutil
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from mcp_server.audit import audit
+from mcp_server.config import (
+    RETENTION_SWEEP_SECONDS,
+    RUN_RETENTION_DAYS,
+    RUN_ROOT,
+    user_run_root,
+)
+from mcp_server.identity import user_key
+from mcp_server.skills.simulation.operations import _RUNS, _pid_alive, _sim_lock
+from mcp_server.util import resolve_run_dir
+
+PIN_MARKER = ".pinned"
+_NOT_A_RUN = {"examples", "exports"}  # user working dirs, never GC'd
+
+
+def _is_run_dir(d: Path) -> bool:
+    """A dir is a run iff it holds a run record / OpenStudio output / run subdir."""
+    if d.name in _NOT_A_RUN:
+        return False
+    return (
+        (d / "run_record.json").exists()
+        or (d / "out.osw").exists()
+        or (d / "run").is_dir()
+    )
+
+
+def _record(d: Path) -> dict[str, Any] | None:
+    rec = d / "run_record.json"
+    if not rec.exists():
+        return None
+    try:
+        return json.loads(rec.read_text())
+    except Exception:
+        return {}  # present but unreadable -> treat conservatively (see _is_active)
+
+
+def _run_age_seconds(d: Path, now: float) -> float:
+    data = _record(d)
+    if data:
+        ts = data.get("ended_at") or data.get("created_at")
+        if ts:
+            with contextlib.suppress(ValueError, TypeError):
+                return max(0.0, now - float(ts))
+    try:
+        return max(0.0, now - d.stat().st_mtime)
+    except OSError:
+        return 0.0
+
+
+def _is_active(d: Path) -> bool:
+    """True if the run is still queued or genuinely running (never GC these)."""
+    data = _record(d)
+    if data is None:
+        return False
+    if not data:
+        return True  # unreadable record -> don't risk deleting an active run
+    status = data.get("status")
+    if status == "queued":
+        return True
+    if status == "running":
+        pid = data.get("pid")
+        try:
+            return bool(pid and _pid_alive(int(pid)))
+        except (ValueError, TypeError):
+            return True
+    return False  # success / failed / cancelled -> terminal
+
+
+def _dir_size_bytes(d: Path) -> int:
+    total = 0
+    for p in d.rglob("*"):
+        try:
+            if p.is_file():
+                total += p.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _forget(run_id: str) -> None:
+    """Drop a deleted run from the in-memory registry."""
+    with contextlib.suppress(Exception), _sim_lock:
+        _RUNS.pop(run_id, None)
+
+
+def _sweep_user_root(
+    user_root: Path, user: str, max_age_s: float, now: float,
+    *, dry_run: bool, reason: str,
+) -> tuple[list[dict], int]:
+    """Sweep one user's run dirs; delete (or, if dry_run, just list) the eligible
+    ones older than max_age_s. Returns (records, freed_bytes)."""
+    out: list[dict] = []
+    freed = 0
+    if not user_root.exists():
+        return out, freed
+    for d in sorted(user_root.iterdir()):
+        if not d.is_dir() or not _is_run_dir(d):
+            continue
+        if (d / PIN_MARKER).exists() or _is_active(d):
+            continue
+        age = _run_age_seconds(d, now)
+        if age < max_age_s:
+            continue
+        size = _dir_size_bytes(d)
+        rec = {"run_id": d.name, "user": user,
+               "age_days": round(age / 86400.0, 2), "freed_mb": round(size / 1e6, 1)}
+        if not dry_run:
+            shutil.rmtree(d, ignore_errors=True)
+            _forget(d.name)
+            audit("run_evicted", reason=reason, **rec)
+        out.append(rec)
+        freed += size
+    return out, freed
+
+
+# --------------------------------------------------------------------------
+# Background daemon (whole-container, automatic)
+# --------------------------------------------------------------------------
+
+def _gc_sweep_all(now: float | None = None) -> dict[str, Any]:
+    """One whole-container sweep across every user's runs (used by the daemon)."""
+    if RUN_RETENTION_DAYS <= 0 or not RUN_ROOT.exists():
+        return {"deleted": [], "freed_mb": 0.0}
+    now = time.time() if now is None else now
+    max_age_s = RUN_RETENTION_DAYS * 86400.0
+    deleted: list[dict] = []
+    freed = 0
+    for user_dir in sorted(RUN_ROOT.iterdir()):
+        if not user_dir.is_dir():
+            continue
+        recs, f = _sweep_user_root(
+            user_dir, user_dir.name, max_age_s, now, dry_run=False, reason="gc")
+        deleted.extend(recs)
+        freed += f
+    return {"deleted": deleted, "freed_mb": round(freed / 1e6, 1)}
+
+
+def _retention_loop() -> None:
+    interval = max(60.0, RETENTION_SWEEP_SECONDS)
+    while True:
+        with contextlib.suppress(Exception):
+            _gc_sweep_all()
+        time.sleep(interval)
+
+
+_started = False
+_start_lock = threading.Lock()
+
+
+def start_retention_gc() -> bool:
+    """Start the background retention daemon once. No-op if GC is disabled."""
+    global _started
+    if RUN_RETENTION_DAYS <= 0:
+        return False
+    with _start_lock:
+        if _started:
+            return False
+        _started = True
+    threading.Thread(target=_retention_loop, daemon=True, name="sim-retention").start()
+    return True
+
+
+# --------------------------------------------------------------------------
+# MCP tool operations (caller-scoped, explicit)
+# --------------------------------------------------------------------------
+
+def cleanup_runs(older_than_days: float | None = None, dry_run: bool = True) -> dict[str, Any]:
+    """Delete the caller's run dirs older than `older_than_days` (default: the
+    server retention window). dry_run previews without deleting. 0 days = all
+    terminal runs. Pinned and queued/running runs are skipped."""
+    days = RUN_RETENTION_DAYS if older_than_days is None else float(older_than_days)
+    max_age_s = max(0.0, days) * 86400.0
+    recs, freed = _sweep_user_root(
+        user_run_root(), user_key(), max_age_s, time.time(),
+        dry_run=dry_run, reason="cleanup")
+    key = "candidates" if dry_run else "deleted"
+    return {"ok": True, "dry_run": dry_run, "older_than_days": days,
+            key: recs, "count": len(recs), "freed_mb": round(freed / 1e6, 1)}
+
+
+def delete_run(run_id: str) -> dict[str, Any]:
+    """Delete one of the caller's run dirs. Refuses while queued/running."""
+    try:
+        run_dir = resolve_run_dir(user_run_root(), run_id)
+    except FileNotFoundError:
+        return {"ok": False, "error": f"Unknown run_id: {run_id}"}
+    if _is_active(run_dir):
+        return {"ok": False, "error": f"Run {run_id} is queued/running — cancel_run first."}
+    freed = round(_dir_size_bytes(run_dir) / 1e6, 1)
+    shutil.rmtree(run_dir, ignore_errors=True)
+    _forget(run_id)
+    audit("run_deleted", run_id=run_id, user=user_key(), freed_mb=freed)
+    return {"ok": True, "run_id": run_id, "deleted": True, "freed_mb": freed}
+
+
+def pin_run(run_id: str) -> dict[str, Any]:
+    """Protect a run from automatic age-based GC (keep indefinitely)."""
+    try:
+        run_dir = resolve_run_dir(user_run_root(), run_id)
+    except FileNotFoundError:
+        return {"ok": False, "error": f"Unknown run_id: {run_id}"}
+    (run_dir / PIN_MARKER).write_text("pinned\n", encoding="utf-8")
+    audit("run_pinned", run_id=run_id, user=user_key())
+    return {"ok": True, "run_id": run_id, "pinned": True}
+
+
+def unpin_run(run_id: str) -> dict[str, Any]:
+    """Remove a run's pin so it is eligible for cleanup again."""
+    try:
+        run_dir = resolve_run_dir(user_run_root(), run_id)
+    except FileNotFoundError:
+        return {"ok": False, "error": f"Unknown run_id: {run_id}"}
+    marker = run_dir / PIN_MARKER
+    was_pinned = marker.exists()
+    marker.unlink(missing_ok=True)
+    audit("run_unpinned", run_id=run_id, user=user_key())
+    return {"ok": True, "run_id": run_id, "pinned": False, "was_pinned": was_pinned}

--- a/mcp_server/skills/simulation/tools.py
+++ b/mcp_server/skills/simulation/tools.py
@@ -11,6 +11,12 @@ from mcp_server.skills.simulation.operations import (
     validate_model_op,
     validate_osw,
 )
+from mcp_server.skills.simulation.retention import (
+    cleanup_runs,
+    delete_run,
+    pin_run,
+    unpin_run,
+)
 
 
 def register(mcp):
@@ -102,3 +108,34 @@ def register(mcp):
         For post-simulation QA/QC with ASHRAE compliance checks, use run_qaqc_checks instead.
         """
         return validate_model_op()
+
+    @mcp.tool(tags={"simulation"}, name="cleanup_runs")
+    def cleanup_runs_tool(older_than_days: float | None = None, dry_run: bool = True):
+        """Reclaim disk by deleting old simulation run directories you own.
+
+        Defaults to a safe preview (dry_run=True) — call again with dry_run=False
+        to actually delete. older_than_days defaults to the server retention
+        window; 0 deletes ALL your terminal runs regardless of age. Pinned and
+        queued/running runs are never deleted. Old runs are also reclaimed
+        automatically; this tool is for on-demand cleanup.
+        """
+        return cleanup_runs(older_than_days=older_than_days, dry_run=dry_run)
+
+    @mcp.tool(tags={"simulation"}, name="delete_run")
+    def delete_run_tool(run_id: str):
+        """Delete one simulation run directory you own to free disk. Cancel the
+        run first if it is still queued or running.
+        """
+        return delete_run(run_id)
+
+    @mcp.tool(tags={"simulation"}, name="pin_run")
+    def pin_run_tool(run_id: str):
+        """Protect a run from automatic age-based cleanup (keep it indefinitely).
+        Use for reference baselines you want to revisit later.
+        """
+        return pin_run(run_id)
+
+    @mcp.tool(tags={"simulation"}, name="unpin_run")
+    def unpin_run_tool(run_id: str):
+        """Remove a run's pin so it becomes eligible for automatic cleanup again."""
+        return unpin_run(run_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openstudio-mcp"
-version = "1.0.0"
+version = "1.0.0-beta"
 description = "Thin MCP server around OpenStudio CLI with async runs and testable outputs."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openstudio-mcp"
-version = "0.9.0"
+version = "1.0.0"
 description = "Thin MCP server around OpenStudio CLI with async runs and testable outputs."
 requires-python = ">=3.11"
 dependencies = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -48,3 +48,5 @@ select = [
 # Deferred imports (PLC0415) avoid load-time failures; global state (PLW0603) is intentional in model_manager
 # ARG001: _extract_*(model, obj) and baseline system signatures require unused args for interface contracts
 "mcp_server/**" = ["BLE001", "S110", "S112", "PLC0415", "PLW0603", "ARG001", "ARG002"]
+# Dev/CLI scripts (stress harness, etc.): deferred imports, broad except, subprocess are intentional
+"scripts/**" = ["BLE001", "S603", "S607", "S110", "PLC0415"]

--- a/scripts/stress_remote.py
+++ b/scripts/stress_remote.py
@@ -144,7 +144,7 @@ async def phase1_worker(url, i, calls, token, m: M):
         print(f"  worker {i} error: {type(e).__name__}: {e}", file=sys.stderr)
 
 
-async def phase2_queue(url, users, token):
+async def phase2_queue(url, users, token, drain=False, timeout=1200):
     from contextlib import AsyncExitStack
     sessions = []
     async with AsyncExitStack() as stack:
@@ -166,21 +166,40 @@ async def phase2_queue(url, users, token):
             d = _unwrap(await sessions[i].call_tool("get_run_status", {"run_id": rid}))
             return d.get("run", {}).get("status") if d.get("ok") else "not_found"
 
-        max_running, samples = 0, 12
-        for _ in range(samples):
-            sts = await asyncio.gather(*[status(i, rid) for i, rid in live])
-            max_running = max(max_running, sum(1 for x in sts if x == "running"))
-            await asyncio.sleep(0.3)
-
+        # Cross-user ownership: session B must not see session A's run.
         cross_blocked = True
         if len(live) >= 2:
-            other = await status(live[1][0], live[0][1])  # session B asks for A's run
-            cross_blocked = (other == "not_found")
+            cross_blocked = (await status(live[1][0], live[0][1]) == "not_found")
 
+        terminal = {"success", "failed", "cancelled", "error"}
+        peak = 0
+        counts: dict[str, int] = {}
+        if drain:
+            t0 = time.perf_counter()
+            while time.perf_counter() - t0 < timeout:
+                sts = await asyncio.gather(*[status(i, rid) for i, rid in live])
+                counts = {}
+                for x in sts:
+                    counts[x] = counts.get(x, 0) + 1
+                peak = max(peak, counts.get("running", 0))
+                print(f"  t={time.perf_counter() - t0:4.0f}s  "
+                      + "  ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+                if all(x in terminal for x in sts):
+                    break
+                await asyncio.sleep(3)
+            return {"launched": len(live), "max_running": peak,
+                    "cross_blocked": cross_blocked, "final": counts, "drained": True}
+
+        # Sample-and-cancel mode (fast: proves cap + ownership without waiting).
+        for _ in range(12):
+            sts = await asyncio.gather(*[status(i, rid) for i, rid in live])
+            peak = max(peak, sum(1 for x in sts if x == "running"))
+            await asyncio.sleep(0.3)
         await asyncio.gather(*[
             sessions[i].call_tool("cancel_run", {"run_id": rid}) for i, rid in live
         ])
-        return {"launched": len(live), "max_running": max_running, "cross_blocked": cross_blocked}
+        return {"launched": len(live), "max_running": peak,
+                "cross_blocked": cross_blocked, "drained": False}
 
 
 def rss_mb(proc) -> float:
@@ -216,15 +235,23 @@ async def amain(args):
 
         # Phase 2
         if args.sims:
-            print("\nPhase 2 — queue saturation (real sims)")
-            q = await phase2_queue(srv.url, args.users, token)
+            mode = "run to completion" if args.drain else "launch + sample + cancel"
+            print(f"\nPhase 2 — queue saturation (real sims, {mode})")
+            q = await phase2_queue(srv.url, args.users, token, drain=args.drain)
             cap_ok = q["max_running"] <= args.cap
             print(f"  sims launched={q['launched']}  cap={args.cap}")
             print(f"  max concurrent running observed={q['max_running']}  "
                   f"(<= cap: {'PASS' if cap_ok else 'FAIL'})")
             print(f"  cross-user run access blocked: {'PASS' if q['cross_blocked'] else 'FAIL'}")
-            print("  (sims cancelled — not run to completion)")
-            result_ok = result_ok and cap_ok and q["cross_blocked"]
+            if q.get("drained"):
+                f = q["final"]
+                ok_n = f.get("success", 0)
+                print(f"  drained: success={ok_n} failed={f.get('failed', 0)} "
+                      f"cancelled={f.get('cancelled', 0)}")
+                result_ok = result_ok and cap_ok and q["cross_blocked"] and ok_n > 0
+            else:
+                print("  (sims cancelled — not run to completion; use --drain to run them)")
+                result_ok = result_ok and cap_ok and q["cross_blocked"]
 
         # Phase 3
         print("\nPhase 3 — memory")
@@ -255,6 +282,7 @@ def main():
     ap.add_argument("--max-sessions", type=int, dest="max_sessions")
     ap.add_argument("--sims", dest="sims", action="store_true", default=None)
     ap.add_argument("--no-sims", dest="sims", action="store_false")
+    ap.add_argument("--drain", action="store_true", help="run sims to completion (not cancel)")
     args = ap.parse_args()
     defs = PROFILES[args.profile]
     for k, v in defs.items():

--- a/scripts/stress_remote.py
+++ b/scripts/stress_remote.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Local stress test for the remote (HTTP) multi-user MCP server.
+
+Spins up ONE HTTP server, opens many concurrent client sessions, and checks the
+multi-user invariants hold under contention:
+
+  Phase 1 (isolation + throughput): each session builds its own model (example=1
+    zone or baseline=10 zones) and hammers get_model/list/create concurrently.
+    Every read must return that session's own zone count — a cross-session bleed
+    shows up as a mismatch. Reports throughput + latency percentiles.
+  Phase 2 (queue saturation): every session launches a real sim at once; we
+    sample statuses and assert running <= MAX_CONCURRENCY at all times, each
+    session sees only its own run, then cancel.
+  Phase 3 (memory): sample the server process RSS to confirm it stays bounded.
+
+Run inside the Docker image, e.g.:
+  docker run --rm -v "$PWD:/repo" -v "$PWD/runs:/runs" openstudio-mcp:dev \
+    bash -lc "cd /repo && python scripts/stress_remote.py --profile moderate"
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import uuid
+
+import psutil
+
+EPW = ("/opt/comstock-measures/ChangeBuildingLocation"
+       "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
+
+
+def _unwrap(res):
+    content = getattr(res, "content", None)
+    if not content:
+        return res if isinstance(res, dict) else {"_raw": str(res)}
+    text = getattr(content[0], "text", None)
+    if text is None:
+        return {"_raw": str(content[0])}
+    try:
+        return json.loads(text.strip())
+    except Exception:
+        return {"_raw": text.strip()}
+
+
+@contextlib.asynccontextmanager
+async def open_session(url: str):
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+    async with streamablehttp_client(url) as (read, write, *_), ClientSession(read, write) as s:
+        await s.initialize()
+        yield s
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _pct(values, q):
+    if not values:
+        return 0.0
+    xs = sorted(values)
+    i = min(len(xs) - 1, round(q * (len(xs) - 1)))
+    return xs[i]
+
+
+class Spawned:
+    def __init__(self, proc, url):
+        self.proc = proc
+        self.url = url
+
+
+def spawn_server(cap: int, max_sessions: int) -> Spawned:
+    port = _free_port()
+    env = os.environ.copy()
+    env.update({
+        "MCP_TRANSPORT": "http", "MCP_HOST": "127.0.0.1", "MCP_PORT": str(port),
+        "MCP_PATH": "/mcp", "MCP_AUTH": "none",
+        "OSMCP_MAX_CONCURRENCY": str(cap), "OSMCP_MAX_SESSIONS": str(max_sessions),
+    })
+    cmd = os.environ.get("MCP_SERVER_CMD", "openstudio-mcp")
+    proc = subprocess.Popen([cmd], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"server exited early (code {proc.returncode})")
+        with socket.socket() as sk:
+            sk.settimeout(0.5)
+            if sk.connect_ex(("127.0.0.1", port)) == 0:
+                return Spawned(proc, f"http://127.0.0.1:{port}/mcp")
+        time.sleep(0.3)
+    proc.terminate()
+    raise TimeoutError("server not ready")
+
+
+class M:
+    def __init__(self):
+        self.latencies: list[float] = []
+        self.errors = 0
+        self.evictions = 0
+        self.isolation_failures = 0
+        self.calls = 0
+
+
+async def phase1_worker(url, i, calls, token, m: M):
+    kind = "example" if i % 2 == 0 else "baseline"
+    create_tool = "create_example_osm" if kind == "example" else "create_baseline_osm"
+    expected = 1 if kind == "example" else 10
+    try:
+        async with open_session(url) as s:
+            await s.call_tool(create_tool, {"name": f"st_{i}_{token}"})
+            m.calls += 1
+            for k in range(calls):
+                t0 = time.perf_counter()
+                d = _unwrap(await s.call_tool("list_thermal_zones", {"max_results": 0}))
+                m.latencies.append(time.perf_counter() - t0)
+                m.calls += 1
+                if "thermal_zones" not in d:
+                    if "model" in str(d.get("error", "")).lower():
+                        m.evictions += 1
+                        await s.call_tool(create_tool, {"name": f"st_{i}_{k}_{token}"})
+                        m.calls += 1
+                        continue
+                    m.errors += 1
+                    continue
+                if len(d["thermal_zones"]) != expected:
+                    m.isolation_failures += 1
+                if k % 5 == 0:
+                    await s.call_tool(create_tool, {"name": f"st_{i}_{k}_{token}"})
+                    m.calls += 1
+            d = _unwrap(await s.call_tool("list_thermal_zones", {"max_results": 0}))
+            if d.get("thermal_zones") is not None and len(d["thermal_zones"]) != expected:
+                m.isolation_failures += 1
+    except Exception as e:
+        m.errors += 1
+        print(f"  worker {i} error: {type(e).__name__}: {e}", file=sys.stderr)
+
+
+async def phase2_queue(url, users, token):
+    from contextlib import AsyncExitStack
+    sessions = []
+    async with AsyncExitStack() as stack:
+        for _ in range(users):
+            sessions.append(await stack.enter_async_context(open_session(url)))
+
+        async def launch(i):
+            cr = _unwrap(await sessions[i].call_tool("create_example_osm", {"name": f"q_{i}_{token}"}))
+            if not cr.get("ok"):
+                return None
+            r = _unwrap(await sessions[i].call_tool(
+                "run_simulation", {"osm_path": cr["osm_path"], "epw_path": EPW}))
+            return r.get("run_id") if r.get("ok") else None
+
+        run_ids = await asyncio.gather(*[launch(i) for i in range(users)])
+        live = [(i, rid) for i, rid in enumerate(run_ids) if rid]
+
+        async def status(i, rid):
+            d = _unwrap(await sessions[i].call_tool("get_run_status", {"run_id": rid}))
+            return d.get("run", {}).get("status") if d.get("ok") else "not_found"
+
+        max_running, samples = 0, 12
+        for _ in range(samples):
+            sts = await asyncio.gather(*[status(i, rid) for i, rid in live])
+            max_running = max(max_running, sum(1 for x in sts if x == "running"))
+            await asyncio.sleep(0.3)
+
+        cross_blocked = True
+        if len(live) >= 2:
+            other = await status(live[1][0], live[0][1])  # session B asks for A's run
+            cross_blocked = (other == "not_found")
+
+        await asyncio.gather(*[
+            sessions[i].call_tool("cancel_run", {"run_id": rid}) for i, rid in live
+        ])
+        return {"launched": len(live), "max_running": max_running, "cross_blocked": cross_blocked}
+
+
+def rss_mb(proc) -> float:
+    try:
+        return psutil.Process(proc.pid).memory_info().rss / 1e6
+    except Exception:
+        return 0.0
+
+
+async def amain(args):
+    token = uuid.uuid4().hex[:6]
+    print("=== openstudio-mcp remote stress test ===")
+    print(f"profile={args.profile} users={args.users} calls={args.calls} cap={args.cap} "
+          f"sims={'on' if args.sims else 'off'} max_sessions={args.max_sessions}")
+    srv = spawn_server(args.cap, args.max_sessions)
+    print(f"server: {srv.url} (pid {srv.proc.pid})  rss_start={rss_mb(srv.proc):.0f}MB\n")
+    result_ok = True
+    try:
+        # Phase 1
+        m = M()
+        t0 = time.perf_counter()
+        await asyncio.gather(*[phase1_worker(srv.url, i, args.calls, token, m) for i in range(args.users)])
+        wall = time.perf_counter() - t0
+        rss_peak = rss_mb(srv.proc)
+        print("Phase 1 — isolation + throughput")
+        print(f"  sessions={args.users} (example/baseline split)  tool calls={m.calls}")
+        iso = "PASS" if m.isolation_failures == 0 else f"FAIL ({m.isolation_failures})"
+        print(f"  isolation: {iso}   evictions_handled={m.evictions}   errors={m.errors}")
+        print(f"  wall={wall:.1f}s  throughput={m.calls / wall:.1f} calls/s")
+        print(f"  latency ms: p50={_pct(m.latencies, .5) * 1e3:.0f} "
+              f"p95={_pct(m.latencies, .95) * 1e3:.0f} p99={_pct(m.latencies, .99) * 1e3:.0f}")
+        result_ok = result_ok and m.isolation_failures == 0 and m.errors == 0
+
+        # Phase 2
+        if args.sims:
+            print("\nPhase 2 — queue saturation (real sims)")
+            q = await phase2_queue(srv.url, args.users, token)
+            cap_ok = q["max_running"] <= args.cap
+            print(f"  sims launched={q['launched']}  cap={args.cap}")
+            print(f"  max concurrent running observed={q['max_running']}  "
+                  f"(<= cap: {'PASS' if cap_ok else 'FAIL'})")
+            print(f"  cross-user run access blocked: {'PASS' if q['cross_blocked'] else 'FAIL'}")
+            print("  (sims cancelled — not run to completion)")
+            result_ok = result_ok and cap_ok and q["cross_blocked"]
+
+        # Phase 3
+        print("\nPhase 3 — memory")
+        print(f"  server RSS: start->peak->end ~ {rss_peak:.0f}MB peak, "
+              f"{rss_mb(srv.proc):.0f}MB now (bounded by max_sessions={args.max_sessions})")
+
+        print(f"\nRESULT: {'PASS' if result_ok else 'FAIL'}")
+    finally:
+        srv.proc.terminate()
+        with contextlib.suppress(Exception):
+            srv.proc.wait(timeout=10)
+    return 0 if result_ok else 1
+
+
+PROFILES = {
+    "smoke": {"users": 8, "calls": 10, "cap": 1, "sims": False, "max_sessions": 64},
+    "moderate": {"users": 24, "calls": 20, "cap": 1, "sims": True, "max_sessions": 64},
+    "heavy": {"users": 64, "calls": 30, "cap": 2, "sims": True, "max_sessions": 128},
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--profile", choices=PROFILES, default="moderate")
+    ap.add_argument("--users", type=int)
+    ap.add_argument("--calls", type=int)
+    ap.add_argument("--cap", type=int)
+    ap.add_argument("--max-sessions", type=int, dest="max_sessions")
+    ap.add_argument("--sims", dest="sims", action="store_true", default=None)
+    ap.add_argument("--no-sims", dest="sims", action="store_false")
+    args = ap.parse_args()
+    defs = PROFILES[args.profile]
+    for k, v in defs.items():
+        if getattr(args, k) is None:
+            setattr(args, k, v)
+    sys.exit(asyncio.run(amain(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,9 @@ def http_server(env_overrides: dict | None = None, port: int | None = None):
     env.update({
         "MCP_TRANSPORT": "http", "MCP_HOST": "127.0.0.1",
         "MCP_PORT": str(port), "MCP_PATH": "/mcp",
+        # Disable the auto-GC daemon by default so the suite never reclaims the
+        # shared /runs out from under other tests; retention tests opt in.
+        "OSMCP_RUN_RETENTION_DAYS": "0",
     })
     if env_overrides:
         env.update(env_overrides)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,15 @@ Public API (no leading underscore):
   EPW_PATH / POLL_SECONDS / SIM_TIMEOUT — simulation constants
 """
 import asyncio
+import contextlib
 import json
 import os
 import shlex
+import socket
+import subprocess
 import time
+from contextlib import asynccontextmanager
+from pathlib import Path
 
 from mcp import StdioServerParameters
 
@@ -122,3 +127,83 @@ async def setup_example(session, model_name):
     assert cr.get("ok") is True
     lr = unwrap(await session.call_tool("load_osm_model", {"osm_path": cr["osm_path"]}))
     assert lr.get("ok") is True
+
+
+# ---------------------------------------------------------------------------
+# HTTP (streamable) transport harness — multi-user isolation tests
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@contextlib.contextmanager
+def http_server(env_overrides: dict | None = None, port: int | None = None):
+    """Spawn the MCP server in streamable-HTTP mode; yield (url, proc).
+
+    Runs inside the same host as pytest, so the client connects to 127.0.0.1 —
+    no published Docker port needed.
+    """
+    port = port or _free_port()
+    cmd = os.environ.get("MCP_SERVER_CMD", "openstudio-mcp")
+    args = shlex.split(os.environ.get("MCP_SERVER_ARGS", "") or "")
+    env = os.environ.copy()
+    env.update({
+        "MCP_TRANSPORT": "http", "MCP_HOST": "127.0.0.1",
+        "MCP_PORT": str(port), "MCP_PATH": "/mcp",
+    })
+    if env_overrides:
+        env.update(env_overrides)
+
+    run_root = Path(os.environ.get("OPENSTUDIO_MCP_RUN_ROOT",
+                                   os.environ.get("OSMCP_RUN_ROOT", "/runs")))
+    run_root.mkdir(parents=True, exist_ok=True)
+    log_path = run_root / f"_httpsrv_{port}.log"
+    logf = log_path.open("w")
+    proc = subprocess.Popen(  # noqa: S603 - cmd is the trusted MCP_SERVER_CMD
+        [cmd, *args], env=env, stdout=logf, stderr=subprocess.STDOUT,
+    )
+
+    def _tail() -> str:
+        try:
+            return "\n".join(log_path.read_text(errors="replace").splitlines()[-30:])
+        except Exception:
+            return "(no server log)"
+
+    try:
+        deadline = time.time() + 60
+        while True:
+            if proc.poll() is not None:
+                raise RuntimeError(f"HTTP server exited (code {proc.returncode}).\n{_tail()}")
+            with socket.socket() as s:
+                s.settimeout(0.5)
+                if s.connect_ex(("127.0.0.1", port)) == 0:
+                    break
+            if time.time() > deadline:
+                raise TimeoutError(f"HTTP server not ready on :{port}.\n{_tail()}")
+            time.sleep(0.3)
+        yield f"http://127.0.0.1:{port}/mcp", proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except Exception:
+            proc.kill()
+        logf.close()
+
+
+@asynccontextmanager
+async def http_session(url: str, token: str | None = None):
+    """Open an initialized MCP ClientSession over streamable HTTP."""
+    # streamablehttp_client (deprecated alias) takes headers/auth directly;
+    # streamable_http_client wants a pre-built httpx client instead.
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    headers = {"Authorization": f"Bearer {token}"} if token else None
+    async with streamablehttp_client(url, headers=headers) as (read, write, _get_sid):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            yield session

--- a/tests/llm/test_01_setup.py
+++ b/tests/llm/test_01_setup.py
@@ -17,9 +17,9 @@ should call exactly these tools, not discover alternatives.
 """
 from __future__ import annotations
 
-import pytest
-
 import re
+
+import pytest
 
 from .conftest import BASELINE_MODEL, save_retrofit_run_id, save_sim_run_id
 from .runner import run_claude
@@ -127,7 +127,7 @@ def test_run_baseline_simulation():
 
     # Also try to extract from the final text (agent usually reports it)
     if not run_id:
-        match = re.search(r"sim_[a-f0-9]{12}", result.final_text)
+        match = re.search(r"\b[a-f0-9]{32}\b", result.final_text)
         if match:
             run_id = match.group(0)
 
@@ -171,7 +171,7 @@ def test_run_retrofit_simulation():
 
     # Fallback: extract from final text
     if not run_id:
-        match = re.search(r"sim_[a-f0-9]{12}", result.final_text)
+        match = re.search(r"\b[a-f0-9]{32}\b", result.final_text)
         if match:
             run_id = match.group(0)
 

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,50 @@
+"""Audit logging: every tool call and the full sim lifecycle are recorded."""
+import asyncio
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+from conftest import EPW_PATH, http_server, http_session, integration_enabled, poll_until_done, unwrap
+
+
+@pytest.mark.integration
+def test_audit_records_tool_calls_and_sim_lifecycle():
+    # Validates: AuditMiddleware logs a tool_call line per invocation, and the sim
+    # dispatcher logs sim_queued/sim_launched/sim_finished — to MCP_AUDIT_FILE.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    token = uuid.uuid4().hex[:8]
+    audit_path = f"/runs/audit_{token}.jsonl"
+    with http_server({"MCP_AUTH": "none", "MCP_AUDIT_FILE": audit_path}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                cr = unwrap(await s.call_tool("create_example_osm", {"name": f"audit_{token}"}))
+                assert cr["ok"] is True, cr
+                r = unwrap(await s.call_tool(
+                    "run_simulation", {"osm_path": cr["osm_path"], "epw_path": EPW_PATH}))
+                assert r["ok"] is True, r
+                await poll_until_done(s, r["run_id"])
+
+        asyncio.run(_run())
+
+        lines = [json.loads(ln) for ln in Path(audit_path).read_text().splitlines() if ln.strip()]
+        events = [e["event"] for e in lines]
+        tools = {e.get("tool") for e in lines if e["event"] == "tool_call"}
+
+        # Every tool invocation is recorded.
+        assert "create_example_osm" in tools, f"tool calls not audited: {tools}"
+        assert "run_simulation" in tools
+        # The full sim lifecycle is recorded (the background-thread events too).
+        assert "sim_queued" in events, f"sim lifecycle incomplete: {sorted(set(events))}"
+        assert "sim_launched" in events
+        assert "sim_finished" in events
+
+        # A tool_call line carries identity, outcome, and timing.
+        tc = next(e for e in lines
+                  if e["event"] == "tool_call" and e.get("tool") == "create_example_osm")
+        assert tc.get("ok") is True, tc
+        assert "user" in tc and "ms" in tc, tc
+        fin = next(e for e in lines if e["event"] == "sim_finished")
+        assert fin.get("status") in ("success", "failed"), fin

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,52 @@
+"""Token auth over HTTP.
+
+MCP_AUTH=token must reject missing/invalid bearer tokens and accept valid ones.
+The authenticated principal (client_id) also scopes the caller's run dir.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import http_server, http_session, integration_enabled, unwrap
+
+
+def _uniq(p: str) -> str:
+    return f"{p}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.integration
+def test_http_token_auth_accepts_valid_rejects_invalid():
+    # Validates: token auth rejects missing/invalid bearer tokens, accepts valid
+    # ones, and the authenticated principal (client_id) scopes the run dir.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    tokens = '{"good-secret-abc": "alice"}'
+    with http_server({"MCP_AUTH": "token", "MCP_TOKENS": tokens}) as (url, _proc):
+        async def _run():
+            # Valid token works, and the principal "alice" scopes the run dir.
+            async with http_session(url, token="good-secret-abc") as s:  # noqa: S106 - test token
+                res = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("authok")}))
+                assert res["ok"] is True, res
+                assert "/alice/" in res["out_dir"], \
+                    f"run dir must be scoped to the authenticated principal: {res['out_dir']}"
+
+            # Missing token: rejected (connection/handshake fails).
+            missing_rejected = False
+            try:
+                async with http_session(url) as s:
+                    await s.call_tool("create_example_osm", {"name": "x"})
+            except Exception:
+                missing_rejected = True
+            assert missing_rejected, "connection without a token must be rejected"
+
+            # Invalid token: rejected.
+            bad_rejected = False
+            try:
+                async with http_session(url, token="wrong-token") as s:  # noqa: S106 - test token
+                    await s.call_tool("create_example_osm", {"name": "x"})
+            except Exception:
+                bad_rejected = True
+            assert bad_rejected, "connection with an invalid token must be rejected"
+
+        asyncio.run(_run())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -50,3 +50,40 @@ def test_http_token_auth_accepts_valid_rejects_invalid():
             assert bad_rejected, "connection with an invalid token must be rejected"
 
         asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_http_jwt_auth_accepts_signed_rejects_unsigned():
+    # Validates: MCP_AUTH=jwt accepts a token signed by the configured public key
+    # (issuer/audience enforced) and rejects connections without one.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    from fastmcp.server.auth.providers.jwt import RSAKeyPair
+
+    kp = RSAKeyPair.generate()
+    issuer, audience = "https://issuer.test", "openstudio-mcp"
+    good = kp.create_token(subject="carol", issuer=issuer, audience=audience)
+    env = {
+        "MCP_AUTH": "jwt",
+        "MCP_JWT_PUBLIC_KEY": kp.public_key,
+        "MCP_JWT_ISSUER": issuer,
+        "MCP_JWT_AUDIENCE": audience,
+    }
+    with http_server(env) as (url, _proc):
+        async def _run():
+            # A token signed by the configured key is accepted.
+            async with http_session(url, token=good) as s:
+                res = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("jwtok")}))
+                assert res["ok"] is True, res
+
+            # No token: rejected.
+            rejected = False
+            try:
+                async with http_session(url) as s:
+                    await s.call_tool("create_example_osm", {"name": "x"})
+            except Exception:
+                rejected = True
+            assert rejected, "JWT mode must reject connections without a token"
+
+        asyncio.run(_run())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -87,3 +87,18 @@ def test_http_jwt_auth_accepts_signed_rejects_unsigned():
             assert rejected, "JWT mode must reject connections without a token"
 
         asyncio.run(_run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("bad_tokens", ["not-json", "[1, 2, 3]"])
+def test_invalid_mcp_tokens_fails_fast_with_clear_error(bad_tokens):
+    # Regression: invalid MCP_TOKENS crashed startup with a cryptic JSONDecodeError /
+    # AttributeError. With MCP_AUTH=token (the HTTP default), it must fail fast with
+    # an actionable message naming MCP_TOKENS.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with pytest.raises(RuntimeError) as exc:  # http_server raises if the server exits at startup
+        with http_server({"MCP_AUTH": "token", "MCP_TOKENS": bad_tokens}):
+            pass
+    assert "MCP_TOKENS must be" in str(exc.value), str(exc.value)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -1,0 +1,29 @@
+"""Streamable-HTTP transport smoke test.
+
+Validates the server can run under HTTP transport (the remote/multi-user
+path) and serve a real tool round-trip, not just stdio.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import http_server, http_session, integration_enabled, unwrap
+
+
+@pytest.mark.integration
+def test_http_server_boots_and_serves_tool():
+    # Validates: server runs under streamable-HTTP transport and a real tool
+    # round-trips over HTTP (proves remote transport works end to end).
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                res = unwrap(await s.call_tool(
+                    "create_example_osm", {"name": f"http_smoke_{uuid.uuid4().hex[:8]}"},
+                ))
+                assert res["ok"] is True, f"create_example_osm over HTTP failed: {res}"
+                assert res["osm_path"].endswith(".osm"), res["osm_path"]
+
+        asyncio.run(_run())

--- a/tests/test_load_save_model.py
+++ b/tests/test_load_save_model.py
@@ -142,8 +142,9 @@ def test_load_nonexistent_file_fails():
             async with ClientSession(read, write) as session:
                 await session.initialize()
 
-                # Try to load a file that doesn't exist
-                fake_path = "/runs/nonexistent_model_xyz123.osm"
+                # Try to load a file that doesn't exist (in an allowed shared root,
+                # so we hit the not-found path rather than the path-scope guard)
+                fake_path = "/inputs/nonexistent_model_xyz123.osm"
                 load_resp = await session.call_tool("load_osm_model", {"osm_path": fake_path})
                 load_result = unwrap(load_resp)
                 print("load_osm_model (nonexistent file):", load_result)

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -43,11 +43,18 @@ class TestSeedFilePathTraversal:
 
         from mcp_server.skills.simulation.operations import run_osw
         run_root = tmp_path / "runs"
-        monkeypatch.setattr(
-            "mcp_server.skills.simulation.operations.RUN_ROOT",
-            run_root,
-        )
         run_root.mkdir()
+        # Per-user run dirs: run_osw resolves its run dir via user_run_root().
+        monkeypatch.setattr(
+            "mcp_server.skills.simulation.operations.user_run_root",
+            lambda: run_root,
+        )
+        # Don't start the background dispatcher thread in-process (it would race
+        # other unit tests that drive _dispatch_once manually).
+        monkeypatch.setattr(
+            "mcp_server.skills.simulation.operations._ensure_dispatcher",
+            lambda: None,
+        )
 
         # Stub Popen so staging completes but subprocess "fails"
         class _FakePopen:
@@ -86,11 +93,18 @@ class TestSeedFilePathTraversal:
 
         from mcp_server.skills.simulation.operations import run_osw
         run_root = tmp_path / "runs"
-        monkeypatch.setattr(
-            "mcp_server.skills.simulation.operations.RUN_ROOT",
-            run_root,
-        )
         run_root.mkdir()
+        # Per-user run dirs: run_osw resolves its run dir via user_run_root().
+        monkeypatch.setattr(
+            "mcp_server.skills.simulation.operations.user_run_root",
+            lambda: run_root,
+        )
+        # Don't start the background dispatcher thread in-process (it would race
+        # other unit tests that drive _dispatch_once manually).
+        monkeypatch.setattr(
+            "mcp_server.skills.simulation.operations._ensure_dispatcher",
+            lambda: None,
+        )
 
         # Stub Popen so staging completes but subprocess "fails"
         class _FakePopen:

--- a/tests/test_per_user_run_dirs.py
+++ b/tests/test_per_user_run_dirs.py
@@ -1,0 +1,55 @@
+"""Per-user run dirs + run ownership + cross-user path scoping (over HTTP).
+
+One session's runs and files must be private: another session can neither read
+its run by id nor load a file under its run root.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import EPW_PATH, http_server, http_session, integration_enabled, unwrap
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+@pytest.mark.integration
+def test_runs_and_files_are_private_per_session():
+    # Regression: a global run registry + unscoped paths let any session read
+    # another's runs/files. Per-user run dirs + ownership must prevent that.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s1, http_session(url) as s2:
+                # --- s1 creates a model and starts a simulation ---
+                cr = unwrap(await s1.call_tool("create_example_osm", {"name": _uniq("ua")}))
+                assert cr["ok"] is True, cr
+                osm1 = cr["osm_path"]
+
+                rs = unwrap(await s1.call_tool(
+                    "run_simulation", {"osm_path": osm1, "epw_path": EPW_PATH},
+                ))
+                assert rs["ok"] is True, rs
+                run1 = rs["run_id"]
+                try:
+                    # s1 sees its own run
+                    own = unwrap(await s1.call_tool("get_run_status", {"run_id": run1}))
+                    assert own["ok"] is True, own
+                    assert own["run"]["run_id"] == run1
+
+                    # s2 must NOT see s1's run (ownership guard)
+                    other = unwrap(await s2.call_tool("get_run_status", {"run_id": run1}))
+                    assert other["ok"] is False, f"s2 must not access s1's run: {other}"
+                    assert "unknown run_id" in other["error"].lower(), other
+
+                    # s2 must NOT load a file under s1's run root (path scoping)
+                    ld = unwrap(await s2.call_tool("load_osm_model", {"osm_path": osm1}))
+                    assert ld["ok"] is False, f"s2 must not read s1's file: {ld}"
+                    assert "not allowed" in ld["error"].lower(), ld
+                finally:
+                    await s1.call_tool("cancel_run", {"run_id": run1})
+
+        asyncio.run(_run())

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,102 @@
+"""Integration: run-retention MCP tools (cleanup_runs / pin_run / delete_run).
+
+Drives real simulations to a terminal state, then exercises the disk-reclaim
+contract end-to-end over HTTP: preview, pin-protection, and per-user-scoped delete.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import (
+    EPW_PATH,
+    http_server,
+    http_session,
+    integration_enabled,
+    poll_until_done,
+    unwrap,
+)
+
+
+def _uniq(p: str) -> str:
+    return f"{p}_{uuid.uuid4().hex[:10]}"
+
+
+@pytest.mark.integration
+def test_cleanup_previews_pins_and_deletes():
+    # Validates: cleanup_runs(dry_run) previews without deleting; a pinned run
+    # survives a real cleanup; after unpin the same cleanup reclaims it.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                cr = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("ret")}))
+                assert cr["ok"] is True, cr
+                rs = unwrap(await s.call_tool(
+                    "run_simulation", {"osm_path": cr["osm_path"], "epw_path": EPW_PATH}))
+                assert rs["ok"] is True, rs
+                run_id = rs["run_id"]
+                await poll_until_done(s, run_id)
+
+                # --- preview: lists the run, deletes nothing ---
+                prev = unwrap(await s.call_tool(
+                    "cleanup_runs", {"older_than_days": 0, "dry_run": True}))
+                assert prev["ok"] is True and prev["dry_run"] is True, prev
+                assert run_id in {c["run_id"] for c in prev["candidates"]}, prev
+                still = unwrap(await s.call_tool("get_run_status", {"run_id": run_id}))
+                assert still["ok"] is True, "dry_run must not delete the run"
+
+                # --- pin, then real cleanup must SKIP the pinned run ---
+                assert unwrap(await s.call_tool("pin_run", {"run_id": run_id}))["pinned"] is True
+                after_pin = unwrap(await s.call_tool(
+                    "cleanup_runs", {"older_than_days": 0, "dry_run": False}))
+                assert run_id not in {d["run_id"] for d in after_pin["deleted"]}, after_pin
+                assert unwrap(await s.call_tool(
+                    "get_run_status", {"run_id": run_id}))["ok"] is True, "pinned run must survive"
+
+                # --- unpin, then cleanup reclaims it for real ---
+                assert unwrap(await s.call_tool("unpin_run", {"run_id": run_id}))["was_pinned"] is True
+                final = unwrap(await s.call_tool(
+                    "cleanup_runs", {"older_than_days": 0, "dry_run": False}))
+                assert run_id in {d["run_id"] for d in final["deleted"]}, final
+                assert final["freed_mb"] > 0, f"reclaiming a real sim must free MB: {final}"
+                gone = unwrap(await s.call_tool("get_run_status", {"run_id": run_id}))
+                assert gone["ok"] is False and "unknown run_id" in gone["error"].lower(), gone
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_delete_run_is_user_scoped():
+    # Regression: delete_run must only touch the caller's own run — another
+    # session's run_id is unknown, never deletable.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s1, http_session(url) as s2:
+                cr = unwrap(await s1.call_tool("create_example_osm", {"name": _uniq("del")}))
+                assert cr["ok"] is True, cr
+                rs = unwrap(await s1.call_tool(
+                    "run_simulation", {"osm_path": cr["osm_path"], "epw_path": EPW_PATH}))
+                assert rs["ok"] is True, rs
+                run_id = rs["run_id"]
+                await poll_until_done(s1, run_id)
+
+                # s2 cannot delete s1's run
+                other = unwrap(await s2.call_tool("delete_run", {"run_id": run_id}))
+                assert other["ok"] is False, f"s2 must not delete s1's run: {other}"
+                assert "unknown run_id" in other["error"].lower(), other
+                assert unwrap(await s1.call_tool(
+                    "get_run_status", {"run_id": run_id}))["ok"] is True, "run must still exist"
+
+                # s1 deletes its own run
+                mine = unwrap(await s1.call_tool("delete_run", {"run_id": run_id}))
+                assert mine["ok"] is True and mine["deleted"] is True, mine
+                assert mine["freed_mb"] > 0, f"deleting a real sim must free MB: {mine}"
+                gone = unwrap(await s1.call_tool("get_run_status", {"run_id": run_id}))
+                assert gone["ok"] is False and "unknown run_id" in gone["error"].lower(), gone
+
+        asyncio.run(_run())

--- a/tests/test_retention_unit.py
+++ b/tests/test_retention_unit.py
@@ -123,9 +123,11 @@ def test_run_root_sanity_guard(path, sane):
     (["--gc"], 14.0, 14.0),               # CLI opt-in honours env window
     (["--gc-days", "3"], 0.0, 3.0),       # CLI sets explicit window
     (["--gc-days", "0"], 7.0, 0.0),       # CLI explicitly turns it off
+    (["--gc-days", "-5"], 0.0, 0.0),      # negative CLI window clamped to off (fail-safe)
+    ([], -3.0, 0.0),                      # negative env window clamped to off
     (["--http"], 30.0, 30.0),             # unrelated args ignored
 ])
 def test_resolve_gc_days_opt_in(argv, env_days, expected):
     # Validates: GC is off unless explicitly enabled (--gc / --gc-days / env>0),
-    # with CLI taking precedence over the env default.
+    # with CLI taking precedence over the env default; negatives clamp to off.
     assert resolve_gc_days(argv, env_days) == expected

--- a/tests/test_retention_unit.py
+++ b/tests/test_retention_unit.py
@@ -1,0 +1,75 @@
+"""Unit: the retention sweep deletes the right run dirs and spares the rest.
+
+Pure filesystem logic — crafts run dirs under tmp_path and runs the sweep with a
+fixed clock, so age/pin/active/run-dir predicates are all checked deterministically
+without Docker, OpenStudio, or a real simulation.
+"""
+import json
+import os
+
+import pytest
+
+from mcp_server.skills.simulation.retention import _sweep_user_root
+
+NOW = 2_000_000_000.0
+OLD = NOW - 100 * 86400      # 100 days old
+FRESH = NOW - 3600           # 1 hour old
+WEEK = 7 * 86400
+
+
+def _mk(root, name, record=None, *, out_osw=False, pinned=False, payload=2048):
+    d = root / name
+    d.mkdir()
+    if record is not None:
+        (d / "run_record.json").write_text(json.dumps(record))
+    if out_osw:
+        (d / "out.osw").write_text("{}")
+    if pinned:
+        (d / ".pinned").write_text("pinned\n")
+    (d / "blob.bin").write_bytes(b"x" * payload)
+    return d
+
+
+@pytest.mark.unit
+def test_sweep_deletes_old_terminal_runs_only(tmp_path):
+    # Validates: GC removes terminal run dirs past the age cutoff, and spares
+    # fresh / pinned / queued / running / non-run dirs — the core retention policy.
+    _mk(tmp_path, "succ_old", {"status": "success", "ended_at": OLD})
+    _mk(tmp_path, "cxl_old", {"status": "cancelled", "ended_at": OLD})
+    _mk(tmp_path, "fail_old", {"status": "failed", "ended_at": OLD})
+    _mk(tmp_path, "running_dead", {"status": "running", "pid": 999_999, "ended_at": OLD})
+    _mk(tmp_path, "outosw_old", out_osw=True)  # no record -> mtime fallback (huge vs NOW)
+
+    _mk(tmp_path, "succ_fresh", {"status": "success", "ended_at": FRESH})       # too young
+    _mk(tmp_path, "queued_old", {"status": "queued", "created_at": OLD})        # active
+    _mk(tmp_path, "running_alive", {"status": "running", "pid": os.getpid(), "created_at": OLD})
+    _mk(tmp_path, "pinned_old", {"status": "success", "ended_at": OLD}, pinned=True)
+    _mk(tmp_path, "examples", {"status": "success", "ended_at": OLD})           # excluded by name
+    stray = tmp_path / "stray"
+    stray.mkdir()
+    (stray / "notes.txt").write_text("not a run")                              # not a run dir
+
+    recs, freed = _sweep_user_root(
+        tmp_path, "u", WEEK, NOW, dry_run=False, reason="gc")
+
+    deleted = {r["run_id"] for r in recs}
+    assert deleted == {"succ_old", "cxl_old", "fail_old", "running_dead", "outosw_old"}, deleted
+    assert freed > 0, "deleting 5 run dirs must free bytes"
+
+    for gone in ("succ_old", "cxl_old", "fail_old", "running_dead", "outosw_old"):
+        assert not (tmp_path / gone).exists(), f"{gone} should be deleted"
+    for kept in ("succ_fresh", "queued_old", "running_alive", "pinned_old", "examples", "stray"):
+        assert (tmp_path / kept).exists(), f"{kept} must be spared"
+
+
+@pytest.mark.unit
+def test_sweep_dry_run_deletes_nothing(tmp_path):
+    # Validates: dry_run previews candidates without touching the filesystem.
+    _mk(tmp_path, "succ_old", {"status": "success", "ended_at": OLD})
+
+    recs, freed = _sweep_user_root(
+        tmp_path, "u", WEEK, NOW, dry_run=True, reason="cleanup")
+
+    assert [r["run_id"] for r in recs] == ["succ_old"]
+    assert freed > 0
+    assert (tmp_path / "succ_old").exists(), "dry_run must not delete"

--- a/tests/test_retention_unit.py
+++ b/tests/test_retention_unit.py
@@ -6,10 +6,11 @@ without Docker, OpenStudio, or a real simulation.
 """
 import json
 import os
+from pathlib import Path
 
 import pytest
 
-from mcp_server.skills.simulation.retention import _sweep_user_root
+from mcp_server.skills.simulation.retention import _run_root_is_sane, _sweep_user_root
 
 NOW = 2_000_000_000.0
 OLD = NOW - 100 * 86400      # 100 days old
@@ -73,3 +74,38 @@ def test_sweep_dry_run_deletes_nothing(tmp_path):
     assert [r["run_id"] for r in recs] == ["succ_old"]
     assert freed > 0
     assert (tmp_path / "succ_old").exists(), "dry_run must not delete"
+
+
+@pytest.mark.unit
+def test_sweep_never_follows_symlink_out_of_tree(tmp_path):
+    # Regression: GC must never delete (or follow) a symlink — a run-shaped link
+    # pointing outside the swept tree, and its target, must be left untouched.
+    user_root = tmp_path / "user"
+    user_root.mkdir()
+    real = _mk(user_root, "real_old", {"status": "success", "ended_at": OLD})
+
+    outside = tmp_path / "outside_secret"   # stands in for "anything outside the MCP"
+    outside.mkdir()
+    (outside / "important.txt").write_text("do not delete")
+    (outside / "out.osw").write_text("{}")  # makes the link *look* like a run dir
+    link = user_root / "evil_link"
+    link.symlink_to(outside, target_is_directory=True)
+
+    recs, _freed = _sweep_user_root(user_root, "u", WEEK, NOW, dry_run=False, reason="gc")
+
+    assert {r["run_id"] for r in recs} == {"real_old"}, "only the real run is reclaimed"
+    assert not real.exists()
+    assert link.is_symlink(), "the symlink itself must be left in place"
+    assert outside.exists() and (outside / "important.txt").exists(), \
+        "external target must survive — GC cannot escape via symlink"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("path", "sane"), [
+    ("/runs", True), ("/runs/sub", True), ("/data/openstudio/runs", True),
+    ("/", False), ("/home", False), ("/tmp", False), ("/etc", False), ("/var", False),  # noqa: S108
+])
+def test_run_root_sanity_guard(path, sane):
+    # Validates: the daemon refuses to sweep a filesystem/system root, so a
+    # misconfigured OSMCP_RUN_ROOT can never turn GC loose on real data.
+    assert _run_root_is_sane(Path(path)) is sane

--- a/tests/test_retention_unit.py
+++ b/tests/test_retention_unit.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 import pytest
 
-from mcp_server.skills.simulation.retention import _run_root_is_sane, _sweep_user_root
+from mcp_server.skills.simulation.retention import (
+    _run_root_is_sane,
+    _sweep_user_root,
+    resolve_gc_days,
+)
 
 NOW = 2_000_000_000.0
 OLD = NOW - 100 * 86400      # 100 days old
@@ -109,3 +113,19 @@ def test_run_root_sanity_guard(path, sane):
     # Validates: the daemon refuses to sweep a filesystem/system root, so a
     # misconfigured OSMCP_RUN_ROOT can never turn GC loose on real data.
     assert _run_root_is_sane(Path(path)) is sane
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("argv", "env_days", "expected"), [
+    ([], 0.0, 0.0),                       # off by default
+    ([], 7.0, 7.0),                       # env opt-in
+    (["--gc"], 0.0, 7.0),                 # CLI opt-in, no env -> default window
+    (["--gc"], 14.0, 14.0),               # CLI opt-in honours env window
+    (["--gc-days", "3"], 0.0, 3.0),       # CLI sets explicit window
+    (["--gc-days", "0"], 7.0, 0.0),       # CLI explicitly turns it off
+    (["--http"], 30.0, 30.0),             # unrelated args ignored
+])
+def test_resolve_gc_days_opt_in(argv, env_days, expected):
+    # Validates: GC is off unless explicitly enabled (--gc / --gc-days / env>0),
+    # with CLI taking precedence over the env default.
+    assert resolve_gc_days(argv, env_days) == expected

--- a/tests/test_session_eviction.py
+++ b/tests/test_session_eviction.py
@@ -1,0 +1,64 @@
+"""Session model-state eviction: idle TTL + LRU cap.
+
+Exercises the eviction policy directly (manipulating the session registry with
+dummy state) — deterministic, no real models or MCP server needed. It imports
+model_manager (which imports openstudio), so it runs in the integration tier.
+"""
+import pytest
+from conftest import integration_enabled
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _guard_and_clean():
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+    import mcp_server.model_manager as mm
+    mm._clear_all()
+    yield
+    mm._clear_all()
+
+
+def test_idle_sessions_evicted_by_ttl(monkeypatch):
+    # Validates: a session idle longer than SESSION_TTL_SECONDS is dropped on sweep,
+    # while a recently-active session is retained.
+    import mcp_server.model_manager as mm
+
+    monkeypatch.setattr(mm, "SESSION_TTL_SECONDS", 100.0)
+    now = mm._now()
+    mm._sessions["stale"] = mm._SessionState(model=object(), path=None, last_access=now - 1000)
+    mm._sessions["fresh"] = mm._SessionState(model=object(), path=None, last_access=now)
+
+    mm._sweep_idle()
+
+    assert "stale" not in mm._sessions, "session idle beyond TTL must be evicted"
+    assert "fresh" in mm._sessions, "recently-active session must be retained"
+
+
+def test_ttl_zero_disables_eviction(monkeypatch):
+    # Validates: SESSION_TTL_SECONDS=0 disables idle eviction entirely.
+    import mcp_server.model_manager as mm
+
+    monkeypatch.setattr(mm, "SESSION_TTL_SECONDS", 0.0)
+    mm._sessions["ancient"] = mm._SessionState(model=object(), path=None, last_access=mm._now() - 10_000)
+
+    mm._sweep_idle()
+
+    assert "ancient" in mm._sessions, "TTL=0 must keep sessions regardless of idle time"
+
+
+def test_lru_cap_evicts_least_recently_used(monkeypatch):
+    # Validates: when at the cap, the least-recently-used session is evicted to make room.
+    import mcp_server.model_manager as mm
+
+    monkeypatch.setattr(mm, "MAX_SESSIONS", 2)
+    monkeypatch.setattr(mm, "SESSION_TTL_SECONDS", 0.0)  # isolate LRU from TTL
+    now = mm._now()
+    mm._sessions["old"] = mm._SessionState(model=object(), path=None, last_access=now - 10)
+    mm._sessions["mid"] = mm._SessionState(model=object(), path=None, last_access=now - 5)
+
+    mm._evict_if_needed(keep="new")  # making room for a third session
+
+    assert "old" not in mm._sessions, "LRU cap must evict the oldest session"
+    assert "mid" in mm._sessions, "the more-recently-used session must survive"

--- a/tests/test_session_isolation.py
+++ b/tests/test_session_isolation.py
@@ -1,0 +1,53 @@
+"""Per-session model isolation over HTTP.
+
+Two client sessions share ONE server process. Each must keep its own loaded
+model. This is the core multi-user guarantee — and the test that fails against
+the old global ``_current_model`` singleton.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import (
+    create_and_load,
+    create_baseline_and_load,
+    http_server,
+    http_session,
+    integration_enabled,
+    unwrap,
+)
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+@pytest.mark.integration
+def test_two_http_sessions_keep_independent_models():
+    # Regression: with the global _current_model singleton, session 2 loading a
+    # model overwrote session 1's. Session-keyed state must keep them separate.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    n1, n2 = _uniq("u1"), _uniq("u2")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            # --- Arrange: two sessions, one process ---
+            async with http_session(url) as s1, http_session(url) as s2:
+                # --- Act ---
+                z1_initial = sorted(await create_and_load(s1, n1))      # example model in s1
+                z2 = sorted(await create_baseline_and_load(s2, n2))     # 10-zone baseline in s2
+
+                after = unwrap(await s1.call_tool("list_thermal_zones", {"max_results": 0}))
+                z1_after = sorted(z["name"] for z in after["thermal_zones"])
+
+                # --- Assert ---
+                assert z1_after == z1_initial, (
+                    f"session 1's model was stomped by session 2: "
+                    f"{z1_after} != {z1_initial}"
+                )
+                assert z1_after != z2, "two sessions must hold different models"
+                assert len(z2) == 10, f"baseline must have 10 zones, got {len(z2)}"
+
+        asyncio.run(_run())

--- a/tests/test_sim_queue.py
+++ b/tests/test_sim_queue.py
@@ -84,3 +84,46 @@ def test_run_simulation_leaves_no_orphan_staging_dir():
                     await s.call_tool("cancel_run", {"run_id": rs["run_id"]})
 
         asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_cancelled_running_sim_stays_cancelled():
+    # Regression: _refresh_status reclassified a cancelled (running) run as "failed"
+    # on the next get_run_status — a killed pid reads as failure — breaking the
+    # cancel contract and corrupting retention/audit (cancelled must stay terminal).
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    async def _status(s, run_id):
+        return unwrap(await s.call_tool("get_run_status", {"run_id": run_id}))["run"]["status"]
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                cr = unwrap(await s.call_tool(
+                    "create_example_osm", {"name": f"cxl_{uuid.uuid4().hex[:8]}"}))
+                assert cr["ok"] is True, cr
+                rs = unwrap(await s.call_tool(
+                    "run_simulation", {"osm_path": cr["osm_path"], "epw_path": EPW_PATH}))
+                assert rs["ok"] is True, rs
+                run_id = rs["run_id"]
+
+                # Wait until the sim is actually running (pid set), not just queued.
+                state = rs["status"]
+                for _ in range(60):
+                    state = await _status(s, run_id)
+                    if state in ("running", "success", "failed"):
+                        break
+                    await asyncio.sleep(0.5)
+                assert state == "running", f"sim never reached running (got {state!r})"
+
+                cancelled = unwrap(await s.call_tool("cancel_run", {"run_id": run_id}))
+                assert cancelled["ok"] is True, cancelled
+
+                # Re-poll: a cancelled run must stay 'cancelled', never flip to 'failed'.
+                for _ in range(3):
+                    again = await _status(s, run_id)
+                    assert again == "cancelled", f"cancelled run reclassified to {again!r}"
+                    await asyncio.sleep(0.3)
+
+        asyncio.run(_run())

--- a/tests/test_sim_queue.py
+++ b/tests/test_sim_queue.py
@@ -6,6 +6,7 @@ test stays fast (no full EnergyPlus completion needed).
 """
 import asyncio
 import uuid
+from pathlib import Path
 
 import pytest
 from conftest import EPW_PATH, http_server, http_session, integration_enabled, unwrap
@@ -47,5 +48,39 @@ def test_queue_caps_concurrent_sims():
 
                 assert running <= 1, f"MAX_CONCURRENCY=1 must cap running at 1, got {statuses}"
                 assert queued >= 2, f"3 sims at cap=1 must queue >=2, got {statuses}"
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_run_simulation_leaves_no_orphan_staging_dir():
+    # Regression: run_simulation staged its OSW into a persistent /runs/<user>/sim_<id>
+    # dir, then run_osw copied that into the real run dir — leaving the sim_* dir behind
+    # forever (unbounded disk). Staging must be ephemeral; only the real run dir persists.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                cr = unwrap(await s.call_tool(
+                    "create_example_osm", {"name": f"orphan_{uuid.uuid4().hex[:8]}"},
+                ))
+                assert cr["ok"] is True, cr
+
+                rs = unwrap(await s.call_tool(
+                    "run_simulation", {"osm_path": cr["osm_path"], "epw_path": EPW_PATH},
+                ))
+                assert rs["ok"] is True, rs
+                run_dir = Path(rs["run_dir"])
+                try:
+                    assert run_dir.exists(), f"real run dir missing: {run_dir}"
+                    assert not run_dir.name.startswith("sim_"), \
+                        f"run_dir must be the real run hex dir, not a staging dir: {run_dir}"
+                    # The user's run root must hold no sim_* staging leftovers.
+                    orphans = sorted(p.name for p in run_dir.parent.glob("sim_*"))
+                    assert orphans == [], f"orphan sim_* staging dir(s) left behind: {orphans}"
+                finally:
+                    await s.call_tool("cancel_run", {"run_id": rs["run_id"]})
 
         asyncio.run(_run())

--- a/tests/test_sim_queue.py
+++ b/tests/test_sim_queue.py
@@ -1,0 +1,51 @@
+"""Integration: the sim queue enforces MAX_CONCURRENCY across concurrent runs.
+
+Launches more simulations than the cap and snapshots their states — the cap
+must hold and the surplus must be queued. Runs are cancelled afterward so the
+test stays fast (no full EnergyPlus completion needed).
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import EPW_PATH, http_server, http_session, integration_enabled, unwrap
+
+
+@pytest.mark.integration
+def test_queue_caps_concurrent_sims():
+    # Validates: with MAX_CONCURRENCY=1 (Docker default), 3 sims -> <=1 running, >=2 queued
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                cr = unwrap(await s.call_tool(
+                    "create_example_osm", {"name": f"q_{uuid.uuid4().hex[:8]}"},
+                ))
+                assert cr["ok"] is True, cr
+                osm = cr["osm_path"]
+
+                run_ids = []
+                for i in range(3):
+                    r = unwrap(await s.call_tool(
+                        "run_simulation",
+                        {"osm_path": osm, "epw_path": EPW_PATH, "name": f"q{i}"},
+                    ))
+                    assert r["ok"] is True, f"run_simulation {i} failed: {r}"
+                    run_ids.append(r["run_id"])
+
+                statuses = [
+                    unwrap(await s.call_tool("get_run_status", {"run_id": rid}))["run"]["status"]
+                    for rid in run_ids
+                ]
+                running = statuses.count("running")
+                queued = statuses.count("queued")
+                # Cancel everything before asserting so we never leak sims on failure.
+                for rid in run_ids:
+                    await s.call_tool("cancel_run", {"run_id": rid})
+
+                assert running <= 1, f"MAX_CONCURRENCY=1 must cap running at 1, got {statuses}"
+                assert queued >= 2, f"3 sims at cap=1 must queue >=2, got {statuses}"
+
+        asyncio.run(_run())

--- a/tests/test_sim_queue_unit.py
+++ b/tests/test_sim_queue_unit.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.unit
 
 def _mk_rec(run_id: str) -> ops.RunRecord:
     return ops.RunRecord(
-        run_id=run_id, name=run_id, status="queued",
+        run_id=run_id, user_key="local", name=run_id, status="queued",
         created_at=0.0, started_at=None, ended_at=None, pid=None,
         run_dir=Path(run_id), osw_path=Path(run_id) / "w.osw",
         epw_path=None, exit_code=None, error=None,
@@ -22,7 +22,9 @@ def _mk_rec(run_id: str) -> ops.RunRecord:
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry():
+def _reset_registry(monkeypatch):
+    # Never touch disk: dummy records have relative run_dirs.
+    monkeypatch.setattr(ops, "_persist_run_record", lambda _rec: None)
     ops._RUNS.clear()
     ops._queue.clear()
     yield

--- a/tests/test_sim_queue_unit.py
+++ b/tests/test_sim_queue_unit.py
@@ -1,0 +1,113 @@
+"""Unit tests for the simulation queue policy (FIFO + concurrency cap).
+
+The queue *logic* is the unit under test; only its dependencies are mocked
+(the subprocess launch and process-liveness check). No Docker/OpenStudio.
+"""
+from pathlib import Path
+
+import pytest
+
+import mcp_server.skills.simulation.operations as ops
+
+pytestmark = pytest.mark.unit
+
+
+def _mk_rec(run_id: str) -> ops.RunRecord:
+    return ops.RunRecord(
+        run_id=run_id, name=run_id, status="queued",
+        created_at=0.0, started_at=None, ended_at=None, pid=None,
+        run_dir=Path(run_id), osw_path=Path(run_id) / "w.osw",
+        epw_path=None, exit_code=None, error=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    ops._RUNS.clear()
+    ops._queue.clear()
+    yield
+    ops._RUNS.clear()
+    ops._queue.clear()
+
+
+def test_queue_caps_running_at_max_concurrency(monkeypatch):
+    # Validates: the dispatcher never launches more than MAX_CONCURRENCY at once
+    monkeypatch.setattr(ops, "MAX_CONCURRENCY", 2)
+    alive: set[int] = set()
+
+    def fake_launch(rec):
+        rec.pid = int(rec.run_id[1:]) + 1000
+        rec.status = "running"
+        alive.add(rec.pid)
+
+    monkeypatch.setattr(ops, "_launch", fake_launch)
+    monkeypatch.setattr(ops, "_pid_alive", lambda pid: pid in alive)
+
+    for i in range(4):
+        rid = f"r{i}"
+        ops._RUNS[rid] = _mk_rec(rid)
+        ops._enqueue(rid)
+    ops._dispatch_once()
+
+    running = [r.run_id for r in ops._RUNS.values() if r.status == "running"]
+    queued = [r.run_id for r in ops._RUNS.values() if r.status == "queued"]
+    assert len(running) == 2, f"cap=2 must cap concurrent runs, got running={running}"
+    assert len(queued) == 2, f"remaining must stay queued, got queued={queued}"
+    assert running == ["r0", "r1"], f"FIFO: first-enqueued launch first, got {running}"
+
+
+def test_slot_frees_on_completion_launches_next_fifo(monkeypatch):
+    # Validates: when a running sim finishes, the next queued sim (FIFO) starts
+    monkeypatch.setattr(ops, "MAX_CONCURRENCY", 1)
+    alive: set[int] = set()
+
+    def fake_launch(rec):
+        rec.pid = int(rec.run_id[1:]) + 1000
+        rec.status = "running"
+        alive.add(rec.pid)
+
+    def fake_refresh(rec):
+        rec.status = "success"
+        return rec
+
+    monkeypatch.setattr(ops, "_launch", fake_launch)
+    monkeypatch.setattr(ops, "_pid_alive", lambda pid: pid in alive)
+    monkeypatch.setattr(ops, "_refresh_status", fake_refresh)
+    monkeypatch.setattr(ops, "_persist_run_record", lambda _rec: None)
+
+    for i in range(3):
+        rid = f"r{i}"
+        ops._RUNS[rid] = _mk_rec(rid)
+        ops._enqueue(rid)
+    ops._dispatch_once()
+    assert ops._RUNS["r0"].status == "running", "first run starts under cap=1"
+    assert ops._RUNS["r1"].status == "queued"
+    assert ops._RUNS["r2"].status == "queued"
+
+    # r0's process exits -> next dispatch reaps it and launches r1
+    alive.discard(ops._RUNS["r0"].pid)
+    ops._dispatch_once()
+    assert ops._RUNS["r0"].status == "success", "finished run is reaped"
+    assert ops._RUNS["r1"].status == "running", "freed slot launches next FIFO run"
+    assert ops._RUNS["r2"].status == "queued", "third run still waits"
+
+
+def test_cancelled_queued_run_is_not_launched(monkeypatch):
+    # Regression: a queued run cancelled before launch must never start
+    monkeypatch.setattr(ops, "MAX_CONCURRENCY", 1)
+    launched: list[str] = []
+    monkeypatch.setattr(ops, "_launch", lambda rec: launched.append(rec.run_id))
+    monkeypatch.setattr(ops, "_pid_alive", lambda _pid: True)
+
+    for i in range(2):
+        rid = f"r{i}"
+        ops._RUNS[rid] = _mk_rec(rid)
+        ops._enqueue(rid)
+    # Cancel the queued tail before any dispatch
+    ops._RUNS["r1"].status = "cancelled"
+    ops._dispatch_once()  # launches r0
+    ops._RUNS["r0"].status = "success"  # free the slot
+    ops._dispatch_once()  # r1 is cancelled -> skipped, nothing else to run
+
+    assert launched == ["r0"], f"cancelled run must be skipped, launched={launched}"
+    assert ops._RUNS["r1"].status == "cancelled"

--- a/tests/test_sim_queue_unit.py
+++ b/tests/test_sim_queue_unit.py
@@ -113,3 +113,37 @@ def test_cancelled_queued_run_is_not_launched(monkeypatch):
 
     assert launched == ["r0"], f"cancelled run must be skipped, launched={launched}"
     assert ops._RUNS["r1"].status == "cancelled"
+
+
+def test_per_user_cap_prevents_monopoly(monkeypatch):
+    # Validates: a per-user cap stops one user taking all global slots — another
+    # user's queued run launches instead (FIFO with per-user fairness).
+    monkeypatch.setattr(ops, "MAX_CONCURRENCY", 4)
+    monkeypatch.setattr(ops, "MAX_CONCURRENCY_PER_USER", 1)
+    running: set[int] = set()
+
+    def fake_launch(rec):
+        rec.pid = hash(rec.run_id) & 0xFFFF
+        rec.status = "running"
+        running.add(rec.pid)
+
+    monkeypatch.setattr(ops, "_launch", fake_launch)
+    monkeypatch.setattr(ops, "_pid_alive", lambda pid: pid in running)
+
+    # alice submits 3, bob submits 2 (alice first in FIFO order).
+    for rid, uk in [("a0", "alice"), ("a1", "alice"), ("a2", "alice"), ("b0", "bob"), ("b1", "bob")]:
+        rec = _mk_rec(rid)
+        rec.user_key = uk
+        ops._RUNS[rid] = rec
+        ops._enqueue(rid)
+    ops._dispatch_once()
+
+    by_user: dict[str, int] = {}
+    for r in ops._RUNS.values():
+        if r.status == "running":
+            by_user[r.user_key] = by_user.get(r.user_key, 0) + 1
+    assert by_user.get("alice", 0) == 1, f"alice must be capped at 1: {by_user}"
+    assert by_user.get("bob", 0) == 1, f"bob must be capped at 1: {by_user}"
+    assert sum(by_user.values()) == 2, f"per-user caps leave global slots idle for fairness: {by_user}"
+    queued = sorted(r.run_id for r in ops._RUNS.values() if r.status == "queued")
+    assert queued == ["a1", "a2", "b1"], f"capped runs must stay queued: {queued}"

--- a/tests/test_skill_registration.py
+++ b/tests/test_skill_registration.py
@@ -125,6 +125,11 @@ EXPECTED_TOOLS = {
     "get_run_logs",
     "get_run_artifacts",
     "cancel_run",
+    # Run retention / disk management
+    "cleanup_runs",
+    "delete_run",
+    "pin_run",
+    "unpin_run",
     "read_file",
     "extract_summary_metrics",
     "copy_file",
@@ -189,7 +194,7 @@ def test_all_skills_registered():
 
 
 def test_all_tool_names_registered():
-    # Validates: all 142 expected tools are registered, no extras — migration backward-compatibility
+    # Validates: all 146 expected tools are registered, no extras — migration backward-compatibility
     """Every expected tool function is registered via mcp.tool()."""
     registered_tools = {}
 

--- a/tests/test_tool_baseline.py
+++ b/tests/test_tool_baseline.py
@@ -55,12 +55,12 @@ def _register_tools_with_docs() -> dict[str, dict]:
 
 
 def test_tool_count():
-    # Validates: total registered tool count matches expected 142 — catches accidental add/remove
-    """Record current tool count — expect 139 before search_api."""
+    # Validates: total registered tool count matches expected 146 — catches accidental add/remove
+    """Record current tool count (146 = 142 + 4 run-retention tools)."""
     tools = _register_tools_with_docs()
     count = len(tools)
     print(f"\nTool count: {count}")
-    assert count == 142, f"Expected 142 tools, got {count}"
+    assert count == 146, f"Expected 146 tools, got {count}"
 
 
 def test_total_schema_chars():
@@ -82,7 +82,7 @@ def test_total_schema_chars():
 
 
 def test_tags_coverage():
-    # Validates: tag coverage measurement — all 142 tools must be tagged post-Phase 2
+    # Validates: tag coverage measurement — all 146 tools must be tagged post-Phase 2
     """Check how many tools have tags. Post Phase 2: expect 100%."""
     tools = _register_tools_with_docs()
     tagged = {name: t for name, t in tools.items() if t["tags"]}
@@ -95,9 +95,9 @@ def test_tags_coverage():
 
     # Assert actual coverage matches expected state
     assert len(tools) > 0, "Should have tools to measure"
-    # Post-Phase 2: all 142 tools are tagged
-    assert len(tagged) == 142, (
-        f"Expected 142 tagged tools, found {len(tagged)}; "
+    # Post-Phase 2: all 146 tools are tagged
+    assert len(tagged) == 146, (
+        f"Expected 146 tagged tools, found {len(tagged)}; "
         f"untagged: {sorted(untagged)}"
     )
 

--- a/tests/test_validate_model.py
+++ b/tests/test_validate_model.py
@@ -5,7 +5,6 @@ Marked with RUN_OPENSTUDIO_INTEGRATION so they only run in Docker.
 from __future__ import annotations
 
 import os
-
 from pathlib import Path
 
 import pytest
@@ -32,7 +31,7 @@ class TestValidateModel:
     def test_no_model_loaded(self):
         # Validates: validate_model_op raises when no model is loaded
         from mcp_server.skills.simulation.operations import validate_model_op
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="model"):
             validate_model_op()
 
     def test_example_model_passes(self):
@@ -54,15 +53,19 @@ class TestValidateModel:
         # Weather file warning is expected (EPW passed via OSW)
         assert any("weather" in w.lower() for w in v["warnings"])
 
-    def test_empty_model_fails(self):
+    def test_empty_model_fails(self, tmp_path):
         # Validates: empty model fails validation with design day error and weather warning
         import openstudio
-        import mcp_server.model_manager as mm
+
+        from mcp_server.model_manager import load_model
         from mcp_server.skills.simulation.operations import validate_model_op
 
+        # Inject an empty in-memory model via the public load path (the old
+        # mm._current_model back-door was removed in the session-keyed refactor).
         model = openstudio.model.Model()
-        mm._current_model = model
-        mm._current_model_path = "/tmp/empty.osm"
+        osm = tmp_path / "empty.osm"
+        model.save(str(osm), True)
+        load_model(osm)
 
         v = validate_model_op()
         assert v["ok"] is False


### PR DESCRIPTION
First major release (beta). openstudio-mcp can now run as a shared, multi-user remote server — while the existing single-container **stdio workflow is unchanged**.

## What's in it

**Transport & auth**
- Streamable **HTTP** transport (`MCP_TRANSPORT=http`) alongside stdio. Works with Claude Code, Cursor, VS Code.
- Bearer-token (`MCP_AUTH=token`) and JWT/IdP (`MCP_AUTH=jwt`) auth; HTTP defaults to fail-closed token auth.

**Per-user isolation**
- Per-session in-memory model with LRU cap + idle-TTL eviction.
- Per-user run directories, path scoping, and run ownership — a user can't see or touch another's runs/files.

**Throughput & ops**
- Global FIFO **simulation queue** with a concurrency cap (+ optional per-user fairness cap).
- Structured JSON **audit log** (tool calls + sim lifecycle + retention events) to stderr / `MCP_AUDIT_FILE`.
- Opt-in **run retention / disk GC** (off by default; `--gc` / `--gc-days` / env), containment-hardened (no symlink escape, no system roots, run-dirs only), plus `cleanup_runs` / `delete_run` / `pin_run` / `unpin_run` tools.

**Fixes**
- stdio resolves to one "local" user owning all of `/runs` (FastMCP's per-connection session id had splintered the single-user workflow and broken direct `/runs/*.osm` saves).
- `run_simulation` no longer leaves orphan `sim_*` staging dirs.
- `cancel_run` persists `cancelled` so cancelled runs are terminal/reclaimable across restarts.

**Docs**
- `docs/remote-multi-user.md` (setup, auth, token issuance, isolation, log-access boundary) and `docs/run-retention.md`.
- README slimmed: tool reference collapsed into `<details>` groups, counts reconciled to **146 tools** / 12 workflow skills.

## Tests
- New CI coverage (shards 2 & 5): HTTP transport, session isolation, token + JWT auth, session eviction, sim queue, per-user run dirs, audit log, retention (unit + integration).
- Tool-count baselines bumped 142 → 146.
- **All 5 integration shards + unit suite pass locally** (556 integration + 252 unit), and the pushed-branch CI run is green.

## Notes
- Version `1.0.0-beta` (PEP 440 → `1.0.0b0`). Tag/release to follow on merge.
- Backward compatible: stdio deployments behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)