### PR TITLE
fix(measures): resolve bare EPW refs in apply_measure; fix dotted companion detection

### DIFF
--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -18,6 +18,7 @@ import openstudio
 
 from mcp_server.config import OSCLI_GEM_PATH, OSCLI_GEMFILE, user_run_root
 from mcp_server.model_manager import get_model, load_model
+from mcp_server.skills.measures.osw_weather import resolve_osw_weather
 from mcp_server.util import resolve_run_dir
 
 
@@ -169,23 +170,19 @@ def apply_measure(
         if arguments:
             measure_args = {k: str(v) for k, v in arguments.items()}
 
-        # Collect file_paths for the OSW — include weather file directory
-        # so the runner can find EPW files referenced by the model
-        file_paths = []
-        epw_file = model.weatherFile()
-        if epw_file.is_initialized():
-            epw_path = epw_file.get().path()
-            if epw_path.is_initialized():
-                epw_str = str(epw_path.get())
-                epw_resolved = Path(epw_str)
-                if epw_resolved.is_file():
-                    file_paths.append(str(epw_resolved.parent))
+        # Resolve the model's weather reference so the OSW runner's
+        # Initialization state doesn't abort on a bare/stale EPW url —
+        # the runner validates weather even for --measures_only.
+        # Tiers: resolvable url -> file_paths; basename in known weather
+        # dirs -> staged into files/; unfindable -> stripped from seed
+        # (snapshot restored onto the reloaded model below)
+        weather = resolve_osw_weather(model, run_dir, temp_osm)
+        file_paths = weather["file_paths"]
+        osw_weather_file = weather["weather_file"]
 
         # Also add directories of any EPW paths passed as arguments
         # (e.g. ChangeBuildingLocation's weather_file_name argument).
-        # Set weather_file in OSW so the runner can resolve the model's
-        # weather reference even if the original EPW path is stale.
-        osw_weather_file = None
+        # An explicit argument EPW overrides model-based resolution.
         if arguments:
             for v in arguments.values():
                 v_str = str(v)
@@ -300,6 +297,23 @@ def apply_measure(
             "run_dir": str(run_dir),
             "arguments_applied": measure_args,
         }
+
+        # If weather was stripped from the seed, restore the original
+        # reference — unless the measure set a new one (e.g.
+        # ChangeBuildingLocation)
+        if weather["stripped_idf"] is not None:
+            reloaded = get_model()
+            if reloaded.weatherFile().is_initialized():
+                result["weather_note"] = (
+                    "model weather reference was unresolvable; measure set a new weather file"
+                )
+            else:
+                reloaded.addObject(weather["stripped_idf"])
+                result["weather_note"] = (
+                    "model weather reference was unresolvable; removed for the "
+                    "measures_only run and restored afterward"
+                )
+
         if runner_messages:
             result["runner_messages"] = runner_messages
         return result

--- a/mcp_server/skills/measures/osw_weather.py
+++ b/mcp_server/skills/measures/osw_weather.py
@@ -1,0 +1,78 @@
+"""Weather-reference resolution for measure OSW runs.
+
+`openstudio run --measures_only` validates the seed model's weather
+reference during workflow Initialization even though no weather data is
+read. Models conventionally store OS:WeatherFile Url as a bare filename
+(resolved at run time against search paths), which the OSW runner cannot
+resolve without help. Resolution tiers:
+
+1. Url resolves as-is -> add its parent dir to OSW file_paths
+2. Basename found in known weather dirs -> stage the EPW into the run's
+   files/ dir and set OSW weather_file (same mechanics as run_osw)
+3. Unfindable -> strip OS:WeatherFile from the temp seed OSM; the caller
+   restores it on the reloaded model (unless the measure set a new one)
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any
+
+import openstudio
+
+from mcp_server.skills.weather.operations import find_epw_by_name
+
+
+def resolve_osw_weather(model: Any, run_dir: Path, temp_osm: Path) -> dict[str, Any]:
+    """Make the temp seed's weather reference survivable by the OSW runner.
+
+    Returns dict with:
+      file_paths: directory strings for the OSW file_paths key
+      weather_file: OSW weather_file value (relative to run_dir), or None
+      stripped_idf: IdfObject snapshot of a stripped OS:WeatherFile, or None
+    """
+    out: dict[str, Any] = {"file_paths": [], "weather_file": None, "stripped_idf": None}
+    wf = model.weatherFile()
+    if not wf.is_initialized():
+        return out
+    url = wf.get().path()
+    if not url.is_initialized():
+        return out
+    epw = Path(str(url.get()))
+
+    # Tier 1: url already resolves (absolute path still valid on this machine)
+    if epw.is_file():
+        out["file_paths"].append(str(epw.parent))
+        return out
+
+    # Tier 2: bare/stale name — look in known weather dirs, stage like run_osw
+    found = find_epw_by_name(epw.name)
+    if found is not None:
+        files_dir = run_dir / "files"
+        files_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(str(found), str(files_dir / found.name))
+        out["weather_file"] = f"files/{found.name}"
+        return out
+
+    # Tier 3: nowhere to be found — measures_only never reads weather data,
+    # so drop the reference from the seed and let the caller restore it
+    out["stripped_idf"] = strip_weather_from_seed(temp_osm)
+    return out
+
+
+def strip_weather_from_seed(temp_osm: Path) -> Any | None:
+    """Remove OS:WeatherFile from a saved seed OSM; return its IdfObject.
+
+    Returns None if the seed can't be loaded or has no weather file.
+    """
+    loaded = openstudio.model.Model.load(openstudio.toPath(str(temp_osm)))
+    if not loaded.is_initialized():
+        return None
+    seed = loaded.get()
+    wf = seed.weatherFile()
+    if not wf.is_initialized():
+        return None
+    snapshot = wf.get().idfObject()
+    wf.get().remove()
+    seed.save(openstudio.toPath(str(temp_osm)), True)
+    return snapshot

--- a/mcp_server/skills/measures/osw_weather.py
+++ b/mcp_server/skills/measures/osw_weather.py
@@ -40,9 +40,12 @@ def resolve_osw_weather(model: Any, run_dir: Path, temp_osm: Path) -> dict[str, 
         return out
     epw = Path(str(url.get()))
 
-    # Tier 1: url already resolves (absolute path still valid on this machine)
+    # Tier 1: url already resolves (absolute path still valid on this
+    # machine). resolve() so a url relative to the server cwd doesn't
+    # produce a relative file_paths entry — the runner executes with
+    # cwd=run_dir and would resolve it against the wrong base
     if epw.is_file():
-        out["file_paths"].append(str(epw.parent))
+        out["file_paths"].append(str(epw.resolve().parent))
         return out
 
     # Tier 2: bare/stale name — look in known weather dirs, stage like run_osw

--- a/mcp_server/skills/weather/operations.py
+++ b/mcp_server/skills/weather/operations.py
@@ -171,9 +171,11 @@ def find_epw_by_name(basename: str) -> Path | None:
         return None
     for d in _epw_search_dirs():
         if d == INPUT_ROOT:
-            hits = sorted(d.rglob(basename))
-            if hits:
-                return hits[0]
+            # First hit short-circuits the recursive walk — same EPW name
+            # means same data, so picking among duplicates is cosmetic
+            hit = next(d.rglob(basename), None)
+            if hit is not None:
+                return hit
         else:
             candidate = d / basename
             if candidate.is_file():

--- a/mcp_server/skills/weather/operations.py
+++ b/mcp_server/skills/weather/operations.py
@@ -96,12 +96,14 @@ def list_weather_files() -> dict[str, Any]:
             if wd.is_dir():
                 sources.append(str(wd))
                 for epw in sorted(wd.glob("*.epw")):
-                    base = epw.with_suffix("")
+                    # with_suffix(".ddy") on the .epw path itself — an
+                    # intermediate with_suffix("") mangles dotted names
+                    # (USA_MA_Boston-Logan.Intl.AP.725090_TMY3 -> ...AP.ddy)
                     weather_files.append({
                         "name": epw.name,
                         "path": str(epw),
-                        "has_ddy": base.with_suffix(".ddy").exists(),
-                        "has_stat": base.with_suffix(".stat").exists(),
+                        "has_ddy": epw.with_suffix(".ddy").exists(),
+                        "has_stat": epw.with_suffix(".stat").exists(),
                     })
 
         # 2. ChangeBuildingLocation measure test EPWs
@@ -109,12 +111,11 @@ def list_weather_files() -> dict[str, Any]:
         if cbl_tests.is_dir():
             sources.append(str(cbl_tests))
             for epw in sorted(cbl_tests.glob("*.epw")):
-                base = epw.with_suffix("")
                 weather_files.append({
                     "name": epw.name,
                     "path": str(epw),
-                    "has_ddy": base.with_suffix(".ddy").exists(),
-                    "has_stat": base.with_suffix(".stat").exists(),
+                    "has_ddy": epw.with_suffix(".ddy").exists(),
+                    "has_stat": epw.with_suffix(".stat").exists(),
                 })
 
         # 3. /inputs directory
@@ -123,12 +124,11 @@ def list_weather_files() -> dict[str, Any]:
             if input_epws:
                 sources.append(str(INPUT_ROOT))
                 for epw in input_epws:
-                    base = epw.with_suffix("")
                     weather_files.append({
                         "name": epw.name,
                         "path": str(epw),
-                        "has_ddy": base.with_suffix(".ddy").exists(),
-                        "has_stat": base.with_suffix(".stat").exists(),
+                        "has_ddy": epw.with_suffix(".ddy").exists(),
+                        "has_stat": epw.with_suffix(".stat").exists(),
                     })
 
         return {
@@ -139,6 +139,46 @@ def list_weather_files() -> dict[str, Any]:
         }
     except Exception as e:
         return {"ok": False, "error": f"Failed to list weather files: {e}"}
+
+
+def _epw_search_dirs() -> list[Path]:
+    """Known EPW locations, priority order: user /inputs first, then
+    openstudio-standards gem data, then ChangeBuildingLocation test files."""
+    dirs: list[Path] = []
+    if INPUT_ROOT.exists():
+        dirs.append(INPUT_ROOT)
+    gem_root = Path(OSCLI_GEM_PATH)
+    dirs.extend(
+        d for d in gem_root.glob("ruby/*/gems/openstudio-standards-*/data/weather")
+        if d.is_dir()
+    )
+    cbl_tests = COMSTOCK_MEASURES_DIR / "ChangeBuildingLocation" / "tests"
+    if cbl_tests.is_dir():
+        dirs.append(cbl_tests)
+    return dirs
+
+
+def find_epw_by_name(basename: str) -> Path | None:
+    """Locate an EPW by exact filename across known weather dirs.
+
+    Resolves bare-filename OS:WeatherFile urls (the OSM convention) to a
+    real file. Exact name match only — EPW filenames encode location, WMO
+    station, and dataset vintage, so same name means same data; guessing a
+    "close" EPW would silently corrupt results. /inputs is searched
+    recursively (user files), gem/comstock dirs are flat.
+    """
+    if not basename.lower().endswith(".epw"):
+        return None
+    for d in _epw_search_dirs():
+        if d == INPUT_ROOT:
+            hits = sorted(d.rglob(basename))
+            if hits:
+                return hits[0]
+        else:
+            candidate = d / basename
+            if candidate.is_file():
+                return candidate
+    return None
 
 
 def get_weather_info() -> dict[str, Any]:

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -5,6 +5,7 @@ Uses a minimal test measure at tests/assets/measures/set_building_name/.
 """
 import asyncio
 import uuid
+from pathlib import Path
 
 import pytest
 from conftest import integration_enabled, server_params, setup_example, unwrap
@@ -18,6 +19,18 @@ def _unique(prefix: str = "pytest_measures") -> str:
 
 # Measure path inside container (repo mounted at /repo)
 MEASURE_DIR = "/repo/tests/assets/measures/set_building_name"
+
+BOGUS_EPW_NAME = "ZZZ_Nowhere.Fake.999999_TMY3.epw"
+
+
+def _bogus_weather_fixture() -> str:
+    """Copy of SystemD_baseline.osm with its weather url renamed to an EPW
+    that exists nowhere on disk. Returns the fixture's container path."""
+    src = Path("/repo/tests/assets/SystemD_baseline.osm").read_text()
+    fixture = Path("/runs") / f"{_unique('pytest_bogus_weather')}.osm"
+    fixture.write_text(src.replace(
+        "USA_MD_Baltimore-Washington.Intl.AP.724060_TMY3.epw", BOGUS_EPW_NAME))
+    return str(fixture)
 
 
 @pytest.mark.integration
@@ -119,6 +132,104 @@ def test_apply_measure_invalid_dir():
                 }))
                 assert res["ok"] is False
                 assert "error" in res, "Missing error message for invalid measure dir"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_apply_measure_bare_weather_filename():
