### PR TITLE
Document Python measures at parity with Ruby (skill + tests)

### DIFF
--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -60,8 +60,12 @@ extract_summary_metrics(run_id=<retrofit_id>)   # compare to baseline
 
 ## Language Choice
 
-- **Ruby**: Preferred for most measures. Matches OpenStudio SDK documentation and existing measure libraries.
-- **Python**: Works but less common. Use when user prefers Python.
+Both are **fully supported** — `create_measure(language="Ruby"|"Python")` scaffolds, tests
+(minitest for Ruby, pytest for Python), and applies either. Pick per the user's request or
+project convention:
+
+- **Ruby** — matches most OpenStudio SDK docs and existing measure libraries; a fine default when the user has no preference.
+- **Python** — first-class. Same OpenStudio model API, Python syntax (`()` on method calls, 8-space indent, `openstudio.model.*` classes). One caveat the tools handle for you: `openstudio measure -u` can't regenerate `measure.xml` for Python (SDK limitation), so `create_measure`/`edit_measure` write the XML directly — arguments still work at runtime.
 
 ## Common run_body Patterns (Ruby)
 
@@ -106,6 +110,58 @@ extract_summary_metrics(run_id=<retrofit_id>)   # compare to baseline
 
 WARNING: Beams are AIR TERMINALS (connect via `air_loop.addBranchForZone`), NOT zone equipment (`addToThermalZone`).
 
+## Common run_body Patterns (Python)
+
+Same model API, Python syntax: method calls take `()`, classes are `openstudio.model.*`, indent **8 spaces**. Argument values are auto-extracted by the scaffolding — reference them by name.
+
+Python gotchas (different from Ruby):
+- `obj.name()` returns an OptionalString — use `str(obj.name())` or `obj.name().get()`, never bare `obj.name()`.
+- `runner.registerError("msg")` must be followed by `return False` (capital F; it does not halt).
+- Optionals: `opt = surface.construction()` then `if opt.is_initialized(): c = opt.get()`.
+- Unit conversion: `openstudio.convert(val, "W/m^2", "Btu/hr*ft^2").get()`.
+
+### Envelope
+```python
+        for ld in model.getLightsDefinitions():
+            ld.setWattsperSpaceFloorArea(8.0)
+        for inf in model.getSpaceInfiltrationDesignFlowRates():
+            inf.setFlowperExteriorSurfaceArea(0.0003)
+        for s in model.getSurfaces():
+            if s.outsideBoundaryCondition() != "Outdoors":
+                continue
+            # ...
+```
+
+### HVAC
+```python
+        for loop in model.getAirLoopHVACs():
+            for zone in loop.thermalZones():
+                loop.removeBranchForZone(zone)
+                # create new terminal...
+                loop.addBranchForZone(zone, terminal.to_StraightComponent().get())
+```
+
+### Zone Equipment
+```python
+        for zone in model.getThermalZones():
+            bb = openstudio.model.ZoneHVACBaseboardConvectiveElectric(model)
+            bb.setName(f"{str(zone.name())} Baseboard")
+            bb.addToThermalZone(zone)
+```
+
+### Air Terminals (beams)
+```python
+        # CooledBeam (2-pipe, cooling only)
+        coil = openstudio.model.CoilCoolingCooledBeam(model)
+        terminal = openstudio.model.AirTerminalSingleDuctConstantVolumeCooledBeam(model, sch, coil)
+
+        # FourPipeBeam (4-pipe, heating + cooling)
+        cc = openstudio.model.CoilCoolingFourPipeBeam(model)
+        hc = openstudio.model.CoilHeatingFourPipeBeam(model)
+        terminal = openstudio.model.AirTerminalSingleDuctConstantVolumeFourPipeBeam(model, cc, hc)
+```
+(Same beam warning applies: connect via `air_loop.addBranchForZone`, not `addToThermalZone`.)
+
 ## ReportingMeasures
 
 ReportingMeasures run **after simulation** and access SQL results. Use when the user wants to
@@ -139,6 +195,7 @@ apply_measure(measure_dir="/runs/custom_measures/custom_eui_report", run_id="<co
 - Model & SQL boilerplate is auto-generated: `model` and `sql` variables are available in run_body
 - `arguments()` takes no params (not `model`)
 - Includes empty `energyPlusOutputRequests()` stub (edit via `edit_measure` if needed)
+- Works in Python too — `language="Python"`. Query SQL with `val = sql.execAndReturnFirstDouble(query)` then `if val.is_initialized(): runner.registerValue("k", val.get())`.
 
 ## Notes
 

--- a/tests/test_measure_authoring.py
+++ b/tests/test_measure_authoring.py
@@ -30,6 +30,21 @@ PYTHON_ARGS = [
      "required": False, "default_value": "exterior"},
 ]
 
+# A Python ModelMeasure using the documented patterns: iteration over
+# model.getThermalZones(), OptionalString handling via str(z.name()), and an
+# auto-extracted argument (`tag`). 8-space indent (Python measures).
+PY_TAG_BODY = (
+    "        tagged = 0\n"
+    "        for z in model.getThermalZones():\n"
+    "            z.setName(str(z.name()) + ' ' + tag)\n"
+    "            tagged += 1\n"
+    "        runner.registerFinalCondition('Tagged ' + str(tagged) + ' zones')"
+)
+PY_TAG_ARGS = [
+    {"name": "tag", "display_name": "Tag", "description": "Suffix appended to each zone name",
+     "type": "String", "required": False, "default_value": "RETROFIT"},
+]
+
 
 @pytest.mark.integration
 def test_list_custom_measures():
