### PR TITLE
feat(remote): out-of-band file transfer for HTTP deployment

### DIFF
--- a/.claude/skills/energy-report/SKILL.md
+++ b/.claude/skills/energy-report/SKILL.md
@@ -38,7 +38,7 @@ Extract all result categories from a completed simulation and present a structur
    run_qaqc_checks()
    ```
 
-4. Present structured report with these sections:
+6. Present structured report with these sections:
 
 ### Report Sections
 

--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -37,6 +37,8 @@ test_measure(measure_dir="/runs/custom_measures/set_lights_8w")
 Tests run against the currently loaded model (or SystemD_baseline.osm fallback),
 so measures that depend on HVAC, plant loops, or zones will work correctly.
 Use `model_path` to test against a specific model.
+Over HTTP, custom measures land under `/runs/<user>/custom_measures` — always use
+the `measure_dir` path that `create_measure` returns, not a hardcoded one.
 
 ### 3. Apply to Model
 ```
@@ -165,7 +167,9 @@ Python gotchas (different from Ruby):
 ## ReportingMeasures
 
 ReportingMeasures run **after simulation** and access SQL results. Use when the user wants to
-generate custom reports, extract specific metrics, or post-process simulation output.
+generate custom reports, extract specific metrics, or post-process simulation output — but only
+when the existing `extract_*` / `query_timeseries` tools don't already cover the metric
+(CLAUDE.md's "never write scripts to parse SQL" rule; this is the sanctioned exception).
 
 ### Create a ReportingMeasure
 ```

--- a/.claude/skills/openstudio-patterns/SKILL.md
+++ b/.claude/skills/openstudio-patterns/SKILL.md
@@ -119,7 +119,7 @@ search_wiring_patterns("four pipe beam")     # get working connection code
 | `"system_type must be 1-10"` | Invalid system number | Check `list_baseline_systems` |
 | Simulation fails, no results | Missing weather file or design days | `change_building_location` (sets EPW + DDY + climate zone) |
 | EUI = 0 or unreasonable | No loads, no HVAC, or no run period | Check `inspect_osm_summary` for missing objects |
-| `"Output directory is not allowed"` | Path outside mounted volumes | Use `/runs/` for output, `/inputs/` for input files |
+| `"Output directory is not allowed"` / `"... path not allowed"` | Path outside your allowed roots (over HTTP each user is scoped to `/runs/<user>/`) | Use `/runs/` for output, `/inputs/` for input files; over HTTP use paths returned by tools |
 
 ## Save vs Simulate
 

--- a/.claude/skills/qaqc/SKILL.md
+++ b/.claude/skills/qaqc/SKILL.md
@@ -29,12 +29,12 @@ Inspect the current model for common issues before running a simulation.
    - **No design days:** needed for HVAC sizing
    - **No run period:** `get_run_period()` — check if simulation dates are set
 
-3. Run ASHRAE QA/QC checks (if model has been simulated):
+4. Run ASHRAE QA/QC checks (if model has been simulated):
    ```
    run_qaqc_checks(template="90.1-2019")
    ```
 
-4. Report findings organized by severity:
+5. Report findings organized by severity:
 
    **Errors** (will cause simulation failure):
    - Missing weather file
@@ -52,4 +52,4 @@ Inspect the current model for common issues before running a simulation.
    - Total conditioned area
    - HVAC system types in use
 
-5. Suggest fixes for each issue found, referencing specific tools.
+6. Suggest fixes for each issue found, referencing specific tools.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             2)
               # common_measures, hvac_systems, geometry, zone terminal, skill_energy_report
               # + remote HTTP transport, session isolation, token auth & session eviction (no-sim, fast)
-              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py"
+              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py tests/test_file_transfer.py"
               EXTRA_ENV=""
               ;;
             3)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,12 +40,19 @@ jobs:
           OSMCP_SANDBOX: "auto"
         run: |
           mkdir -p runs
-          FILES=$(ls tests/test_sandbox.py tests/test_security_*.py 2>/dev/null || true)
-          if [ -z "$FILES" ]; then
+          # Build the list as an array — ls output is newline-separated, and an
+          # unquoted $FILES inside bash -lc "…" split the inner script across
+          # lines, executing the 2nd test file as a command (exit 126).
+          FILES=()
+          [ -f tests/test_sandbox.py ] && FILES+=(tests/test_sandbox.py)
+          for f in tests/test_security_*.py; do
+            [ -e "$f" ] && FILES+=("$f")
+          done
+          if [ ${#FILES[@]} -eq 0 ]; then
             echo "No security tests present in this checkout — nothing to run."
             exit 0
           fi
-          echo "[${{ matrix.arch }}] security tests under OSMCP_SANDBOX=$OSMCP_SANDBOX: $FILES"
+          echo "[${{ matrix.arch }}] security tests under OSMCP_SANDBOX=$OSMCP_SANDBOX: ${FILES[*]}"
           docker run --rm -v "$PWD:/repo" -v "$PWD/runs:/runs" \
             -e RUN_OPENSTUDIO_INTEGRATION -e MCP_SERVER_CMD -e OSMCP_SANDBOX \
-            openstudio-mcp:dev bash -lc "cd /repo && pytest -vv $FILES"
+            openstudio-mcp:dev bash -lc 'cd /repo && pytest -vv "$@"' -- "${FILES[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,12 @@ results — all through 151 MCP tools backed by the OpenStudio SDK.
 Always use openstudio-mcp tools for BEM tasks:
 - Never generate raw IDF files
 - OSM files are created/modified only through MCP tools (create_typical_building, create_new_building, etc)
-- Never write Python/Ruby/others scripts to parse SQL results, create visualizations, build HVAC wiring, or extract data — equivalent MCP tools already exist (extract_*, query_timeseries, view_model, view_simulation_data, add_baseline_system, etc.)
+- Never write Python/Ruby/others scripts to parse SQL results, create visualizations, build HVAC wiring, or extract data — equivalent MCP tools already exist (extract_*, query_timeseries, view_model, view_simulation_data, add_baseline_system, etc.). Sanctioned exception: custom ReportingMeasures via create_measure, when no extract_* tool covers the metric (see measure-authoring skill)
 - If a task genuinely cannot be done with existing tools, ASK THE USER before writing any code or scripts
 - For workflow guidance, run: `list_skills()` or `get_skill("new-building")`
 
 ## Coding Rules
-1. Keep files under ~250 lines — don't split artificially just to hit a number
+1. New files target ~250 lines; don't grow a file past ~400 without splitting by responsibility. Don't split artificially. Legacy large files are grandfathered — split opportunistically when touched
 2. Every MCP tool must have an integration test. New behavior, bug fixes, and security hardening need tests too — not just the happy path
 3. Integration tests must be added to `.github/workflows/ci.yml` — append to the lightest shard's `FILES=` list (5 shards, keep balanced ~200s each)
 4. Follow testing rules in `.claude/rules/testing.md`. Critical: every test needs `# Regression:` or `# Validates:` comment; never delete failing tests or weaken assertions; assert exact values not existence; integration tests mock nothing; unit tests never import `openstudio`
@@ -52,7 +52,7 @@ Two real classes of stdout pollution corrupt MCP JSON-RPC — two-layer defense 
 docker build -f docker/Dockerfile -t openstudio-mcp:dev .
 ```
 
-Run all tests (single container, fastest, matches CI):
+Run all tests (single container, fastest; same suite CI runs across 5 shards):
 ```bash
 docker run --rm \
   -v "C:/projects/openstudio-mcp:/repo" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@ always be brutally honest
 ## Project: openstudio-mcp
 MCP server giving AI agents full control of building energy modeling —
 create buildings, author measures, configure HVAC, run EnergyPlus sims, extract
-results — all through 146 MCP tools backed by the OpenStudio SDK.
+results — all through 151 MCP tools backed by the OpenStudio SDK.
 
 ## Critical: Use MCP Tools — Do Not Reinvent
 Always use openstudio-mcp tools for BEM tasks:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Model Context Protocol server for [OpenStudio](https://openstudio.net/) building energy simulation.** It lets MCP hosts — Claude Desktop, Claude Code, Cursor, VS Code — create, query, and modify OpenStudio models, run EnergyPlus, and read results, all in plain language. The server handles the OpenStudio/EnergyPlus complexity behind MCP tool calls.
 
-**146 tools · 12 workflow skills · 480+ integration tests**
+**151 tools · 12 workflow skills · 480+ integration tests**
 
 ---
 
@@ -90,6 +90,8 @@ Look for the **hammer icon** in Claude Desktop's input — click it to see the o
 ## Remote & multi-user (HTTP)
 
 The quick start runs one container per user over stdio. To host it on one machine and let teammates connect from their own laptops — each with an isolated session, run directory, and optional bearer-token or JWT auth — run it over streamable HTTP (`-e MCP_TRANSPORT=http`). Works with Claude Code, Cursor, and VS Code.
+
+Since a remote server can't see files on your laptop, the `file_transfer` tools (`request_upload` / `get_upload` / `request_download`) move models, weather files, and measure `.zip`s in and out over a signed, out-of-band channel — see **[docs/remote-multi-user.md §6](docs/remote-multi-user.md)**.
 
 See **[docs/remote-multi-user.md](docs/remote-multi-user.md)** for setup, auth, the isolation model, and log access — and **[docs/run-retention.md](docs/run-retention.md)** for optional disk garbage-collection.
 
@@ -190,7 +192,7 @@ Workflow/task skills are invoked with `/name`; knowledge skills load automatical
 
 ## Tool reference
 
-146 tools, grouped by area — expand a group to see its tools. New here? `create_new_building`, `run_simulation`, and `extract_summary_metrics` cover most workflows; `list_skills()` and `recommend_tools(task)` help the AI find the rest.
+151 tools, grouped by area — expand a group to see its tools. New here? `create_new_building`, `run_simulation`, and `extract_summary_metrics` cover most workflows; `list_skills()` and `recommend_tools(task)` help the AI find the rest.
 
 <details>
 <summary><b>Model creation & management</b> — 13 tools</summary>

--- a/docs/plans/plan-remote-file-transfer.md
+++ b/docs/plans/plan-remote-file-transfer.md
@@ -1,0 +1,139 @@
+# Plan: Remote File Transfer (HTTP deployment)
+
+**Branch:** `feat/remote-file-transfer` (off `origin/develop` @ 6c5d0e0)
+**Depends on:** multi-user-remote-mcp (HTTP transport, token/JWT auth, per-user
+`RUN_ROOT/<user_key>/`, path allowlist, per-tenant-UID sandbox) — all shipped.
+**Status:** Implemented + verified — 24/24 (7 integration over HTTP harness + 17
+unit) pass in Docker; ruff clean. New skill `mcp_server/skills/file_transfer/`,
+CLI `mcp_server/tools/osmcp.py`, CI shard 4, docs §6.
+
+**Q1 resolved (empirically):** FastMCP `custom_route` is NOT behind the `auth=`
+verifier — a custom route serves 200 with no/bad token. So signed URLs are the
+route's authorization (not optional). No bearer required on the routes.
+
+## 1. Problem
+
+Remote/HTTP server: every file tool takes a **server-side path**
+(`load_osm_model(osm_path)`, `apply_measure(measure_dir)`,
+`change_building_location(weather_file)`, `import_floorspacejs`). User's `.osm`,
+custom measure **.zip**, `.epw`/`.ddy`/`.stat`, FloorspaceJS `.json` live on the
+**laptop**. No path on the server points at them.
+
+Why in-band (base64 tool arg) is dead: MCP tool args are emitted by the LLM, so
+a 1 MB OSM ≈ 1.4 MB base64 ≈ ~350K tokens — and file bytes would land in context
++ audit logs. **Bytes must move out-of-band, beside the protocol, not through it.**
+
+## 2. Locked decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Out-of-band HTTP, not in-band base64** | Cost + log hygiene; only viable path for real model files |
+| 2 | **Local-disk sidecar** (not object store) | Matches Pattern-A target (VPN/Tailscale single box); reuses all isolation. Object store = multi-box follow-up |
+| 3 | **Presigned (HMAC) URLs**, not bearer-on-route | Authenticated `request_upload` mints short-TTL signed URL bound to (user, file_id, op). Route verifies signature → token never enters model context; leaked URL expires fast + scoped to one file |
+| 4 | **Land in existing sandbox**: `RUN_ROOT/<user_key>/uploads/<file_id>/` | Already the only writable, per-tenant-UID, allowlisted area — `is_path_allowed`, UID drop, `reject_escaping_symlinks` reused for free |
+| 5 | **Auto-extract archives on ingest** | `.zip` → guarded extract, return resolved dir for `apply_measure`. One round-trip |
+| 6 | **One general ingest tool**, type-agnostic transport | Per-type logic is post-ingest only (OSM single file / weather set / measure dir) |
+| 7 | **Both uploaders**: agent-curl default + thin CLI fallback | Claude Code/Cursor/VS Code have local shell; CLI for shell-less clients |
+| 8 | **Existing consuming tools unchanged** | They already accept allowlisted paths; uploads land under the user's own run root = readable |
+
+## 3. Flow
+
+```
+request_upload(filename, sha256, size, kind?)   ← authenticated MCP call
+   → server: mint file_id, mkdir uploads/<file_id>/, record pending meta,
+             return {file_id, upload_url=signed, expires_at, max_size}
+[agent] curl --upload-file model.osm "<upload_url>"   ← out-of-band PUT, no bearer
+   → route /files/u/{file_id}?sig=…&exp=…: verify HMAC+TTL+size, stream to disk,
+             verify sha256, (if .zip/kind=measure) guarded extract, mark ready
+get_upload(file_id)  → {ready, server_path, extracted_path?}
+load_osm_model(osm_path=server_path)   ← existing tool, unchanged
+```
+
+Download (outputs back): `request_download(path|run_id+artifact)` → signed GET URL
+→ `GET /files/d/{token}` streams bytes (saved OSM, HTML reports, CSV). `read_file`
+stays for small text; binary GET is for large/binary artifacts.
+
+## 4. Components
+
+- **New skill `mcp_server/skills/file_transfer/`**
+  - `tools.py` — `request_upload`, `get_upload`, `list_uploads`, `delete_upload`,
+    `request_download`; plus `@mcp.custom_route` for `PUT /files/u/{id}` +
+    `GET /files/d/{token}`. All thin → call operations.
+  - `operations.py` — file_id minting, HMAC sign/verify, streamed write w/ size
+    cap, sha256 verify, archive extraction guards, quota accounting. (split if >250 LOC)
+  - `SKILL.md`
+- **`config.py`** — `OSMCP_MAX_UPLOAD_MB` (default 200), `OSMCP_USER_QUOTA_MB`,
+  `OSMCP_FILE_SIGNING_KEY` (HMAC secret; refuse to start signed URLs if unset on
+  HTTP), `OSMCP_UPLOAD_URL_TTL` (default 300s). `uploads/` already under run_root
+  → `is_path_allowed` covers it.
+- **CLI helper** `tools/osmcp_put.py` / `osmcp_get.py` (or a `osmcp` console entry)
+  — calls `request_upload`, curls bytes. ~50 LOC each.
+- **Docs** — extend `docs/remote-multi-user.md`; client-setup snippet.
+
+## 5. Security
+
+| Threat | Mitigation | Source |
+|---|---|---|
+| Bytes in LLM ctx / audit log | Out-of-band channel; log name/size/sha256 only | new |
+| Token leakage to model | Presigned URL carries no bearer | new |
+| Cross-tenant read/write | file_id under `user_key`; download path checked vs requester run_root | reuse (run-ownership pattern) |
+| Path traversal via filename | **Server** mints file_id path; filename = metadata only, sanitized | new |
+| Malicious measure/OSM | Exec as dropped tenant UID under Landlock+seccomp | reuse sandbox |
+| Zip-bomb | Decompressed-size cap + entry-count cap | new |
+| Zip path/symlink escape | Reject `..`/absolute entries; `reject_escaping_symlinks` on extracted tree | reuse + new |
+| Integrity | client `sha256` verified on close | new |
+| Resource exhaustion | per-upload size cap (mid-stream abort) + per-user quota + TTL GC | new |
+| URL replay | short TTL + one-time consume on PUT | new |
+| TLS | deployer perimeter (VPN/proxy) | unchanged |
+| **DAC: sandbox UID must read uploads** | ensure `uploads/` perms let dropped tenant UID read at measure/sim exec (apply_measure already copies measure into run dir before exec) | integration w/ sandbox — verify |
+
+## 6. Tests (split: functional vs adversarial)
+
+**`tests/test_file_transfer.py`** — functional, CI shard 4: upload→`load_osm_model`
+round-trip; measure `.zip` auto-extract → `list_measure_arguments`; download round-trip.
+
+**`tests/test_security_file_transfer.py`** — adversarial; auto-runs in `security.yml`
+on amd64 + arm64 (globs `test_security_*.py`): forged-sig 403; traversal filename
+neutralized; sha/size tampering 422; oversize at mint + mid-stream 413; cross-user
+read/download denied; **download path-escape (`/etc/passwd`) denied (exfil guard)**;
+upload replay 409; **zip-bomb over the live route 422**; **per-user quota enforced**;
+**isolation under real token auth (signed PUT needs no bearer)**.
+
+**`tests/test_file_transfer_unit.py`** — `-m unit`, Docker (no openstudio): HMAC
+sign/verify + tamper/expiry/wrong-op; filename sanitize (parametrized); archive
+guards (escape, symlink member, bomb, entry cap, clean); finalize size/sha mismatch.
+
+Verified: 17 unit + 3 functional + 10 security = 30 pass; ruff clean; full
+`-m "not integration"` = 218 pass (tool-count gates updated 146→151).
+
+## 7. Out of scope (follow-ups)
+
+- Object store (S3/MinIO presigned) for multi-box / cloud
+- Resumable/chunked upload for very large files
+- Antivirus/content scanning beyond magic-byte + sandbox
+- Client-native file sync (no MCP host supports it today)
+
+## 8. Decisions taken (was: unresolved)
+
+1. **custom_route auth** — RESOLVED: not behind `auth=`; signed URL is the route
+   authz. No bearer on routes.
+2. **Size cap** — `OSMCP_MAX_UPLOAD_MB=200`, env-tunable (smart default).
+3. **Quota** — `OSMCP_USER_QUOTA_MB=4096`, env-tunable; checked at mint against
+   `uploads/` size. (Standalone, not folded into run-retention GC.)
+4. **CLI** — `python -m mcp_server.tools.osmcp put|get` (module entry, no pyproject
+   console script needed). Agent-curl remains the default path.
+5. **Signing key** — auto-generate + persist `RUN_ROOT/.file_signing_key` (0600)
+   if `OSMCP_FILE_SIGNING_KEY` unset; env overrides for rotation/multi-box.
+6. **Report download** — both: single-file GET (`path=`) and zip-on-the-fly bundle
+   (`run_id=...&bundle=True`).
+
+## 9. Residuals / follow-ups
+
+- DAC: uploaded files are written by the server process; `apply_measure` copies
+  the measure into a per-run dir and the sandbox chowns it to the tenant uid
+  before exec, so the dropped uid reads the copy (not the upload) — verified by
+  `test_measure_zip_autoextract`. Watch if a future tool reads an upload *in place*
+  under the dropped uid.
+- Single `.epw` upload has no `.ddy`/`.stat` companions — upload them together as
+  a `kind="weather"` zip (auto-extracted side by side) or as separate files.
+- Object store (S3/MinIO presigned) still the multi-box / cloud follow-up.

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -198,6 +198,13 @@ Don't expose port 8000 to the public internet directly.
 | `OSMCP_RETENTION_SWEEP_SECONDS` | `3600` | how often the retention daemon sweeps (60s floor) |
 | `MCP_AUDIT` | `on` | structured audit logging (tool calls + sim lifecycle); `off` to disable |
 | `MCP_AUDIT_FILE` | — | also append audit JSON lines to this file (e.g. `/runs/audit.log`) |
+| `OSMCP_MAX_UPLOAD_MB` | `200` | max size of a single uploaded file |
+| `OSMCP_USER_QUOTA_MB` | `4096` | per-user cap on total bytes under `uploads/` (`0` = unlimited) |
+| `OSMCP_UPLOAD_URL_TTL` | `300` | seconds a signed upload/download URL stays valid |
+| `OSMCP_MAX_ARCHIVE_UNCOMPRESSED_MB` | `1024` | zip-bomb cap on extracted archive size |
+| `OSMCP_MAX_ARCHIVE_ENTRIES` | `5000` | max entries in an uploaded archive |
+| `OSMCP_PUBLIC_BASE_URL` | — | external base URL so file URLs are absolute (else a relative path is returned) |
+| `OSMCP_FILE_SIGNING_KEY` | auto | HMAC key for signed file URLs (auto-generated + persisted under `RUN_ROOT` if unset) |
 
 Auto-GC of old run dirs is **off by default**. Enable it with `openstudio-mcp --gc`
 (7-day window), `openstudio-mcp --gc-days 14`, or `OSMCP_RUN_RETENTION_DAYS=14`
@@ -207,7 +214,47 @@ for the full setup, safety model, and the `cleanup_runs` / `delete_run` /
 
 ---
 
-## 6. Limitations / not yet
+## 6. Getting your files to & from the server
+
+Over HTTP the server runs on a different machine, so a tool path like
+`load_osm_model(osm_path=...)` can't see a file on your laptop. Move it across
+**out-of-band** with the `file_transfer` tools — bytes travel beside the MCP
+protocol (never through the model context), authorized by a short-lived
+HMAC-signed URL.
+
+**Upload (agent-driven):**
+
+1. `request_upload(filename, size_bytes[, sha256, kind])` → `{file_id, upload_url}`
+2. `curl --upload-file model.osm "<upload_url>"`
+3. `get_upload(file_id)` → `server_path` (or `extracted_path` for a `.zip`)
+4. pass that path to `load_osm_model` / `apply_measure` / `change_building_location`
+
+A `.zip` (or `kind="measure"`) is auto-extracted server-side, guarded against
+zip bombs and path/symlink escapes; `extracted_path` points at the measure dir.
+
+**Download:** `request_download(path=...)` (single file) or
+`request_download(run_id=..., bundle=True)` (zip a run's `reports/`) →
+`download_url`; `curl -O -J "<download_url>"`. Small text → use `read_file`.
+
+**CLI (shell-less clients):**
+
+```bash
+export OSMCP_URL=http://box:8000/mcp OSMCP_TOKEN=s3cret-abc
+python -m mcp_server.tools.osmcp put my_measure.zip --kind measure   # prints server path
+python -m mcp_server.tools.osmcp get /runs/<user>/<run>/exports/model.osm -o model.osm
+```
+
+**Security.** Uploads land only in your own sandboxed `RUN_ROOT/<user>/uploads/`
+(another tenant can't read them). The server mints the `file_id`, so a hostile
+filename can't traverse paths. Enforced: `OSMCP_MAX_UPLOAD_MB`,
+`OSMCP_USER_QUOTA_MB`, optional sha256 integrity, and archive bomb/escape guards.
+The signed URL carries no bearer token, so it never enters the model context and
+expires after `OSMCP_UPLOAD_URL_TTL`. If a reverse proxy fronts the server, set
+`OSMCP_PUBLIC_BASE_URL` so the returned URLs are absolute.
+
+---
+
+## 7. Limitations / not yet
 
 - **Single box only** — in-memory model state isn't shared across machines.
   Horizontal scale would need a per-user-container topology behind a router.
@@ -218,7 +265,7 @@ See `docs/plans/multi-user-remote-mcp.md` for the full design rationale.
 
 ---
 
-## 7. Stress testing locally
+## 8. Stress testing locally
 
 `scripts/stress_remote.py` drives many concurrent sessions at one server and
 asserts the multi-user invariants under load — session isolation, the sim

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -168,6 +168,24 @@ SANDBOX_RLIMIT_NOFILE = _safe_int(os.environ.get("OSMCP_SANDBOX_RLIMIT_NOFILE", 
 SANDBOX_RLIMIT_CPU = _safe_int(os.environ.get("OSMCP_SANDBOX_RLIMIT_CPU", "0"), 0)
 SANDBOX_RLIMIT_AS = _safe_int(os.environ.get("OSMCP_SANDBOX_RLIMIT_AS", "0"), 0)
 
+# --- Remote file transfer (HTTP deployment) -----------------------------------
+# Over HTTP the user's files live on their laptop, not the server. Bytes move
+# out-of-band via signed PUT/GET routes (see skills/file_transfer); these knobs
+# bound and locate that channel. All sizes are megabytes.
+OSMCP_MAX_UPLOAD_MB = _safe_int(os.environ.get("OSMCP_MAX_UPLOAD_MB", "200"), 200)
+# Per-user cap on total bytes resident under their uploads/ dir (0 = unlimited).
+OSMCP_USER_QUOTA_MB = _safe_int(os.environ.get("OSMCP_USER_QUOTA_MB", "4096"), 4096)
+# How long a minted upload/download URL stays valid (seconds).
+OSMCP_UPLOAD_URL_TTL = _safe_int(os.environ.get("OSMCP_UPLOAD_URL_TTL", "300"), 300)
+# Zip-bomb backstops for auto-extracted archives.
+OSMCP_MAX_ARCHIVE_UNCOMPRESSED_MB = _safe_int(
+    os.environ.get("OSMCP_MAX_ARCHIVE_UNCOMPRESSED_MB", "1024"), 1024)
+OSMCP_MAX_ARCHIVE_ENTRIES = _safe_int(os.environ.get("OSMCP_MAX_ARCHIVE_ENTRIES", "5000"), 5000)
+# Externally reachable base URL of THIS server (e.g. https://box.example). The
+# server can't know its own proxy-fronted URL, so when unset request_upload
+# returns a relative path and the client prepends the same host it uses for /mcp.
+OSMCP_PUBLIC_BASE_URL = os.environ.get("OSMCP_PUBLIC_BASE_URL", "").rstrip("/")
+
 # Shared roots are read-only for everyone; the only per-user writable area is
 # RUN_ROOT/<user_key> (see user_run_root). Writes elsewhere are denied.
 _SHARED_READ_ROOTS = [
@@ -192,6 +210,33 @@ def user_run_root() -> Path:
     root = (RUN_ROOT if key == LOCAL else RUN_ROOT / key).resolve()
     root.mkdir(parents=True, exist_ok=True)
     return root
+
+
+def run_root_for(key: str) -> Path:
+    """Run root for an EXPLICIT user key (no identity context needed).
+
+    The signed file-transfer routes run outside MCP request context, so they
+    can't call user_run_root() (which resolves identity per-call). They pass the
+    key carried in the verified URL signature here instead. LOCAL owns the whole
+    RUN_ROOT, matching user_run_root().
+    """
+    from mcp_server.identity import LOCAL
+    root = (RUN_ROOT if key == LOCAL else RUN_ROOT / key).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def is_path_allowed_for(key: str, p: Path, *, write: bool = False) -> bool:
+    """is_path_allowed but for an EXPLICIT user key (used by signed routes)."""
+    rp = p.resolve()
+    own = run_root_for(key)
+    if _under(rp, own):
+        return True
+    if _under(rp, RUN_ROOT):
+        return False
+    if write:
+        return False
+    return any(_under(rp, root) for root in _SHARED_READ_ROOTS)
 
 
 def _under(p: Path, root: Path) -> bool:

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -57,7 +57,7 @@ def _build_auth():
 mcp = FastMCP(
     "openstudio-mcp",
     instructions=(
-        "Building energy simulation server (OpenStudio SDK) with 146 tools for "
+        "Building energy simulation server (OpenStudio SDK) with 151 tools for "
         "creating, modifying, simulating, and analyzing building energy models. "
         "Use these tools for all building energy modeling tasks — if no tool "
         "exists for a task, ask the user before writing code. "

--- a/mcp_server/skills/file_transfer/SKILL.md
+++ b/mcp_server/skills/file_transfer/SKILL.md
@@ -1,0 +1,39 @@
+# file_transfer
+
+Move user files to/from a **remote (HTTP) openstudio-mcp server** securely.
+
+## Why
+Over HTTP the server runs on a different machine than the user. Every file tool
+(`load_osm_model`, `apply_measure`, `change_building_location`, `import_floorspacejs`)
+takes a **server-side path**, but the user's files are on their laptop. MCP tool
+args flow through the LLM, so passing file bytes in-band (base64) is infeasible
+(token cost) and leaks bytes into context/logs. This skill moves bytes
+**out-of-band** over signed HTTP routes on the same port.
+
+## Flow (upload)
+1. `request_upload(filename, size_bytes[, sha256, kind])` → `{file_id, upload_url, ...}`
+2. PUT raw bytes: `curl --upload-file model.osm "<upload_url>"`
+3. `get_upload(file_id)` → `server_path` (or `extracted_path` for a `.zip`)
+4. pass that path to `load_osm_model` / `apply_measure` / `change_building_location`
+
+A `.zip` (or `kind="measure"`) is auto-extracted server-side; `extracted_path`
+is the measure dir, ready for `apply_measure(measure_dir=...)`.
+
+## Flow (download)
+`request_download(path=...)` or `request_download(run_id=..., bundle=True)` →
+`download_url`; `curl -O -J "<download_url>"`. Small text → use `read_file` instead.
+
+## Security
+- **Signed URLs** (HMAC, short TTL) authorize the routes — the bearer token never
+  enters the URL or the model context; a leaked URL expires fast + is op/file-scoped.
+- Uploads land in `RUN_ROOT/<user>/uploads/` — the existing per-user, sandboxed,
+  path-allowlisted area. Server mints the `file_id` (client filename can't traverse).
+- Enforced: max size (`OSMCP_MAX_UPLOAD_MB`), per-user quota (`OSMCP_USER_QUOTA_MB`),
+  optional sha256 integrity, zip-bomb + path/symlink-escape guards on archives.
+
+## Tools
+`request_upload`, `get_upload`, `list_uploads`, `delete_upload`, `request_download`.
+
+## CLI (shell-less clients)
+`python -m mcp_server.tools.osmcp put <file> --kind measure` /
+`python -m mcp_server.tools.osmcp get <server_path>` wrap the same two HTTP calls.

--- a/mcp_server/skills/file_transfer/archive.py
+++ b/mcp_server/skills/file_transfer/archive.py
@@ -1,0 +1,67 @@
+"""Guarded extraction of user-uploaded archives (e.g. measure .zip).
+
+Untrusted zips reach the server: a malicious archive can path-traverse out of
+the extract dir (`../../etc/cron.d/x`), smuggle a symlink to a host file, or
+zip-bomb the disk. We extract entry-by-entry with explicit guards instead of
+ZipFile.extractall, then run reject_escaping_symlinks as a backstop.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import zipfile
+from pathlib import Path
+
+from mcp_server.util import reject_escaping_symlinks
+
+_CHUNK = 1 << 20  # 1 MiB
+
+
+def guarded_extract(
+    zip_path: Path, dest_dir: Path, *, max_uncompressed_bytes: int, max_entries: int,
+) -> str | None:
+    """Extract `zip_path` into `dest_dir`. Return an error string, or None on success.
+
+    Guards: entry-count cap, no absolute / `..`-escaping member paths, no symlink
+    members, and a REAL (streamed) uncompressed-size cap — the ZipInfo.file_size
+    header is attacker-controlled, so we also count bytes as we read.
+    """
+    if not zipfile.is_zipfile(zip_path):
+        return "not a valid zip archive"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_root = dest_dir.resolve()
+    total = 0
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            infos = zf.infolist()
+            if len(infos) > max_entries:
+                return f"archive has too many entries ({len(infos)} > {max_entries})"
+            for info in infos:
+                name = info.filename
+                if name.startswith("/") or Path(name).is_absolute() or ".." in Path(name).parts:
+                    return f"archive entry escapes extract dir: {name!r}"
+                # zip stores unix mode in the high 16 bits of external_attr.
+                mode = (info.external_attr >> 16) & 0xFFFF
+                if stat.S_ISLNK(mode):
+                    return f"archive contains a symlink (not allowed): {name!r}"
+                target = (dest_root / name).resolve()
+                if target != dest_root and not str(target).startswith(str(dest_root) + os.sep):
+                    return f"archive entry escapes extract dir: {name!r}"
+                if info.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info) as src, target.open("wb") as dst:
+                    while True:
+                        chunk = src.read(_CHUNK)
+                        if not chunk:
+                            break
+                        total += len(chunk)
+                        if total > max_uncompressed_bytes:
+                            return (f"archive expands beyond limit "
+                                    f"({max_uncompressed_bytes} bytes) — possible zip bomb")
+                        dst.write(chunk)
+    except (zipfile.BadZipFile, OSError) as e:
+        return f"failed to extract archive: {e}"
+    # Backstop: nothing under the tree may be a symlink that escapes the root.
+    return reject_escaping_symlinks(dest_root)

--- a/mcp_server/skills/file_transfer/operations.py
+++ b/mcp_server/skills/file_transfer/operations.py
@@ -30,6 +30,7 @@ from mcp_server.skills.file_transfer.archive import guarded_extract
 
 _MB = 1024 * 1024
 _FILE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_KINDS = {"auto", "osm", "weather", "measure", "floorplan", "osw", "archive", "other"}
 
 
 def _uploads_dir(key: str) -> Path:
@@ -82,6 +83,10 @@ def request_upload_op(filename: str, size_bytes: int, sha256: str = "", kind: st
         return {"ok": False, "error": "size_bytes must be an integer"}
     if size <= 0:
         return {"ok": False, "error": "size_bytes must be > 0"}
+    kind = str(kind or "auto")
+    if kind not in _KINDS:
+        return {"ok": False,
+                "error": f"unknown kind {kind!r} — expected one of: {', '.join(sorted(_KINDS))}"}
     max_bytes = OSMCP_MAX_UPLOAD_MB * _MB
     if size > max_bytes:
         return {"ok": False, "error": f"file exceeds max upload size ({OSMCP_MAX_UPLOAD_MB} MB)"}
@@ -208,7 +213,11 @@ def finalize_upload(key: str, file_id: str, tmp_path: Path, sha_hex: str, size: 
         return {"ok": False, "status": 422, "error": "sha256 mismatch"}
 
     entry = _entry_dir(key, file_id)
-    dest = entry / meta["filename"]
+    # Payload lives one level down so a filename like "meta.json" or "extracted"
+    # can never collide with the entry's own bookkeeping files.
+    data_dir = entry / "data"
+    data_dir.mkdir(exist_ok=True)
+    dest = data_dir / meta["filename"]
     tmp_path.replace(dest)
     server_path = str(dest)
     extracted_path = None
@@ -258,7 +267,7 @@ def verify_download(token: str) -> dict:
         return {"ok": False, "status": 403, "error": "not allowed"}
     if not target.exists():
         return {"ok": False, "status": 404, "error": "not found"}
-    return {"ok": True, "path": target, "bundle": bool(payload.get("b"))}
+    return {"ok": True, "path": target, "bundle": bool(payload.get("b")), "user": key}
 
 
 def _public_meta(key: str, meta: dict) -> dict:

--- a/mcp_server/skills/file_transfer/operations.py
+++ b/mcp_server/skills/file_transfer/operations.py
@@ -9,6 +9,7 @@ Two call sites:
 from __future__ import annotations
 
 import json
+import os
 import re
 import secrets
 import shutil
@@ -213,6 +214,16 @@ def finalize_upload(key: str, file_id: str, tmp_path: Path, sha_hex: str, size: 
         return {"ok": False, "status": 422, "error": "sha256 mismatch"}
 
     entry = _entry_dir(key, file_id)
+    # Atomic finalize claim: the first PUT to win this exclusive create proceeds; a
+    # concurrent PUT on the same token (TOCTOU on status above) loses and is rejected,
+    # preserving one-time semantics. Released on failure below so a retry can succeed.
+    claim = entry / ".finalized"
+    try:
+        os.close(os.open(claim, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600))
+    except FileExistsError:
+        tmp_path.unlink(missing_ok=True)
+        return {"ok": False, "status": 409, "error": "upload already completed"}
+
     # Payload lives one level down so a filename like "meta.json" or "extracted"
     # can never collide with the entry's own bookkeeping files.
     data_dir = entry / "data"
@@ -230,8 +241,18 @@ def finalize_upload(key: str, file_id: str, tmp_path: Path, sha_hex: str, size: 
         )
         if err:
             shutil.rmtree(extract_dir, ignore_errors=True)
+            claim.unlink(missing_ok=True)  # release the claim so the client can retry
             return {"ok": False, "status": 422, "error": err}
         extracted_path = _resolve_extracted(extract_dir)
+
+    # Hard-enforce the per-user quota at PUT time: the mint-time check sees only the
+    # compressed size and can be raced by concurrent mints, so an archive can expand
+    # past the cap here. Roll the whole entry back if it does.
+    if OSMCP_USER_QUOTA_MB > 0 and _dir_size(_uploads_dir(key)) > OSMCP_USER_QUOTA_MB * _MB:
+        shutil.rmtree(entry, ignore_errors=True)
+        return {"ok": False, "status": 413,
+                "error": (f"upload exceeds your {OSMCP_USER_QUOTA_MB} MB quota — "
+                          f"delete old uploads first")}
 
     meta.update({"status": "ready", "sha256": sha_hex, "size": size,
                  "server_path": server_path, "extracted_path": extracted_path})

--- a/mcp_server/skills/file_transfer/operations.py
+++ b/mcp_server/skills/file_transfer/operations.py
@@ -1,0 +1,272 @@
+"""Business logic for remote file transfer. No MCP awareness; returns plain dicts.
+
+Two call sites:
+  * MCP tools (request_upload/get_upload/...) run in request context -> identity
+    via user_key().
+  * the signed PUT/GET routes run OUTSIDE context -> identity is the user key
+    carried in the verified URL token, passed in explicitly.
+"""
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import shutil
+import time
+from pathlib import Path
+
+from mcp_server.config import (
+    OSMCP_MAX_ARCHIVE_ENTRIES,
+    OSMCP_MAX_ARCHIVE_UNCOMPRESSED_MB,
+    OSMCP_MAX_UPLOAD_MB,
+    OSMCP_PUBLIC_BASE_URL,
+    OSMCP_UPLOAD_URL_TTL,
+    OSMCP_USER_QUOTA_MB,
+    is_path_allowed_for,
+    run_root_for,
+)
+from mcp_server.skills.file_transfer import signing
+from mcp_server.skills.file_transfer.archive import guarded_extract
+
+_MB = 1024 * 1024
+_FILE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def _uploads_dir(key: str) -> Path:
+    d = run_root_for(key) / "uploads"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _entry_dir(key: str, file_id: str) -> Path:
+    if not _FILE_ID_RE.match(file_id):
+        raise ValueError("bad file_id")  # server-minted; never a client path
+    return _uploads_dir(key) / file_id
+
+
+def _meta_path(key: str, file_id: str) -> Path:
+    return _entry_dir(key, file_id) / "meta.json"
+
+
+def _sanitize_filename(name: str) -> str:
+    base = Path(str(name or "")).name  # strip any directory components
+    base = re.sub(r"[^A-Za-z0-9_.-]", "_", base).strip("._")
+    return base or "upload.bin"
+
+
+def _dir_size(path: Path) -> int:
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file() and not p.is_symlink():
+            total += p.stat().st_size
+    return total
+
+
+def _is_archive(filename: str, kind: str) -> bool:
+    return kind in ("measure", "archive") or filename.lower().endswith(".zip")
+
+
+def _public_url(path: str) -> str:
+    return f"{OSMCP_PUBLIC_BASE_URL}{path}" if OSMCP_PUBLIC_BASE_URL else path
+
+
+# --- MCP-context tools --------------------------------------------------------
+
+def request_upload_op(filename: str, size_bytes: int, sha256: str = "", kind: str = "auto") -> dict:
+    from mcp_server.identity import user_key
+
+    key = user_key()
+    try:
+        size = int(size_bytes)
+    except (TypeError, ValueError):
+        return {"ok": False, "error": "size_bytes must be an integer"}
+    if size <= 0:
+        return {"ok": False, "error": "size_bytes must be > 0"}
+    max_bytes = OSMCP_MAX_UPLOAD_MB * _MB
+    if size > max_bytes:
+        return {"ok": False, "error": f"file exceeds max upload size ({OSMCP_MAX_UPLOAD_MB} MB)"}
+    if OSMCP_USER_QUOTA_MB > 0:
+        used = _dir_size(_uploads_dir(key))
+        if used + size > OSMCP_USER_QUOTA_MB * _MB:
+            return {"ok": False, "error": (
+                f"upload would exceed your {OSMCP_USER_QUOTA_MB} MB quota "
+                f"(using {used // _MB} MB) — delete old uploads first")}
+
+    file_id = secrets.token_hex(16)
+    safe_name = _sanitize_filename(filename)
+    entry = _entry_dir(key, file_id)
+    entry.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "file_id": file_id, "filename": safe_name, "kind": kind,
+        "expected_size": size, "expected_sha256": (sha256 or "").lower(),
+        "status": "pending", "created": int(time.time()),
+    }
+    _meta_path(key, file_id).write_text(json.dumps(meta), encoding="utf-8")
+    token = signing.make_token(key, file_id, "u", OSMCP_UPLOAD_URL_TTL)
+    path = f"/files/u/{file_id}?t={token}"
+    return {
+        "ok": True, "file_id": file_id, "method": "PUT",
+        "upload_url": _public_url(path), "upload_path": path,
+        "expires_in": OSMCP_UPLOAD_URL_TTL, "max_size_bytes": max_bytes,
+        "hint": ("PUT the raw file bytes to upload_url (or upload_path on the same "
+                 "host as /mcp), e.g. curl --upload-file <file> '<upload_url>', "
+                 "then call get_upload(file_id) for the server path."),
+    }
+
+
+def get_upload_op(file_id: str) -> dict:
+    from mcp_server.identity import user_key
+
+    key = user_key()
+    try:
+        meta = json.loads(_meta_path(key, file_id).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"ok": False, "error": f"unknown file_id: {file_id}"}
+    return {"ok": True, **_public_meta(key, meta)}
+
+
+def list_uploads_op() -> dict:
+    from mcp_server.identity import user_key
+
+    key = user_key()
+    uploads = []
+    for meta_file in sorted(_uploads_dir(key).glob("*/meta.json")):
+        try:
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        uploads.append(_public_meta(key, meta))
+    return {"ok": True, "count": len(uploads), "uploads": uploads}
+
+
+def delete_upload_op(file_id: str) -> dict:
+    from mcp_server.identity import user_key
+
+    key = user_key()
+    try:
+        entry = _entry_dir(key, file_id)
+    except ValueError:
+        return {"ok": False, "error": f"unknown file_id: {file_id}"}
+    if not (entry / "meta.json").exists():
+        return {"ok": False, "error": f"unknown file_id: {file_id}"}
+    shutil.rmtree(entry, ignore_errors=True)
+    return {"ok": True, "file_id": file_id, "deleted": True}
+
+
+def request_download_op(path: str | None = None, run_id: str | None = None,
+                        bundle: bool = False) -> dict:
+    from mcp_server.identity import user_key
+
+    key = user_key()
+    if bundle:
+        if not run_id:
+            return {"ok": False, "error": "bundle download requires run_id"}
+        target = (run_root_for(key) / run_id).resolve()
+        if not target.is_dir() or not is_path_allowed_for(key, target):
+            return {"ok": False, "error": f"unknown run_id: {run_id}"}
+        token = signing.make_token(key, "-", "d", OSMCP_UPLOAD_URL_TTL,
+                                   p=str(target), b=1)
+        url = f"/files/d/{run_id}.zip?t={token}"
+        return {"ok": True, "method": "GET", "download_url": _public_url(url),
+                "download_path": url, "expires_in": OSMCP_UPLOAD_URL_TTL, "bundle": True}
+    if not path:
+        return {"ok": False, "error": "provide a file path, or run_id + bundle=True"}
+    target = Path(path).resolve()
+    if not target.is_file() or not is_path_allowed_for(key, target):
+        return {"ok": False, "error": f"file not accessible: {path}"}
+    token = signing.make_token(key, "-", "d", OSMCP_UPLOAD_URL_TTL, p=str(target))
+    url = f"/files/d/{target.name}?t={token}"
+    return {"ok": True, "method": "GET", "download_url": _public_url(url),
+            "download_path": url, "expires_in": OSMCP_UPLOAD_URL_TTL,
+            "size_bytes": target.stat().st_size}
+
+
+# --- signed-route helpers (no MCP context) ------------------------------------
+
+def finalize_upload(key: str, file_id: str, tmp_path: Path, sha_hex: str, size: int) -> dict:
+    """Verify a streamed upload against its pending meta, place it, auto-extract.
+
+    Called by the PUT route after streaming bytes to `tmp_path`. Returns a result
+    dict; on any failure the partial upload is removed.
+    """
+    meta_path = _meta_path(key, file_id)
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        tmp_path.unlink(missing_ok=True)
+        return {"ok": False, "status": 404, "error": "unknown or expired upload"}
+    if meta.get("status") == "ready":
+        tmp_path.unlink(missing_ok=True)
+        return {"ok": False, "status": 409, "error": "upload already completed"}
+    if size != meta["expected_size"]:
+        tmp_path.unlink(missing_ok=True)
+        return {"ok": False, "status": 422,
+                "error": f"size mismatch: got {size}, expected {meta['expected_size']}"}
+    expected_sha = meta.get("expected_sha256") or ""
+    if expected_sha and sha_hex != expected_sha:
+        tmp_path.unlink(missing_ok=True)
+        return {"ok": False, "status": 422, "error": "sha256 mismatch"}
+
+    entry = _entry_dir(key, file_id)
+    dest = entry / meta["filename"]
+    tmp_path.replace(dest)
+    server_path = str(dest)
+    extracted_path = None
+    if _is_archive(meta["filename"], meta.get("kind", "auto")):
+        extract_dir = entry / "extracted"
+        err = guarded_extract(
+            dest, extract_dir,
+            max_uncompressed_bytes=OSMCP_MAX_ARCHIVE_UNCOMPRESSED_MB * _MB,
+            max_entries=OSMCP_MAX_ARCHIVE_ENTRIES,
+        )
+        if err:
+            shutil.rmtree(extract_dir, ignore_errors=True)
+            return {"ok": False, "status": 422, "error": err}
+        extracted_path = _resolve_extracted(extract_dir)
+
+    meta.update({"status": "ready", "sha256": sha_hex, "size": size,
+                 "server_path": server_path, "extracted_path": extracted_path})
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    return {"ok": True, "file_id": file_id, "sha256": sha_hex, "size": size,
+            "server_path": server_path, "extracted_path": extracted_path}
+
+
+def _resolve_extracted(extract_dir: Path) -> str:
+    """Point measures at the actual measure dir even if zipped with a top folder.
+
+    A measure zip is usually `my_measure/measure.rb,...`; if extraction produced a
+    single top-level dir, return it so apply_measure(measure_dir=...) just works.
+    """
+    children = [p for p in extract_dir.iterdir() if p.name != "__MACOSX"]
+    if len(children) == 1 and children[0].is_dir():
+        return str(children[0])
+    return str(extract_dir)
+
+
+def verify_download(token: str) -> dict:
+    """Validate a download token; return {ok, path, bundle} or {ok:False,...}."""
+    try:
+        payload = signing.verify_token(token, op="d")
+    except ValueError as e:
+        return {"ok": False, "status": 403, "error": str(e)}
+    key = payload.get("u")
+    path = payload.get("p")
+    if not key or not path:
+        return {"ok": False, "status": 403, "error": "bad token"}
+    target = Path(path).resolve()
+    if not is_path_allowed_for(key, target):
+        return {"ok": False, "status": 403, "error": "not allowed"}
+    if not target.exists():
+        return {"ok": False, "status": 404, "error": "not found"}
+    return {"ok": True, "path": target, "bundle": bool(payload.get("b"))}
+
+
+def _public_meta(key: str, meta: dict) -> dict:
+    return {
+        "file_id": meta.get("file_id"), "filename": meta.get("filename"),
+        "kind": meta.get("kind"), "status": meta.get("status"),
+        "ready": meta.get("status") == "ready",
+        "size_bytes": meta.get("size"), "sha256": meta.get("sha256"),
+        "server_path": meta.get("server_path"),
+        "extracted_path": meta.get("extracted_path"),
+    }

--- a/mcp_server/skills/file_transfer/routes.py
+++ b/mcp_server/skills/file_transfer/routes.py
@@ -14,7 +14,8 @@ import zipfile
 from pathlib import Path
 
 from starlette.background import BackgroundTask
-from starlette.requests import Request
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import FileResponse, JSONResponse
 
 from mcp_server.audit import audit
@@ -41,11 +42,15 @@ async def upload_route(request: Request) -> JSONResponse:
         return JSONResponse({"ok": False, "error": "unknown or expired upload"}, status_code=404)
 
     max_bytes = OSMCP_MAX_UPLOAD_MB * _MB
-    tmp = entry / ".incoming"
+    # Unique temp per request: concurrent PUTs on one token must not share a file
+    # (the loser would corrupt the winner's finalized bytes through its open fd).
+    fd, tmp_name = tempfile.mkstemp(prefix=".incoming-", dir=entry)
+    tmp = Path(tmp_name)
+    tmp.chmod(0o644)  # mkstemp gives 0600; the per-tenant sandbox uid must read uploads
     h = hashlib.sha256()
     size = 0
     try:
-        with tmp.open("wb") as f:
+        with os.fdopen(fd, "wb") as f:
             async for chunk in request.stream():
                 size += len(chunk)
                 if size > max_bytes:
@@ -56,6 +61,9 @@ async def upload_route(request: Request) -> JSONResponse:
                         status_code=413)
                 h.update(chunk)
                 f.write(chunk)
+    except ClientDisconnect:
+        tmp.unlink(missing_ok=True)
+        return JSONResponse({"ok": False, "error": "client disconnected"}, status_code=400)
     except OSError as e:
         tmp.unlink(missing_ok=True)
         return JSONResponse({"ok": False, "error": f"write failed: {e}"}, status_code=500)
@@ -73,10 +81,10 @@ async def download_route(request: Request):
     if not res["ok"]:
         return JSONResponse({"ok": False, "error": res["error"]}, status_code=res["status"])
     path: Path = res["path"]
+    audit("file_download", user=res["user"], file=str(path), bundle=res["bundle"])
     if res["bundle"]:
-        audit("file_download", file=str(path), bundle=True)
-        return _zip_bundle(path)
-    audit("file_download", file=str(path), bundle=False)
+        # Zipping a run dir is heavy sync I/O — keep it off the event loop.
+        return await run_in_threadpool(_zip_bundle, path)
     return FileResponse(path, filename=path.name)
 
 

--- a/mcp_server/skills/file_transfer/routes.py
+++ b/mcp_server/skills/file_transfer/routes.py
@@ -7,6 +7,7 @@ the user key, and (for upload) the file_id; the route trusts nothing else.
 """
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 import tempfile
@@ -46,7 +47,10 @@ async def upload_route(request: Request) -> JSONResponse:
     # (the loser would corrupt the winner's finalized bytes through its open fd).
     fd, tmp_name = tempfile.mkstemp(prefix=".incoming-", dir=entry)
     tmp = Path(tmp_name)
-    tmp.chmod(0o644)  # mkstemp gives 0600; the per-tenant sandbox uid must read uploads
+    with contextlib.suppress(OSError):
+        # best-effort: mkstemp gives 0600; widen so the per-tenant sandbox uid can
+        # read uploads. An exotic mount may reject chmod — upload still finalizes.
+        tmp.chmod(0o644)
     h = hashlib.sha256()
     size = 0
     try:

--- a/mcp_server/skills/file_transfer/routes.py
+++ b/mcp_server/skills/file_transfer/routes.py
@@ -1,0 +1,94 @@
+"""Signed, out-of-band HTTP routes that carry file bytes beside the MCP protocol.
+
+These are NOT behind FastMCP's `auth=` verifier (custom routes never are), so
+authorization is the HMAC signature in the `?t=` token, minted by the
+authenticated request_upload / request_download tools. The token binds the op,
+the user key, and (for upload) the file_id; the route trusts nothing else.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+
+from starlette.background import BackgroundTask
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse
+
+from mcp_server.audit import audit
+from mcp_server.config import OSMCP_MAX_UPLOAD_MB
+from mcp_server.skills.file_transfer import operations, signing
+
+_MB = 1024 * 1024
+
+
+async def upload_route(request: Request) -> JSONResponse:
+    token = request.query_params.get("t", "")
+    try:
+        payload = signing.verify_token(token, op="u")
+    except ValueError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=403)
+    key, file_id = payload["u"], payload["f"]
+    if request.path_params.get("file_id") != file_id:
+        return JSONResponse({"ok": False, "error": "file_id mismatch"}, status_code=403)
+    try:
+        entry = operations._entry_dir(key, file_id)
+    except ValueError:
+        return JSONResponse({"ok": False, "error": "bad file_id"}, status_code=403)
+    if not (entry / "meta.json").exists():
+        return JSONResponse({"ok": False, "error": "unknown or expired upload"}, status_code=404)
+
+    max_bytes = OSMCP_MAX_UPLOAD_MB * _MB
+    tmp = entry / ".incoming"
+    h = hashlib.sha256()
+    size = 0
+    try:
+        with tmp.open("wb") as f:
+            async for chunk in request.stream():
+                size += len(chunk)
+                if size > max_bytes:
+                    f.close()
+                    tmp.unlink(missing_ok=True)
+                    return JSONResponse(
+                        {"ok": False, "error": f"exceeds max upload size ({OSMCP_MAX_UPLOAD_MB} MB)"},
+                        status_code=413)
+                h.update(chunk)
+                f.write(chunk)
+    except OSError as e:
+        tmp.unlink(missing_ok=True)
+        return JSONResponse({"ok": False, "error": f"write failed: {e}"}, status_code=500)
+
+    result = operations.finalize_upload(key, file_id, tmp, h.hexdigest(), size)
+    status = 200 if result.get("ok") else result.pop("status", 422)
+    audit("file_upload", user=key, file_id=file_id, size=size,
+          sha256=h.hexdigest(), ok=result.get("ok"), error=result.get("error"))
+    return JSONResponse(result, status_code=status)
+
+
+async def download_route(request: Request):
+    token = request.query_params.get("t", "")
+    res = operations.verify_download(token)
+    if not res["ok"]:
+        return JSONResponse({"ok": False, "error": res["error"]}, status_code=res["status"])
+    path: Path = res["path"]
+    if res["bundle"]:
+        audit("file_download", file=str(path), bundle=True)
+        return _zip_bundle(path)
+    audit("file_download", file=str(path), bundle=False)
+    return FileResponse(path, filename=path.name)
+
+
+def _zip_bundle(run_dir: Path) -> FileResponse:
+    """Zip a run's reports (or the whole run dir if no reports/) to a temp file."""
+    src = run_dir / "reports" if (run_dir / "reports").is_dir() else run_dir
+    fd, tmp_name = tempfile.mkstemp(prefix="bundle_", suffix=".zip")
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in src.rglob("*"):
+            if p.is_file() and not p.is_symlink():
+                zf.write(p, p.relative_to(src))
+    return FileResponse(tmp_path, filename=f"{run_dir.name}.zip",
+                        background=BackgroundTask(tmp_path.unlink, missing_ok=True))

--- a/mcp_server/skills/file_transfer/signing.py
+++ b/mcp_server/skills/file_transfer/signing.py
@@ -45,13 +45,23 @@ def _load_or_create_key() -> bytes:
         pass
     key = secrets.token_bytes(32)
     try:
-        # Write-then-chmod; best-effort 0600 so other tenants can't read the key.
-        _KEY_FILE.write_bytes(key)
-        _KEY_FILE.chmod(0o600)
+        # O_EXCL: born 0600 (no chmod window) and exactly one process wins the
+        # create — concurrent cold-started workers all converge on the same key.
+        fd = os.open(_KEY_FILE, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        try:
+            data = _KEY_FILE.read_bytes()
+            if len(data) >= 32:
+                return data
+        except OSError:
+            pass
+        return key
     except OSError:
         # Read-only RUN_ROOT (unusual): fall back to a process-lifetime key. URLs
         # then don't survive a restart, but signing still works within the run.
-        pass
+        return key
+    with os.fdopen(fd, "wb") as f:
+        f.write(key)
     return key
 
 

--- a/mcp_server/skills/file_transfer/signing.py
+++ b/mcp_server/skills/file_transfer/signing.py
@@ -1,0 +1,105 @@
+"""HMAC-signed URL tokens for the out-of-band file-transfer routes.
+
+The file PUT/GET routes run OUTSIDE FastMCP request context (custom_route is not
+behind the `auth=` verifier — empirically: a custom route serves 200 with no
+token), so they cannot derive the caller from context. Instead the authenticated
+`request_upload` / `request_download` MCP tools — which DO have context and know
+`user_key()` — mint a short-lived token binding (user, file_id, op, expiry). The
+route verifies the HMAC and trusts the embedded user key as the authorization.
+
+This keeps the long-lived bearer token out of the URL (and out of the model's
+context), and a leaked URL expires fast and is scoped to one file + one op.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+
+from mcp_server.config import RUN_ROOT
+
+_KEY_FILE = RUN_ROOT / ".file_signing_key"
+_key_cache: bytes | None = None
+
+
+def _load_or_create_key() -> bytes:
+    """Resolve the HMAC key: env override > persisted file > generate+persist.
+
+    Persisting (mode 0600) means URLs survive a restart and every worker derives
+    the same signatures. Operators who want to rotate or share a key across boxes
+    set OSMCP_FILE_SIGNING_KEY.
+    """
+    env = os.environ.get("OSMCP_FILE_SIGNING_KEY")
+    if env:
+        return hashlib.sha256(env.encode("utf-8")).digest()
+    try:
+        if _KEY_FILE.exists():
+            data = _KEY_FILE.read_bytes()
+            if len(data) >= 32:
+                return data
+    except OSError:
+        pass
+    key = secrets.token_bytes(32)
+    try:
+        # Write-then-chmod; best-effort 0600 so other tenants can't read the key.
+        _KEY_FILE.write_bytes(key)
+        _KEY_FILE.chmod(0o600)
+    except OSError:
+        # Read-only RUN_ROOT (unusual): fall back to a process-lifetime key. URLs
+        # then don't survive a restart, but signing still works within the run.
+        pass
+    return key
+
+
+def _key() -> bytes:
+    global _key_cache
+    if _key_cache is None:
+        _key_cache = _load_or_create_key()
+    return _key_cache
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64u_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def make_token(user_key: str, file_id: str, op: str, ttl: int, **extra) -> str:
+    """Mint a signed token. `op` is "u" (upload) or "d" (download)."""
+    payload = {"u": user_key, "f": file_id, "op": op, "exp": int(time.time()) + int(ttl)}
+    payload.update({k: v for k, v in extra.items() if v is not None})
+    body = _b64u(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    sig = _b64u(hmac.new(_key(), body.encode("ascii"), hashlib.sha256).digest())
+    return f"{body}.{sig}"
+
+
+def verify_token(token: str, *, op: str | None = None) -> dict:
+    """Validate signature + expiry; return the payload. Raises ValueError if bad.
+
+    Constant-time signature compare; explicit expiry check; optional op match so
+    an upload URL can't be replayed against the download route or vice versa.
+    """
+    try:
+        body, sig = token.split(".", 1)
+    except ValueError as e:
+        raise ValueError("malformed token") from e
+    expected = _b64u(hmac.new(_key(), body.encode("ascii"), hashlib.sha256).digest())
+    if not hmac.compare_digest(sig, expected):
+        raise ValueError("bad signature")
+    try:
+        payload = json.loads(_b64u_decode(body))
+    except (ValueError, json.JSONDecodeError) as e:
+        raise ValueError("malformed payload") from e
+    if not isinstance(payload, dict) or "exp" not in payload:
+        raise ValueError("malformed payload")
+    if time.time() > float(payload["exp"]):
+        raise ValueError("token expired")
+    if op is not None and payload.get("op") != op:
+        raise ValueError("wrong token op")
+    return payload

--- a/mcp_server/skills/file_transfer/tools.py
+++ b/mcp_server/skills/file_transfer/tools.py
@@ -39,7 +39,8 @@ def register(mcp):
             filename: Original name (used for display + type detection; never as a path)
             size_bytes: Exact size of the file in bytes (enforced + quota-checked)
             sha256: Optional lowercase hex sha256; verified on upload if given
-            kind: "auto" (default), "osm", "weather", "measure", "floorplan", "osw", "other"
+            kind: "auto" (default), "osm", "weather", "measure", "archive",
+                "floorplan", "osw", "other"
         """
         return request_upload_op(filename=filename, size_bytes=size_bytes,
                                  sha256=sha256, kind=kind)
@@ -81,7 +82,8 @@ def register(mcp):
         curl -O -J "<download_url>".
 
         Args:
-            path: Absolute server path to a single file (must be under your run dir)
+            path: Absolute server path to a single file (your run dir, or the
+                shared read-only roots e.g. bundled measures)
             run_id: With bundle=True, zip this run's reports/ for download
             bundle: If True, bundle a run's reports into one .zip (requires run_id)
         """

--- a/mcp_server/skills/file_transfer/tools.py
+++ b/mcp_server/skills/file_transfer/tools.py
@@ -1,0 +1,96 @@
+"""MCP tools + signed HTTP routes for getting user files to/from a remote server.
+
+Over HTTP the user's files live on their laptop. These tools mint short-lived,
+HMAC-signed URLs; the bytes then move out-of-band over PUT/GET (never through the
+LLM context), landing in the caller's isolated, sandboxed RUN_ROOT/<user>/uploads.
+"""
+from __future__ import annotations
+
+from mcp_server.skills.file_transfer.operations import (
+    delete_upload_op,
+    get_upload_op,
+    list_uploads_op,
+    request_download_op,
+    request_upload_op,
+)
+from mcp_server.skills.file_transfer.routes import download_route, upload_route
+
+
+def register(mcp):
+    @mcp.tool(tags={"core", "files"}, name="request_upload")
+    def request_upload_tool(
+        filename: str, size_bytes: int, sha256: str = "", kind: str = "auto",
+    ):
+        """Get a one-time URL to upload a LOCAL file to the remote server.
+
+        Use when a file the server needs (an .osm model, custom measure .zip,
+        weather .epw/.ddy/.stat, FloorspaceJS .json) lives on your machine, not
+        on the server. Workflow:
+          1. request_upload(filename, size_bytes[, sha256, kind])
+          2. PUT the raw bytes to the returned upload_url, e.g.
+             curl --upload-file model.osm "<upload_url>"
+          3. get_upload(file_id) -> server_path (or extracted_path for a .zip)
+          4. pass that path to load_osm_model / apply_measure / change_building_location
+
+        A .zip (or kind="measure") is auto-extracted server-side, guarded against
+        zip bombs and path escapes; extracted_path points at the measure dir.
+
+        Args:
+            filename: Original name (used for display + type detection; never as a path)
+            size_bytes: Exact size of the file in bytes (enforced + quota-checked)
+            sha256: Optional lowercase hex sha256; verified on upload if given
+            kind: "auto" (default), "osm", "weather", "measure", "floorplan", "osw", "other"
+        """
+        return request_upload_op(filename=filename, size_bytes=size_bytes,
+                                 sha256=sha256, kind=kind)
+
+    @mcp.tool(tags={"files"}, name="get_upload")
+    def get_upload_tool(file_id: str):
+        """Check an upload's status and get its server-side path.
+
+        Returns ready=True with server_path once the PUT completes. For an
+        extracted archive, extracted_path is the measure/contents dir.
+
+        Args:
+            file_id: The id returned by request_upload
+        """
+        return get_upload_op(file_id=file_id)
+
+    @mcp.tool(tags={"files"}, name="list_uploads")
+    def list_uploads_tool():
+        """List your uploaded files (file_id, filename, status, server_path)."""
+        return list_uploads_op()
+
+    @mcp.tool(tags={"files"}, name="delete_upload")
+    def delete_upload_tool(file_id: str):
+        """Delete an uploaded file and free its quota.
+
+        Args:
+            file_id: The id returned by request_upload
+        """
+        return delete_upload_op(file_id=file_id)
+
+    @mcp.tool(tags={"files"}, name="request_download")
+    def request_download_tool(
+        path: str | None = None, run_id: str | None = None, bundle: bool = False,
+    ):
+        """Get a one-time URL to download a server file back to your machine.
+
+        Use for binary/large outputs (saved .osm, HTML reports, CSVs). For small
+        text, read_file is simpler. GET the returned download_url, e.g.
+        curl -O -J "<download_url>".
+
+        Args:
+            path: Absolute server path to a single file (must be under your run dir)
+            run_id: With bundle=True, zip this run's reports/ for download
+            bundle: If True, bundle a run's reports into one .zip (requires run_id)
+        """
+        return request_download_op(path=path, run_id=run_id, bundle=bundle)
+
+    # Out-of-band byte channel on the same app/port. Authorization is the signed
+    # URL (these routes are NOT behind the MCP auth verifier). Guarded so skill
+    # registration still works under the mock-MCP objects used by the tool-router
+    # index and tag tests (which don't implement custom_route).
+    if hasattr(mcp, "custom_route"):
+        mcp.custom_route("/files/u/{file_id}", methods=["PUT"])(upload_route)
+        mcp.custom_route("/files/d/{name}", methods=["GET"])(download_route)

--- a/mcp_server/tools/osmcp.py
+++ b/mcp_server/tools/osmcp.py
@@ -1,0 +1,124 @@
+"""Thin CLI for the remote file-transfer channel — for clients without a shell.
+
+The agent-driven path (request_upload tool -> curl -> get_upload) is the default;
+this is the fallback for shell-less or human-driven use. It calls the same MCP
+tools over the same authenticated endpoint, then moves bytes out-of-band.
+
+    python -m mcp_server.tools.osmcp put model.osm --kind osm
+    python -m mcp_server.tools.osmcp put my_measure.zip --kind measure
+    python -m mcp_server.tools.osmcp get /runs/<user>/<run>/exports/model.osm -o out.osm
+
+Endpoint + token come from --url/--token or OSMCP_URL / OSMCP_TOKEN.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+
+def _base_url(mcp_url: str) -> str:
+    parts = urlsplit(mcp_url)
+    return urlunsplit((parts.scheme, parts.netloc, "", "", ""))
+
+
+def _abs(mcp_url: str, url_or_path: str) -> str:
+    return url_or_path if url_or_path.startswith("http") else _base_url(mcp_url) + url_or_path
+
+
+# Long, explicit timeout for moving large model files (not None — bandit S113).
+_XFER_TIMEOUT = 3600
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+async def _call(client: Client, name: str, args: dict) -> dict:
+    res = await client.call_tool(name, args)
+    data = getattr(res, "data", None)
+    if isinstance(data, dict):
+        return data
+    sc = getattr(res, "structured_content", None)
+    return sc if isinstance(sc, dict) else {}
+
+
+async def _put(url: str, token: str, mcp_url: str, kind: str) -> int:
+    src = Path(url)
+    if not src.is_file():
+        print(f"not a file: {src}", file=sys.stderr)
+        return 2
+    transport = StreamableHttpTransport(mcp_url, headers={"Authorization": f"Bearer {token}"})
+    async with Client(transport) as client:
+        req = await _call(client, "request_upload", {
+            "filename": src.name, "size_bytes": src.stat().st_size,
+            "sha256": _sha256(src), "kind": kind,
+        })
+        if not req.get("ok"):
+            print(f"request_upload failed: {req.get('error')}", file=sys.stderr)
+            return 1
+        put_url = _abs(mcp_url, req.get("upload_url") or req["upload_path"])
+        async with httpx.AsyncClient(timeout=_XFER_TIMEOUT) as http:
+            with src.open("rb") as f:
+                r = await http.put(put_url, content=f)
+        if r.status_code != 200:
+            print(f"upload failed ({r.status_code}): {r.text}", file=sys.stderr)
+            return 1
+        info = await _call(client, "get_upload", {"file_id": req["file_id"]})
+        path = info.get("extracted_path") or info.get("server_path")
+        print(path)  # stdout = the server path to feed to load_osm_model/apply_measure
+        return 0
+
+
+async def _get(server_path: str, token: str, mcp_url: str, out: str | None) -> int:
+    transport = StreamableHttpTransport(mcp_url, headers={"Authorization": f"Bearer {token}"})
+    async with Client(transport) as client:
+        req = await _call(client, "request_download", {"path": server_path})
+        if not req.get("ok"):
+            print(f"request_download failed: {req.get('error')}", file=sys.stderr)
+            return 1
+        get_url = _abs(mcp_url, req.get("download_url") or req["download_path"])
+        dest = Path(out) if out else Path(Path(server_path).name)
+        async with httpx.AsyncClient(timeout=_XFER_TIMEOUT) as http:
+            r = await http.get(get_url)
+        if r.status_code != 200:
+            print(f"download failed ({r.status_code}): {r.text}", file=sys.stderr)
+            return 1
+        dest.write_bytes(r.content)
+        print(str(dest))
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="osmcp", description="openstudio-mcp file transfer")
+    p.add_argument("--url", default=os.environ.get("OSMCP_URL"), help="MCP endpoint, e.g. http://box:8000/mcp")
+    p.add_argument("--token", default=os.environ.get("OSMCP_TOKEN"), help="bearer token")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    pu = sub.add_parser("put", help="upload a local file")
+    pu.add_argument("file")
+    pu.add_argument("--kind", default="auto")
+    pg = sub.add_parser("get", help="download a server file")
+    pg.add_argument("server_path")
+    pg.add_argument("-o", "--out", default=None)
+    a = p.parse_args(argv)
+    if not a.url or not a.token:
+        p.error("--url/--token (or OSMCP_URL/OSMCP_TOKEN) required")
+    if a.cmd == "put":
+        return asyncio.run(_put(a.file, a.token, a.url, a.kind))
+    return asyncio.run(_get(a.server_path, a.token, a.url, a.out))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mcp_server/tools/osmcp.py
+++ b/mcp_server/tools/osmcp.py
@@ -46,6 +46,14 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+async def _stream_file(path: Path):
+    # httpx.AsyncClient requires an ASYNC byte iterable for content= — a sync
+    # file object raises "Attempted to send an sync request with an AsyncClient".
+    with path.open("rb") as f:
+        while chunk := f.read(1 << 20):
+            yield chunk
+
+
 async def _call(client: Client, name: str, args: dict) -> dict:
     res = await client.call_tool(name, args)
     data = getattr(res, "data", None)
@@ -71,8 +79,7 @@ async def _put(url: str, token: str, mcp_url: str, kind: str) -> int:
             return 1
         put_url = _abs(mcp_url, req.get("upload_url") or req["upload_path"])
         async with httpx.AsyncClient(timeout=_XFER_TIMEOUT) as http:
-            with src.open("rb") as f:
-                r = await http.put(put_url, content=f)
+            r = await http.put(put_url, content=_stream_file(src))
         if r.status_code != 200:
             print(f"upload failed ({r.status_code}): {r.text}", file=sys.stderr)
             return 1
@@ -91,12 +98,15 @@ async def _get(server_path: str, token: str, mcp_url: str, out: str | None) -> i
             return 1
         get_url = _abs(mcp_url, req.get("download_url") or req["download_path"])
         dest = Path(out) if out else Path(Path(server_path).name)
-        async with httpx.AsyncClient(timeout=_XFER_TIMEOUT) as http:
-            r = await http.get(get_url)
-        if r.status_code != 200:
-            print(f"download failed ({r.status_code}): {r.text}", file=sys.stderr)
-            return 1
-        dest.write_bytes(r.content)
+        async with httpx.AsyncClient(timeout=_XFER_TIMEOUT) as http, \
+                   http.stream("GET", get_url) as r:
+            if r.status_code != 200:
+                body = (await r.aread()).decode(errors="replace")
+                print(f"download failed ({r.status_code}): {body}", file=sys.stderr)
+                return 1
+            with dest.open("wb") as f:
+                async for chunk in r.aiter_bytes():
+                    f.write(chunk)
         print(str(dest))
         return 0
 

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -6,7 +6,10 @@ Adversarial / abuse-case coverage lives in tests/test_security_file_transfer.py
 import asyncio
 import hashlib
 import io
+import json
 import os
+import subprocess
+import sys
 import uuid
 import zipfile
 from pathlib import Path
@@ -121,3 +124,62 @@ def test_download_roundtrip():
                 assert r.content == data
 
         asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_download_bundle_roundtrip():
+    # Validates: request_download(bundle=True) zips a dir under the caller's run
+    # root and serves it with members byte-intact
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                data = b"OS:Version,3.11.0;\nbundle,me\n"
+                info = await _upload(s, url, "bundle_me.osm", data)
+                assert info["ready"] is True, info
+                # uploads/ is itself a dir under the caller's run root — bundle it
+                dl = unwrap(await s.call_tool("request_download",
+                                              {"run_id": "uploads", "bundle": True}))
+                assert dl["ok"] is True and dl["bundle"] is True, dl
+                r = httpx.get(_base(url) + dl["download_path"], timeout=60)
+                assert r.status_code == 200, r.text
+                zf = zipfile.ZipFile(io.BytesIO(r.content))
+                names = [n for n in zf.namelist() if n.endswith("bundle_me.osm")]
+                assert len(names) == 1, f"uploaded file missing from bundle: {zf.namelist()}"
+                assert zf.read(names[0]) == data
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_cli_put_get_roundtrip(tmp_path):
+    # Regression: `osmcp put` crashed before moving any bytes — httpx AsyncClient
+    # rejects a sync file object as content= (RuntimeError); CLI path had no test
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    data = b"OS:Version,3.11.0;\n" + b"x," * 5000
+    src = tmp_path / "cli_model.osm"
+    src.write_bytes(data)
+
+    # Token auth (the documented CLI setup): put and get are separate MCP sessions,
+    # so identity must come from the token, not the session, for get to see put's file.
+    with http_server({"MCP_AUTH": "token",
+                      "MCP_TOKENS": json.dumps({"tok-cli": "cliuser"})}) as (url, _proc):
+        env = {**os.environ, "OSMCP_URL": url, "OSMCP_TOKEN": "tok-cli"}
+        put = subprocess.run(  # noqa: S603 - args are sys.executable + test-owned paths
+            [sys.executable, "-m", "mcp_server.tools.osmcp", "put", str(src), "--kind", "osm"],
+            capture_output=True, text=True, env=env, timeout=180, check=False)
+        assert put.returncode == 0, f"osmcp put failed:\n{put.stderr}"
+        server_path = put.stdout.strip().splitlines()[-1]
+        assert server_path.endswith("cli_model.osm"), put.stdout
+        assert Path(server_path).read_bytes() == data
+
+        out = tmp_path / "back.osm"
+        get = subprocess.run(  # noqa: S603 - args are sys.executable + test-owned paths
+            [sys.executable, "-m", "mcp_server.tools.osmcp", "get", server_path, "-o", str(out)],
+            capture_output=True, text=True, env=env, timeout=180, check=False)
+        assert get.returncode == 0, f"osmcp get failed:\n{get.stderr}"
+        assert out.read_bytes() == data

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -1,0 +1,123 @@
+"""Remote file transfer over HTTP — FUNCTIONAL round-trips (does the feature work).
+
+Adversarial / abuse-case coverage lives in tests/test_security_file_transfer.py
+(it runs in the dedicated security workflow on both amd64 and arm64).
+"""
+import asyncio
+import hashlib
+import io
+import os
+import uuid
+import zipfile
+from pathlib import Path
+
+import httpx
+import pytest
+from conftest import http_server, http_session, integration_enabled, unwrap
+
+_MB = 1 << 20
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+def _base(url: str) -> str:
+    # url is http://127.0.0.1:<port>/mcp ; file routes live at the same host root
+    return url[: -len("/mcp")] if url.endswith("/mcp") else url
+
+
+def _put(url: str, upload_path: str, data: bytes) -> httpx.Response:
+    return httpx.put(_base(url) + upload_path, content=data, timeout=60)
+
+
+async def _upload(session, url: str, filename: str, data: bytes, kind: str = "auto") -> dict:
+    """request_upload -> PUT bytes -> get_upload. Returns the get_upload dict."""
+    req = unwrap(await session.call_tool("request_upload", {
+        "filename": filename, "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(), "kind": kind,
+    }))
+    assert req["ok"] is True, req
+    r = _put(url, req["upload_path"], data)
+    assert r.status_code == 200, f"PUT failed: {r.status_code} {r.text}"
+    return unwrap(await session.call_tool("get_upload", {"file_id": req["file_id"]}))
+
+
+@pytest.mark.integration
+def test_upload_roundtrip_loads_model():
+    # Validates: a model uploaded out-of-band becomes a server path that load_osm_model loads
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                # Make a real OSM on the server, then re-upload its bytes as if from a laptop.
+                cr = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("up")}))
+                assert cr["ok"] is True, cr
+                data = Path(cr["osm_path"]).read_bytes()
+
+                info = await _upload(s, url, "client_model.osm", data, kind="osm")
+                assert info["ok"] is True and info["ready"] is True, info
+                assert info["sha256"] == hashlib.sha256(data).hexdigest()
+                assert "/uploads/" in info["server_path"], info
+                assert info["server_path"].endswith("client_model.osm")
+
+                ld = unwrap(await s.call_tool("load_osm_model", {"osm_path": info["server_path"]}))
+                assert ld["ok"] is True, f"uploaded model must load: {ld}"
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_measure_zip_autoextract():
+    # Validates: an uploaded measure .zip is extracted to a usable measure dir
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    measures_root = Path(os.environ.get("COMMON_MEASURES_DIR", "/opt/common-measures"))
+    src = next((d for d in sorted(measures_root.iterdir())
+                if (d / "measure.rb").is_file() and (d / "measure.xml").is_file()), None)
+    if src is None:
+        pytest.skip("no bundled measure with measure.rb+measure.xml found")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for f in ("measure.rb", "measure.xml"):
+            zf.write(src / f, f"{src.name}/{f}")
+    zip_bytes = buf.getvalue()
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                info = await _upload(s, url, f"{src.name}.zip", zip_bytes, kind="measure")
+                assert info["ready"] is True, info
+                ep = info["extracted_path"]
+                assert ep is not None, info
+                assert (Path(ep) / "measure.rb").is_file(), f"extract should yield measure dir: {ep}"
+
+                # The extracted measure is usable by the existing measure tooling.
+                args = unwrap(await s.call_tool("list_measure_arguments", {"measure_dir": ep}))
+                assert args["ok"] is True, f"extracted measure must be readable: {args}"
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_download_roundtrip():
+    # Validates: a server file round-trips back out via a signed GET URL, bytes intact
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                data = b"OS:Version,3.11.0;\nsome,model,bytes\n"
+                info = await _upload(s, url, "rt.osm", data)
+                dl = unwrap(await s.call_tool("request_download", {"path": info["server_path"]}))
+                assert dl["ok"] is True, dl
+                r = httpx.get(_base(url) + dl["download_path"], timeout=30)
+                assert r.status_code == 200, r.text
+                assert r.content == data
+
+        asyncio.run(_run())

--- a/tests/test_file_transfer_unit.py
+++ b/tests/test_file_transfer_unit.py
@@ -1,19 +1,42 @@
 """Unit tests for the file-transfer channel: signing, filename safety, archive
-guards, and upload finalization. No server, no openstudio — pure logic.
+guards, upload finalization, and route behavior (via fake ASGI requests).
+No server, no openstudio — pure logic.
 """
+import asyncio
 import base64
 import hashlib
+import io
 import json
+import logging
 import zipfile
+from pathlib import Path
 
 import pytest
 
-from mcp_server.skills.file_transfer import operations, signing
+from mcp_server.skills.file_transfer import operations, routes, signing
 from mcp_server.skills.file_transfer.archive import guarded_extract
 
 pytestmark = pytest.mark.unit
 
 _MB = 1 << 20
+
+
+def _http_request(method: str, query: str, path_params: dict, messages=None):
+    """Build a real starlette Request driven by a canned ASGI message list."""
+    from starlette.requests import Request
+
+    msgs = iter(messages or [])
+
+    async def receive():
+        return next(msgs)
+
+    scope = {
+        "type": "http", "method": method, "scheme": "http", "http_version": "1.1",
+        "server": ("test", 80), "client": ("127.0.0.1", 1), "root_path": "",
+        "path": "/files/x", "raw_path": b"/files/x",
+        "query_string": query.encode(), "headers": [], "path_params": path_params,
+    }
+    return Request(scope, receive)
 
 
 def test_signed_token_roundtrip():
@@ -159,3 +182,149 @@ def test_finalize_rejects_sha_mismatch():
     assert res["status"] == 422
     assert "sha256 mismatch" in res["error"]
     operations.delete_upload_op(fid)
+
+
+def test_reserved_filename_meta_json_preserved():
+    # Regression: uploading a file literally named meta.json had its bytes silently
+    # replaced by the entry's own metadata (finalize wrote both to the same path)
+    data = b"the users actual file bytes"
+    req = operations.request_upload_op(filename="meta.json", size_bytes=len(data))
+    assert req["ok"] is True, req
+    fid = req["file_id"]
+    tmp = operations._entry_dir("local", fid) / ".incoming"
+    tmp.write_bytes(data)
+    res = operations.finalize_upload("local", fid, tmp,
+                                     hashlib.sha256(data).hexdigest(), len(data))
+    assert res["ok"] is True, res
+    assert Path(res["server_path"]).read_bytes() == data, \
+        "uploaded bytes must survive a filename that collides with internal files"
+    info = operations.get_upload_op(fid)
+    assert info["ok"] is True and info["ready"] is True, info
+    operations.delete_upload_op(fid)
+
+
+def test_reserved_filename_extracted_archive_finalizes():
+    # Regression: a measure upload whose name sanitized to "extracted" collided with
+    # the extraction dir — uncaught FileExistsError became an HTTP 500 from the route
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("m/measure.rb", "class M; end\n")
+    data = buf.getvalue()
+    req = operations.request_upload_op(filename="extracted", size_bytes=len(data),
+                                       kind="measure")
+    fid = req["file_id"]
+    tmp = operations._entry_dir("local", fid) / ".incoming"
+    tmp.write_bytes(data)
+    res = operations.finalize_upload("local", fid, tmp,
+                                     hashlib.sha256(data).hexdigest(), len(data))
+    assert res["ok"] is True, res
+    assert (Path(res["extracted_path"]) / "measure.rb").is_file(), res
+    operations.delete_upload_op(fid)
+
+
+def test_unknown_kind_rejected():
+    # Validates: kind is validated against the documented enum, not silently stored
+    req = operations.request_upload_op(filename="x.osm", size_bytes=10, kind="bogus")
+    if req.get("ok"):  # red-run hygiene: don't leave an entry behind
+        operations.delete_upload_op(req["file_id"])
+    assert req["ok"] is False, req
+    assert "kind" in req["error"].lower()
+
+
+def test_disconnect_mid_put_cleans_partial():
+    # Regression: a client disconnect mid-PUT raised ClientDisconnect through the
+    # route and leaked the partial temp file, permanently counting toward quota
+    req = operations.request_upload_op(filename="part.bin", size_bytes=8)
+    fid = req["file_id"]
+    token = signing.make_token("local", fid, "u", 60)
+    request = _http_request("PUT", f"t={token}", {"file_id": fid}, [
+        {"type": "http.request", "body": b"abcd", "more_body": True},
+        {"type": "http.disconnect"},
+    ])
+    res = asyncio.run(routes.upload_route(request))  # must not raise
+    assert res.status_code == 400, res.status_code
+    entry = operations._entry_dir("local", fid)
+    stray = [p.name for p in entry.iterdir() if p.name.startswith(".incoming")]
+    assert stray == [], f"partial upload left behind: {stray}"
+    assert operations.get_upload_op(fid)["ready"] is False
+    operations.delete_upload_op(fid)
+
+
+def test_concurrent_puts_same_token_keep_winner_intact():
+    # Regression: two concurrent PUTs on one token shared the same temp file — the
+    # losing request's interleaved writes corrupted the winner's finalized upload
+    from starlette.requests import Request
+
+    data_a, data_b = b"A" * 8, b"B" * 8
+    req = operations.request_upload_op(filename="race.bin", size_bytes=8)
+    fid = req["file_id"]
+    token = signing.make_token("local", fid, "u", 60)
+
+    async def _run():
+        a_blocked, b_done = asyncio.Event(), asyncio.Event()
+        calls = {"n": 0}
+
+        async def receive_a():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return {"type": "http.request", "body": data_a[:4], "more_body": True}
+            a_blocked.set()
+            await b_done.wait()
+            return {"type": "http.request", "body": data_a[4:], "more_body": False}
+
+        scope = {
+            "type": "http", "method": "PUT", "scheme": "http", "http_version": "1.1",
+            "server": ("test", 80), "client": ("127.0.0.1", 1), "root_path": "",
+            "path": "/files/x", "raw_path": b"/files/x",
+            "query_string": f"t={token}".encode(), "headers": [],
+            "path_params": {"file_id": fid},
+        }
+        req_a = Request(scope, receive_a)
+        req_b = _http_request("PUT", f"t={token}", {"file_id": fid}, [
+            {"type": "http.request", "body": data_b, "more_body": False}])
+
+        task_a = asyncio.create_task(routes.upload_route(req_a))
+        await a_blocked.wait()                      # A mid-stream, holding its temp
+        res_b = await routes.upload_route(req_b)    # B streams fully and finalizes
+        b_done.set()
+        res_a = await task_a                        # A resumes after B won
+        return res_a, res_b
+
+    res_a, res_b = asyncio.run(_run())
+    assert res_b.status_code == 200, res_b.status_code
+    assert res_a.status_code == 409, res_a.status_code
+    info = operations.get_upload_op(fid)
+    assert info["ready"] is True, info
+    assert Path(info["server_path"]).read_bytes() == data_b, \
+        "winner's finalized bytes were corrupted by the losing PUT"
+    entry = operations._entry_dir("local", fid)
+    stray = [p.name for p in entry.iterdir() if p.name.startswith(".incoming")]
+    assert stray == [], f"losing PUT left a temp file: {stray}"
+    operations.delete_upload_op(fid)
+
+
+def test_download_audit_attributes_user():
+    # Regression: file_download audit lines carried no user attribution — the
+    # exfiltration direction was the one place audit couldn't say who
+    probe = operations._uploads_dir("local") / "audit_probe.txt"
+    probe.write_text("x")
+    token = signing.make_token("local", "-", "d", 60, p=str(probe))
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, rec):
+            records.append(json.loads(rec.getMessage()))
+
+    logger = logging.getLogger("openstudio-mcp.audit")
+    cap = _Capture()
+    logger.addHandler(cap)
+    try:
+        res = asyncio.run(routes.download_route(
+            _http_request("GET", f"t={token}", {"name": "audit_probe.txt"})))
+        assert res.status_code == 200, res.status_code
+    finally:
+        logger.removeHandler(cap)
+        probe.unlink(missing_ok=True)
+    dl = [r for r in records if r.get("event") == "file_download"]
+    assert len(dl) == 1, records
+    assert dl[0].get("user") == "local", f"download audit must say who: {dl[0]}"

--- a/tests/test_file_transfer_unit.py
+++ b/tests/test_file_transfer_unit.py
@@ -328,3 +328,78 @@ def test_download_audit_attributes_user():
     dl = [r for r in records if r.get("event") == "file_download"]
     assert len(dl) == 1, records
     assert dl[0].get("user") == "local", f"download audit must say who: {dl[0]}"
+
+
+def test_chmod_failure_does_not_crash_route():
+    # Regression: tmp.chmod() ran outside the stream try/except — an OSError on an
+    # exotic mount crashed the route and leaked the temp instead of finalizing
+    data = b"chmod-resilient"
+    req = operations.request_upload_op(filename="c.bin", size_bytes=len(data))
+    fid = req["file_id"]
+    token = signing.make_token("local", fid, "u", 60)
+    request = _http_request("PUT", f"t={token}", {"file_id": fid}, [
+        {"type": "http.request", "body": data, "more_body": False}])
+
+    real_chmod = Path.chmod
+
+    def _boom(self, *a, **k):
+        # only sabotage the .incoming temp's chmod, not unrelated chmods
+        if self.name.startswith(".incoming"):
+            raise OSError("chmod not supported on this mount")
+        return real_chmod(self, *a, **k)
+
+    orig = Path.chmod
+    Path.chmod = _boom
+    try:
+        res = asyncio.run(routes.upload_route(request))  # must not raise
+    finally:
+        Path.chmod = orig
+    assert res.status_code == 200, res.status_code
+    info = operations.get_upload_op(fid)
+    assert info["ready"] is True, info
+    entry = operations._entry_dir("local", fid)
+    stray = [p.name for p in entry.iterdir() if p.name.startswith(".incoming")]
+    assert stray == [], f"chmod failure leaked a temp: {stray}"
+    operations.delete_upload_op(fid)
+
+
+def test_finalize_concurrent_claim_rejects_second():
+    # Regression: two concurrent PUTs both passed the status!="ready" check before
+    # either wrote ready, both finalized -> double 200, nondeterministic bytes. An
+    # exclusive finalize claim must reject the loser even while status is "pending".
+    data = b"0123456789"
+    req = operations.request_upload_op(filename="r.bin", size_bytes=len(data))
+    fid = req["file_id"]
+    entry = operations._entry_dir("local", fid)
+    # Simulate PUT-A having claimed but not yet flipped status to ready:
+    (entry / ".finalized").write_bytes(b"")
+    tmp = entry / ".incoming"
+    tmp.write_bytes(data)
+    res = operations.finalize_upload("local", fid, tmp,
+                                     hashlib.sha256(data).hexdigest(), len(data))
+    assert res["ok"] is False and res["status"] == 409, res
+    assert not tmp.exists(), "loser's temp must be cleaned up"
+    operations.delete_upload_op(fid)
+
+
+def test_finalize_enforces_quota_post_extraction(monkeypatch, tmp_path):
+    # Regression: quota was only checked at mint (compressed size); a small archive
+    # expanding past OSMCP_USER_QUOTA_MB on extraction, or raced concurrent mints,
+    # could exceed the on-disk cap. finalize must re-check and roll back.
+    monkeypatch.setattr(operations, "OSMCP_USER_QUOTA_MB", 1)  # 1 MB cap
+    monkeypatch.setattr(operations, "_uploads_dir", lambda _key: tmp_path)  # isolate
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("m/big.bin", b"\0" * (3 * _MB))  # expands to 3 MB > 1 MB cap
+    data = buf.getvalue()
+    req = operations.request_upload_op(filename="x.zip", size_bytes=len(data), kind="measure")
+    assert req["ok"] is True, req  # tiny compressed size passes the mint check
+    fid = req["file_id"]
+    tmp = operations._entry_dir("local", fid) / ".incoming"
+    tmp.write_bytes(data)
+    res = operations.finalize_upload("local", fid, tmp,
+                                     hashlib.sha256(data).hexdigest(), len(data))
+    assert res["ok"] is False and res["status"] == 413, res
+    assert "quota" in res["error"].lower()
+    assert not operations._entry_dir("local", fid).exists(), \
+        "over-quota upload must roll back the whole entry"

--- a/tests/test_file_transfer_unit.py
+++ b/tests/test_file_transfer_unit.py
@@ -1,0 +1,161 @@
+"""Unit tests for the file-transfer channel: signing, filename safety, archive
+guards, and upload finalization. No server, no openstudio — pure logic.
+"""
+import base64
+import hashlib
+import json
+import zipfile
+
+import pytest
+
+from mcp_server.skills.file_transfer import operations, signing
+from mcp_server.skills.file_transfer.archive import guarded_extract
+
+pytestmark = pytest.mark.unit
+
+_MB = 1 << 20
+
+
+def test_signed_token_roundtrip():
+    # Validates: a token minted for (user, file, op) verifies and carries identity
+    tok = signing.make_token("alice", "abc123", "u", 60)
+    payload = signing.verify_token(tok, op="u")
+    assert payload["u"] == "alice"
+    assert payload["f"] == "abc123"
+    assert payload["op"] == "u"
+
+
+def test_tampered_signature_rejected():
+    # Regression: route authorization IS the HMAC — a flipped sig must not verify
+    tok = signing.make_token("alice", "abc", "u", 60)
+    body, _sig = tok.split(".", 1)
+    forged = f"{body}.{'A' * 43}"
+    with pytest.raises(ValueError, match="signature"):
+        signing.verify_token(forged)
+
+
+def test_tampered_payload_rejected():
+    # Regression: swapping the user in the body must invalidate the signature,
+    # so a leaked token can't be edited to impersonate another tenant.
+    tok = signing.make_token("alice", "abc", "u", 60)
+    _body, sig = tok.split(".", 1)
+    evil_body = base64.urlsafe_b64encode(
+        json.dumps({"u": "bob", "f": "abc", "op": "u", "exp": 9_999_999_999},
+                   separators=(",", ":"), sort_keys=True).encode(),
+    ).decode().rstrip("=")
+    with pytest.raises(ValueError, match="signature"):
+        signing.verify_token(f"{evil_body}.{sig}")
+
+
+def test_expired_token_rejected():
+    # Validates: short-TTL URLs must stop working once expired
+    tok = signing.make_token("alice", "abc", "u", -1)
+    with pytest.raises(ValueError, match="expired"):
+        signing.verify_token(tok)
+
+
+def test_wrong_op_token_rejected():
+    # Regression: an upload URL must not be replayable against the download route
+    tok = signing.make_token("alice", "abc", "u", 60)
+    with pytest.raises(ValueError, match="op"):
+        signing.verify_token(tok, op="d")
+
+
+@pytest.mark.parametrize(("raw", "expected"), [
+    ("../../etc/passwd", "passwd"),
+    ("/abs/model.osm", "model.osm"),
+    ("..\\..\\win.osm", "win.osm"),
+    ("", "upload.bin"),
+    ("a b;c.osm", "a_b_c.osm"),
+])
+def test_sanitize_filename(raw, expected):
+    # Regression: client filename must never become a path component
+    out = operations._sanitize_filename(raw)
+    assert out == expected
+    assert "/" not in out and "\\" not in out and ".." not in out
+
+
+def test_archive_rejects_path_escape(tmp_path):
+    # Regression: a `..` zip entry must not write outside the extract dir
+    z = tmp_path / "evil.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("../../escape.txt", "pwned")
+    err = guarded_extract(z, tmp_path / "out", max_uncompressed_bytes=_MB, max_entries=100)
+    assert err is not None and "escape" in err.lower()
+    assert not (tmp_path / "escape.txt").exists()
+    assert not (tmp_path.parent / "escape.txt").exists()
+
+
+def test_archive_rejects_symlink_member(tmp_path):
+    # Regression: a symlink entry (e.g. -> /etc/shadow) must be refused
+    z = tmp_path / "link.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        info = zipfile.ZipInfo("link")
+        info.external_attr = (0o120777 & 0xFFFF) << 16  # S_IFLNK | 0777
+        zf.writestr(info, "/etc/shadow")
+    err = guarded_extract(z, tmp_path / "out", max_uncompressed_bytes=_MB, max_entries=100)
+    assert err is not None and "symlink" in err.lower()
+
+
+def test_archive_rejects_zip_bomb(tmp_path):
+    # Validates: streamed uncompressed-size cap catches a high-ratio bomb
+    z = tmp_path / "bomb.zip"
+    with zipfile.ZipFile(z, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("big.bin", b"\0" * (3 * _MB))
+    err = guarded_extract(z, tmp_path / "out", max_uncompressed_bytes=_MB, max_entries=100)
+    assert err is not None and "bomb" in err.lower()
+
+
+def test_archive_rejects_too_many_entries(tmp_path):
+    # Validates: entry-count cap bounds inode/CPU blowups
+    z = tmp_path / "many.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        for i in range(20):
+            zf.writestr(f"f{i}.txt", "x")
+    err = guarded_extract(z, tmp_path / "out", max_uncompressed_bytes=_MB, max_entries=5)
+    assert err is not None and "too many" in err.lower()
+
+
+def test_archive_extracts_clean_tree(tmp_path):
+    # Validates: a well-formed archive extracts with files intact, no error
+    z = tmp_path / "ok.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("m/measure.rb", "class M; end\n")
+        zf.writestr("m/measure.xml", "<measure/>")
+    out = tmp_path / "out"
+    err = guarded_extract(z, out, max_uncompressed_bytes=_MB, max_entries=100)
+    assert err is None
+    assert (out / "m" / "measure.rb").read_text().startswith("class M")
+
+
+def test_finalize_rejects_size_mismatch():
+    # Regression: declared size must match streamed bytes (truncated/padded upload)
+    req = operations.request_upload_op(filename="m.osm", size_bytes=10)
+    assert req["ok"] is True
+    fid = req["file_id"]
+    entry = operations._entry_dir("local", fid)
+    tmp = entry / ".incoming"
+    tmp.write_bytes(b"short")  # 5 bytes, declared 10
+    res = operations.finalize_upload("local", fid, tmp,
+                                     hashlib.sha256(b"short").hexdigest(), 5)
+    assert res["ok"] is False
+    assert res["status"] == 422
+    assert "size mismatch" in res["error"]
+    operations.delete_upload_op(fid)
+
+
+def test_finalize_rejects_sha_mismatch():
+    # Regression: a corrupted upload (right size, wrong bytes) must be rejected
+    data = b"0123456789"
+    req = operations.request_upload_op(filename="m.osm", size_bytes=len(data),
+                                       sha256="deadbeef")
+    fid = req["file_id"]
+    entry = operations._entry_dir("local", fid)
+    tmp = entry / ".incoming"
+    tmp.write_bytes(data)
+    res = operations.finalize_upload("local", fid, tmp,
+                                     hashlib.sha256(data).hexdigest(), len(data))
+    assert res["ok"] is False
+    assert res["status"] == 422
+    assert "sha256 mismatch" in res["error"]
+    operations.delete_upload_op(fid)

--- a/tests/test_security_file_transfer.py
+++ b/tests/test_security_file_transfer.py
@@ -1,0 +1,222 @@
+"""Adversarial / abuse-case coverage for the remote file-transfer channel.
+
+Named test_security_*.py so it runs in the dedicated `security` workflow on BOTH
+amd64 and arm64 (alongside the sandbox suite), separate from the functional
+round-trips in tests/test_file_transfer.py.
+
+Threats covered: forged/expired signatures, cross-tenant read, path traversal in
+both directions (upload filename + download path = exfil), oversize, sha
+tampering, zip bombs over the live route, per-user quota, upload replay, and
+isolation under real token auth.
+"""
+import asyncio
+import hashlib
+import io
+import json
+import uuid
+import zipfile
+from pathlib import Path
+
+import httpx
+import pytest
+from conftest import http_server, http_session, integration_enabled, unwrap
+
+_MB = 1 << 20
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+def _base(url: str) -> str:
+    return url[: -len("/mcp")] if url.endswith("/mcp") else url
+
+
+def _put(url: str, upload_path: str, data: bytes) -> httpx.Response:
+    return httpx.put(_base(url) + upload_path, content=data, timeout=60)
+
+
+async def _mint(session, filename: str, data: bytes, kind: str = "auto") -> dict:
+    return unwrap(await session.call_tool("request_upload", {
+        "filename": filename, "size_bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(), "kind": kind,
+    }))
+
+
+async def _upload(session, url: str, filename: str, data: bytes, kind: str = "auto") -> dict:
+    req = await _mint(session, filename, data, kind)
+    assert req["ok"] is True, req
+    r = _put(url, req["upload_path"], data)
+    assert r.status_code == 200, f"PUT failed: {r.status_code} {r.text}"
+    return unwrap(await session.call_tool("get_upload", {"file_id": req["file_id"]}))
+
+
+def _need_integration():
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+
+@pytest.mark.integration
+def test_forged_signature_rejected():
+    # Regression: the route's only authorization is the HMAC sig — a forged ?t= must 403
+    _need_integration()
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        r = httpx.put(_base(url) + f"/files/u/{'0' * 32}?t=not.a.real.sig",
+                      content=b"x", timeout=30)
+        assert r.status_code == 403, r.text
+
+
+@pytest.mark.integration
+def test_upload_filename_traversal_neutralized():
+    # Regression: a hostile filename must not become a path component (server mints the id)
+    _need_integration()
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                info = await _upload(s, url, "../../etc/evil.osm", b"OS:Version,3.11.0;\n")
+                assert info["ready"] is True, info
+                assert ".." not in info["server_path"], info
+                assert "/uploads/" in info["server_path"], info
+                assert Path(info["server_path"]).name == "evil.osm", info
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_sha256_and_size_tampering_rejected():
+    # Regression: corrupted (right length, wrong bytes) or wrong-length uploads must 422, not persist
+    _need_integration()
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                good = b"hello world"
+                req = await _mint(s, "x.bin", good)
+                r = _put(url, req["upload_path"], b"HELLO WORLD")  # same len, different bytes
+                assert r.status_code == 422, r.text
+                assert "sha256 mismatch" in r.json()["error"]
+                got = unwrap(await s.call_tool("get_upload", {"file_id": req["file_id"]}))
+                assert got["ready"] is False, "rejected upload must not be marked ready"
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_oversize_rejected_at_mint_and_stream():
+    # Validates: size cap enforced at request time AND mid-stream (declared==cap, send more)
+    _need_integration()
+    with http_server({"MCP_AUTH": "none", "OSMCP_MAX_UPLOAD_MB": "1"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                over = unwrap(await s.call_tool("request_upload", {
+                    "filename": "big.osm", "size_bytes": 2 * _MB}))
+                assert over["ok"] is False and "max upload size" in over["error"], over
+
+                req = unwrap(await s.call_tool("request_upload", {
+                    "filename": "edge.osm", "size_bytes": _MB}))
+                r = _put(url, req["upload_path"], b"a" * (_MB + 64))
+                assert r.status_code == 413, r.text
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_uploads_private_per_user():
+    # Regression: one tenant's upload must not be readable or downloadable by another session
+    _need_integration()
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s1, http_session(url) as s2:
+                cr = unwrap(await s1.call_tool("create_example_osm", {"name": _uniq("u1")}))
+                data = Path(cr["osm_path"]).read_bytes()
+                info = await _upload(s1, url, "private.osm", data, kind="osm")
+                path1 = info["server_path"]
+
+                ld = unwrap(await s2.call_tool("load_osm_model", {"osm_path": path1}))
+                assert ld["ok"] is False and "not allowed" in ld["error"].lower(), ld
+
+                dl = unwrap(await s2.call_tool("request_download", {"path": path1}))
+                assert dl["ok"] is False and "not accessible" in dl["error"].lower(), dl
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_download_path_escape_denied():
+    # Regression: request_download must refuse host files outside the caller's roots (exfil guard)
+    _need_integration()
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                for victim in ("/etc/passwd", "/etc/shadow", "../../etc/passwd"):
+                    dl = unwrap(await s.call_tool("request_download", {"path": victim}))
+                    assert dl["ok"] is False, f"must refuse {victim}: {dl}"
+                    assert "not accessible" in dl["error"].lower(), dl
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_upload_replay_rejected():
+    # Regression: re-PUTting a completed upload must 409, not silently overwrite a referenced file
+    _need_integration()
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                data = b"OS:Version,3.11.0;\n"
+                req = await _mint(s, "once.osm", data)
+                assert _put(url, req["upload_path"], data).status_code == 200
+                replay = _put(url, req["upload_path"], data)
+                assert replay.status_code == 409, replay.text
+                assert "already completed" in replay.json()["error"]
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_zip_bomb_rejected_over_route():
+    # Validates: the live route + extractor reject a decompression bomb (not just the unit test)
+    _need_integration()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("m/measure.rb", b"\0" * (8 * _MB))  # tiny compressed, large expanded
+    bomb = buf.getvalue()
+
+    with http_server({"MCP_AUTH": "none", "OSMCP_MAX_ARCHIVE_UNCOMPRESSED_MB": "1"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                req = await _mint(s, "bomb.zip", bomb, kind="measure")
+                r = _put(url, req["upload_path"], bomb)
+                assert r.status_code == 422, r.text
+                assert "bomb" in r.json()["error"].lower()
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_per_user_quota_enforced():
+    # Validates: per-user upload quota blocks further uploads once exceeded
+    _need_integration()
+    with http_server({"MCP_AUTH": "none", "OSMCP_USER_QUOTA_MB": "1"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s:
+                chunk = b"a" * (700 * 1024)  # 700 KB; two would exceed the 1 MB quota
+                first = await _upload(s, url, "one.bin", chunk)
+                assert first["ready"] is True, first
+                second = await _mint(s, "two.bin", chunk)
+                assert second["ok"] is False, "second upload should be quota-blocked"
+                assert "quota" in second["error"].lower(), second
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_isolation_under_token_auth():
+    # Regression: under real token auth, uploads key to the principal and PUT needs no bearer
+    _need_integration()
+    tok_a, tok_b = "tok-alice", "tok-bob"
+    tokens = {tok_a: "alice", tok_b: "bob"}
+    with http_server({"MCP_AUTH": "token", "MCP_TOKENS": json.dumps(tokens)}) as (url, _proc):
+        async def _run():
+            async with http_session(url, token=tok_a) as sa, \
+                       http_session(url, token=tok_b) as sb:
+                cr = unwrap(await sa.call_tool("create_example_osm", {"name": _uniq("al")}))
+                data = Path(cr["osm_path"]).read_bytes()
+                info = await _upload(sa, url, "alice.osm", data, kind="osm")
+                # The signed PUT carried no bearer yet landed under alice's namespace.
+                assert "/alice/" in info["server_path"], info
+
+                ld = unwrap(await sb.call_tool("load_osm_model", {"osm_path": info["server_path"]}))
+                assert ld["ok"] is False and "not allowed" in ld["error"].lower(), ld
+        asyncio.run(_run())

--- a/tests/test_skill_registration.py
+++ b/tests/test_skill_registration.py
@@ -177,6 +177,12 @@ EXPECTED_TOOLS = {
     "search_wiring_patterns",
     # Tool Router
     "recommend_tools",
+    # File Transfer (remote/HTTP — get user files to/from the server)
+    "request_upload",
+    "get_upload",
+    "list_uploads",
+    "delete_upload",
+    "request_download",
 }
 
 
@@ -194,7 +200,7 @@ def test_all_skills_registered():
 
 
 def test_all_tool_names_registered():
-    # Validates: all 146 expected tools are registered, no extras — migration backward-compatibility
+    # Validates: all 151 expected tools are registered, no extras — migration backward-compatibility
     """Every expected tool function is registered via mcp.tool()."""
     registered_tools = {}
 

--- a/tests/test_tool_baseline.py
+++ b/tests/test_tool_baseline.py
@@ -55,12 +55,12 @@ def _register_tools_with_docs() -> dict[str, dict]:
 
 
 def test_tool_count():
-    # Validates: total registered tool count matches expected 146 — catches accidental add/remove
-    """Record current tool count (146 = 142 + 4 run-retention tools)."""
+    # Validates: total registered tool count matches expected 151 — catches accidental add/remove
+    """Record current tool count (151 = 142 + 4 run-retention + 5 file-transfer tools)."""
     tools = _register_tools_with_docs()
     count = len(tools)
     print(f"\nTool count: {count}")
-    assert count == 146, f"Expected 146 tools, got {count}"
+    assert count == 151, f"Expected 151 tools, got {count}"
 
 
 def test_total_schema_chars():
@@ -82,7 +82,7 @@ def test_total_schema_chars():
 
 
 def test_tags_coverage():
-    # Validates: tag coverage measurement — all 146 tools must be tagged post-Phase 2
+    # Validates: tag coverage measurement — all 151 tools must be tagged post-Phase 2
     """Check how many tools have tags. Post Phase 2: expect 100%."""
     tools = _register_tools_with_docs()
     tagged = {name: t for name, t in tools.items() if t["tags"]}
@@ -95,9 +95,9 @@ def test_tags_coverage():
 
     # Assert actual coverage matches expected state
     assert len(tools) > 0, "Should have tools to measure"
-    # Post-Phase 2: all 146 tools are tagged
-    assert len(tagged) == 146, (
-        f"Expected 146 tagged tools, found {len(tagged)}; "
+    # Post-Phase 2: all 151 tools are tagged
+    assert len(tagged) == 151, (
+        f"Expected 151 tagged tools, found {len(tagged)}; "
         f"untagged: {sorted(untagged)}"
     )
 


### PR DESCRIPTION
## Problem

On the remote/HTTP deployment, every file tool takes a **server-side path**
(`load_osm_model(osm_path)`, `apply_measure(measure_dir)`,
`change_building_location(weather_file)`, `import_floorspacejs`), but the user's
`.osm` / custom measure `.zip` / `.epw` live on their **laptop**. There was no way
to get them to the server. In-band base64 is a non-starter — MCP tool args are
emitted by the LLM, so a 1 MB OSM ≈ ~350K tokens and the bytes would land in
context + audit logs.

## Approach

An **out-of-band, signed file channel** on the same FastMCP app/port — bytes move
beside the protocol, never through the model.

```
request_upload(filename, size_bytes[, sha256, kind])   ← authenticated MCP call
   → { file_id, signed upload_url, expires_in }
curl --upload-file model.osm "<upload_url>"            ← out-of-band PUT, no bearer
   → route: verify HMAC+TTL+size → stream to disk → sha256 → auto-extract .zip
get_upload(file_id) → server_path
load_osm_model(osm_path=server_path)                   ← existing tool, unchanged
```

**Why signed URLs (not bearer-on-route):** verified empirically that FastMCP
`custom_route` is **not** behind the `auth=` verifier (a custom route serves `200`
with no/bad token). So the route's authorization *is* the HMAC signature, minted
by the authenticated `request_upload`. The long-lived token never enters the URL
or the model context; a leaked URL expires fast and is scoped to one file + op.

## What's included

- **New `file_transfer` skill**: `request_upload`, `get_upload`, `list_uploads`,
  `delete_upload`, `request_download` + signed `PUT /files/u/{id}` &
  `GET /files/d/{name}` custom routes.
- Uploads land in the **existing** per-user, path-allowlisted, per-tenant-uid
  sandboxed `RUN_ROOT/<user>/uploads/` — `is_path_allowed`, uid-drop, and
  `reject_escaping_symlinks` are all reused. Consuming tools need **no changes**.
- Measure `.zip` (or `kind="measure"`) **auto-extracted** on ingest with zip-bomb,
  entry-count, and path/symlink-escape guards.
- Enforced: max upload size, per-user quota, optional sha256 integrity, audit
  (name/size/sha only — never content). Signing key auto-generated + persisted
  (`OSMCP_FILE_SIGNING_KEY` to override/rotate).
- `python -m mcp_server.tools.osmcp put|get` CLI fallback for shell-less clients.

## Review fixes (3632ad5)

Self-review of the feature commit found 3 bugs + hardening gaps; each fixed
**red-green** (failing test committed alongside the fix):

- **`osmcp put` CLI was broken end-to-end** — httpx `AsyncClient` rejects a sync
  file object as `content=` (`RuntimeError`); the CLI path had no test. Now an
  async chunk generator; `get` streams to disk too. New CLI round-trip test runs
  under token auth (put/get are separate MCP sessions — identity must come from
  the token, which is also the documented CLI setup).
- **Reserved filenames** — uploading a file literally named `meta.json` had its
  bytes silently replaced by the entry's own metadata (`ok=True`, data lost);
  a measure named `extracted` collided with the extraction dir → uncaught
  `FileExistsError` → 500. Payload now lands in `entry/data/` so client filenames
  can never collide with bookkeeping files.
- **Client disconnect mid-PUT** raised `ClientDisconnect` through the route and
  leaked the partial temp file (counted toward quota forever). Caught + unlinked.
- **Concurrent PUTs on one token** shared `entry/.incoming` — the loser's open fd
  corrupted the winner's finalized bytes (proven with a deterministic fake-ASGI
  interleave test). Unique `mkstemp` temp per request.
- **`file_download` audit had no user attribution** — the exfil direction was the
  one place audit couldn't say who. `verify_download` now returns the key.
- `kind` validated against the documented enum; signing key created with
  `O_CREAT|O_EXCL` 0600 (no chmod window, cold-started workers converge on one
  key); `_zip_bundle` moved off the event loop (`run_in_threadpool`).

## Security tests

Split functional from adversarial; abuse cases run in **`security.yml` on amd64 +
arm64** (it globs `test_security_*.py`).

- `tests/test_security_file_transfer.py` (10): forged-sig 403, traversal filename,
  sha/size tampering 422, oversize mint+stream 413, cross-user read/download
  denied, **download path-escape `/etc/passwd` denied (exfil guard)**, upload
  replay 409, **zip-bomb over the live route 422**, **per-user quota enforced**,
  **isolation under real token auth (signed PUT needs no bearer)**.
- `tests/test_file_transfer.py` (5, ci shard 2): upload→`load_osm_model`,
  measure-zip extract→`list_measure_arguments`, download round-trip, bundle
  download round-trip, CLI put/get round-trip.
- `tests/test_file_transfer_unit.py` (23): HMAC sign/verify/tamper/expiry,
  filename sanitize, archive guards, finalize size/sha mismatch, reserved
  filenames, disconnect cleanup, concurrent-PUT race, download audit user.

All 38 pass in Docker; ruff clean; full `-m "not integration"` = 292 pass
(tool-count gates updated 146 → 151); remote/auth/audit neighbor suites 11/11.

## Doc fixes bundled (instruction-file audit)

Closes #70 (measure-authoring vs no-scripts rule + stdio-only path), closes #71
(openstudio-patterns stale path-denied error row), closes #72 (qaqc/energy-report
duplicate step numbers) — all fixed in e3e0ee4.

## Notes / follow-ups

- Local-disk sidecar (matches the VPN/Tailscale single-box target). Object store
  (S3/MinIO presigned) is the multi-box / cloud follow-up.
- A single `.epw` has no `.ddy`/`.stat` companions — upload weather as a
  `kind="weather"` zip so they extract side-by-side.
- Stale `pending` entries (minted, never PUT) and failed-extract leftovers are not
  GC'd yet — bounded by quota; cleanup is a follow-up.
- Design doc: `docs/plans/plan-remote-file-transfer.md`; usage:
  `docs/remote-multi-user.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