+    """Model whose OS:WeatherFile Url is a bare filename (the OSM convention)."""
+    # Regression: apply_measure failed with "Weather file ... cannot be found" on models
+    # with a bare-filename weather url (e.g. SystemD_baseline.osm) — operations.py only
+    # added the EPW dir to OSW file_paths when the url resolved from server cwd, so the
+    # OSW runner's Initialization state errored before the measure ran
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                # SystemD_baseline.osm has OS:WeatherFile Url =
+                # "USA_MD_Baltimore-Washington.Intl.AP.724060_TMY3.epw" (no path)
+                load = unwrap(await s.call_tool("load_osm_model", {
+                    "osm_path": "/repo/tests/assets/SystemD_baseline.osm",
+                }))
+                assert load["ok"] is True, f"load failed: {load.get('error')}"
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": MEASURE_DIR,
+                    "arguments": {"building_name": "Beam Retrofit Candidate"},
+                }))
+                assert res["ok"] is True, (
+                    f"apply_measure must not require a resolvable weather file for "
+                    f"--measures_only runs: {res.get('error')}"
+                )
+                bldg = unwrap(await s.call_tool("get_building_info", {}))
+                assert bldg["building"]["name"] == "Beam Retrofit Candidate"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_apply_measure_unfindable_weather_stripped_and_restored():
+    """Model EPW exists nowhere — weather stripped from seed, restored after."""
+    # Validates: apply_measure succeeds when the model's EPW url resolves nowhere
+    # (OS:WeatherFile stripped from the OSW seed for --measures_only) and the
+    # reloaded model keeps its original weather reference afterward
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                load = unwrap(await s.call_tool("load_osm_model", {
+                    "osm_path": _bogus_weather_fixture(),
+                }))
+                assert load["ok"] is True, f"load failed: {load.get('error')}"
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": MEASURE_DIR,
+                    "arguments": {"building_name": "Stripped Weather Building"},
+                }))
+                assert res["ok"] is True, f"apply failed: {res.get('error')}"
+                assert "restored" in res["weather_note"], (
+                    f"Expected stripped+restored note, got: {res.get('weather_note')}"
+                )
+                bldg = unwrap(await s.call_tool("get_building_info", {}))
+                assert bldg["building"]["name"] == "Stripped Weather Building"
+                # Original (unresolvable) weather reference must survive the round-trip
+                weather = unwrap(await s.call_tool("get_weather_info", {}))
+                assert weather["ok"] is True, f"weather lost: {weather.get('error')}"
+                assert weather["weather_file"]["url"] == BOGUS_EPW_NAME
+                assert weather["weather_file"]["city"] == "Baltimore Blt Washngtn IntL"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_apply_measure_weather_setting_measure_not_clobbered():
+    """Measure that sets weather (ChangeBuildingLocation) wins over restore."""
+    # Validates: when weather was stripped (unresolvable url) and the measure itself
+    # sets a new weather file, the measure's weather is kept — restore must not
+    # overwrite ChangeBuildingLocation's result with the stale reference
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                load = unwrap(await s.call_tool("load_osm_model", {
+                    "osm_path": _bogus_weather_fixture(),
+                }))
+                assert load["ok"] is True, f"load failed: {load.get('error')}"
+                res = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": "/opt/comstock-measures/ChangeBuildingLocation"
+                                    "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw",
+                }))
+                assert res["ok"] is True, f"change_building_location failed: {res.get('error')}"
+                weather = unwrap(await s.call_tool("get_weather_info", {}))
+                assert weather["ok"] is True
+                assert "Boston" in weather["weather_file"]["url"], (
+                    f"Measure's weather clobbered by restore: {weather['weather_file']}"
+                )
     asyncio.run(_run())
 
 