@@ -213,6 +228,55 @@ def test_test_measure_python_passes():
                 }))
                 assert res["ok"] is True, res.get("test_output", "")
                 assert res["passed"] > 0
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_python_model_measure_iterates_applies_and_mutates():
+    # Validates: a Python ModelMeasure built from the documented patterns
+    # (iteration over model.getThermalZones(), OptionalString via str(z.name()),
+    # argument extraction) creates, passes test_measure, applies, and actually
+    # mutates the loaded model — Python measures are first-class, not just scaffolded.
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique("py_apply"))
+
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": _unique("tag_zones"),
+                    "description": "Tag all thermal zones (Python)",
+                    "run_body": PY_TAG_BODY,
+                    "language": "Python",
+                    "arguments": PY_TAG_ARGS,
+                }))
+                assert create["ok"] is True, create
+                assert create["script_file"] == "measure.py"
+
+                # Python measure runs against a real model under pytest
+                tested = unwrap(await s.call_tool("test_measure", {
+                    "measure_dir": create["measure_dir"],
+                    "arguments": {"tag": "QA"},
+                }))
+                assert tested["ok"] is True, tested.get("test_output", "")
+                assert tested["passed"] > 0, tested
+
+                # Apply with an explicit argument override; model is reloaded after
+                applied = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": create["measure_dir"],
+                    "arguments": {"tag": "APPLIED"},
+                }))
+                assert applied["ok"] is True, applied
+
+                zones = unwrap(await s.call_tool("list_thermal_zones", {"max_results": 0}))
+                names = [z["name"] for z in zones["thermal_zones"]]
+                assert names, "example model should have thermal zones"
+                assert all(n.endswith("APPLIED") for n in names), \
+                    f"Python measure must rename every zone via its argument: {names}"
+
     asyncio.run(_run())
 
 

--- a/tests/test_measure_skill_docs.py
+++ b/tests/test_measure_skill_docs.py
@@ -1,0 +1,39 @@
+"""Unit: the measure-authoring skill documents Python at parity with Ruby.
+
+Reads the skill file directly (no Docker/OpenStudio). Guards the regression where
+the skill carried Ruby-only worked examples and framed Python as "less common" —
+steering the AI away from the fully-supported, tested Python measure path.
+"""
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SKILL = (
+    Path(__file__).resolve().parents[1]
+    / ".claude" / "skills" / "measure-authoring" / "SKILL.md"
+)
+
+
+def test_skill_documents_python_run_body_patterns():
+    # Regression: skill had only "Common run_body Patterns (Ruby)" and called
+    # Python "less common"; Python ModelMeasures are fully supported + tested.
+    text = SKILL.read_text(encoding="utf-8")
+
+    # A dedicated Python patterns section with real Python idioms — not just the word "Python".
+    assert "## Common run_body Patterns (Python)" in text, "missing Python patterns section"
+    assert (
+        "for z in model.getThermalZones():" in text
+        or "for s in model.getSurfaces():" in text
+    ), "Python section must show Python iteration syntax (for x in model.get...())"
+    assert "str(" in text and ".name())" in text, \
+        "must document OptionalString handling, e.g. str(obj.name())"
+    assert "openstudio.model." in text, "must reference the Python SDK module path"
+
+
+def test_skill_framing_no_longer_steers_away_from_python():
+    # Regression: 'Python: Works but less common' nudged the AI to avoid Python.
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "less common" not in text, "drop the 'Python is less common' framing"
+    assert "fully supported" in text, "state that both languages are fully supported"


### PR DESCRIPTION
`create_measure` fully supports Python (ModelMeasure + ReportingMeasure, pytest, syntax check, measure.xml workaround) and it's tested — but the **measure-authoring skill** carried Ruby-only worked examples and framed Python as *"works but less common,"* steering agents away from the supported path. This closes that knowledge gap.

## Changes
- **`.claude/skills/measure-authoring/SKILL.md`**: add a "Common run_body Patterns (**Python**)" section (envelope, HVAC, zone equipment, beams) plus Python gotchas (`str(obj.name())` for OptionalString, `return False`, optionals, `openstudio.convert`); reframe "Language Choice" as **both fully supported**; note Python ReportingMeasure SQL access.
- **unit test** (`tests/test_measure_skill_docs.py`): asserts the skill documents Python idioms and dropped the "less common" framing — a knowledge regression guard (no Docker).
- **integration test** (in `tests/test_measure_authoring.py`, already in CI shard 3): a Python ModelMeasure built from the documented patterns (iterate `getThermalZones()`, `str(z.name())`, an argument) → `create_measure` → `test_measure` → `apply_measure` → asserts **every zone was renamed via its argument**. Proves Python is first-class end-to-end, not just scaffolded.

## Tests
- unit: 2 passed
- new + existing Python integration tests: 4 passed
- full `tests/test_measure_authoring.py`: **31 passed** — no regression
- Manually ran the two existing prompt-based LLM tests with this branch mounted (`python_measure_reduce_plugloads`, `python_measure_boiler_efficiency`): **2/2 passed** — sonnet authored a Python measure, ran the author→test→fix→apply loop, ran baseline + retrofit sims, and compared EUI. (LLM tests are local-only, not CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)