--- a/tests/test_weather_files.py
+++ b/tests/test_weather_files.py
@@ -60,6 +60,39 @@ def test_list_weather_files_known_city():
 
 
 @pytest.mark.integration
+def test_dotted_epw_names_report_companions():
+    """Dotted EPW filenames must report their .ddy/.stat companions."""
+    # Regression: companion detection used epw.with_suffix("").with_suffix(".ddy"),
+    # which mangles dotted names (USA_MA_Boston-Logan.Intl.AP.725090_TMY3 -> ...AP.ddy)
+    # and reported has_ddy/has_stat False for EPWs whose companions exist on disk
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+                result = unwrap(await session.call_tool("list_weather_files", {}))
+                assert result["ok"] is True
+
+                boston = [
+                    f for f in result["weather_files"]
+                    if f["name"] == "USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+                    and "/opt/comstock-measures/" in f["path"]
+                ]
+                assert boston, "Boston CBL EPW missing from list_weather_files"
+                assert boston[0]["has_ddy"] is True, (
+                    f"Boston .ddy exists on disk but reported absent: {boston[0]}"
+                )
+                assert boston[0]["has_stat"] is True, (
+                    f"Boston .stat exists on disk but reported absent: {boston[0]}"
+                )
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
 def test_weather_file_paths_absolute():
     """All returned paths should be absolute and end with .epw."""
     # Validates: list_weather_files returns absolute paths ending with .epw


### PR DESCRIPTION
Closes #61

## Problem

**Bug 1:** `apply_measure` builds an OSW and runs `openstudio run --measures_only`. The OSW runner validates the seed model's weather reference during Initialization even though measures-only runs never read weather data. The old code only added the EPW dir to OSW `file_paths` when the model's `OS:WeatherFile` Url resolved from the server cwd — never true for bare filenames, which are the OSM convention. Result: any measure application on such models (e.g. `tests/assets/SystemD_baseline.osm`) failed with `Weather file ... specified but cannot be found` before the measure ran. This also broke `change_building_location` and every other common-measure wrapper on affected models.

**Bug 2:** `list_weather_files` companion detection used `epw.with_suffix("").with_suffix(".ddy")`, which mangles dotted names (`USA_MA_Boston-Logan.Intl.AP.725090_TMY3` → `...AP.ddy`). Dotted-name EPWs with companions on disk reported `has_ddy/has_stat: false`, steering agents away from usable weather files.

## Fix

New `mcp_server/skills/measures/osw_weather.py` — tiered resolution before the OSW is written:

1. **Url resolves as-is** → parent dir into OSW `file_paths` (old behavior, absolute paths)
2. **Basename found in known weather dirs** → EPW staged into the run's `files/` + OSW `weather_file` set (same mechanics as `run_osw`)
3. **Unfindable anywhere** → `OS:WeatherFile` stripped from the temp seed (measures-only never reads it); IdfObject snapshot restored on the reloaded model unless the measure set new weather (ChangeBuildingLocation case). `weather_note` key reports what happened.

`find_epw_by_name()` added to the weather skill: exact-filename match across `/inputs` (recursive), openstudio-standards gem data, comstock CBL tests — never guesses a "close" EPW.

Companion detection: `epw.with_suffix(".ddy")` directly on the `.epw` path.

## Tests

All have `# Regression:`/`# Validates:` comments; both files already in CI shards (no `ci.yml` change).

- `test_apply_measure_bare_weather_filename` — written red against the bug, green with fix (tier 2)
- `test_apply_measure_unfindable_weather_stripped_and_restored` — tier 3; weather ref survives round-trip
- `test_apply_measure_weather_setting_measure_not_clobbered` — ChangeBuildingLocation's new weather wins over restore
- `test_dotted_epw_names_report_companions` — Boston CBL EPW must report its on-disk `.ddy`/`.stat`

```
pytest tests/test_measures.py tests/test_weather_files.py  → 13 passed
pytest tests/test_comstock.py                              → 5 passed  (CBL paths)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
