### PR TITLE
chore: tool-count single source of truth + CI duplicate-run cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,19 @@
 name: ci
 
+# Trigger on PRs (open + every push to the PR) and on pushes to long-lived
+# branches only. Without the push branch filter, a push to a branch that has
+# an open PR fires BOTH push and pull_request → every job runs twice.
 on:
   push:
+    branches: [main, develop]
   pull_request:
+
+# Cancel superseded in-progress runs on rapid re-push (saves runner minutes).
+# Note: this does NOT dedupe push vs pull_request — they use different
+# github.ref values; the push branch filter above is what removes that dup.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   arm64-build:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,11 +7,18 @@ name: security
 # use arch-specific syscall numbers, so arm64 must be exercised explicitly.
 # Individual tests still pin their own mode per fixture (off/posix/auto).
 
+# Same triggers as ci.yml so the security suite runs like every other test:
+# every PR, plus post-merge on long-lived branches. workflow_dispatch keeps a
+# manual "run now" button.
 on:
   push:
-    branches: [feat/measure-exec-sandbox]
+    branches: [main, develop]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   security-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@ always be brutally honest
 ## Project: openstudio-mcp
 MCP server giving AI agents full control of building energy modeling —
 create buildings, author measures, configure HVAC, run EnergyPlus sims, extract
-results — all through 151 MCP tools backed by the OpenStudio SDK.
+results — all through 150+ MCP tools backed by the OpenStudio SDK.
 
 ## Critical: Use MCP Tools — Do Not Reinvent
 Always use openstudio-mcp tools for BEM tasks:
@@ -27,6 +27,7 @@ Always use openstudio-mcp tools for BEM tasks:
 11. Bundled measures get wrapper tools with typed args — don't expose raw `apply_measure` as primary interface
 12. No `getattr()` or string-based dispatch — every OpenStudio API method called directly (grepable, lintable, visible in stack traces)
 13. MCP clients may send `list[str]` as JSON strings — use `list[str] | str` type annotation + `parse_str_list()` from `osm_helpers.py`
+14. Tool roster has ONE source of truth: `EXPECTED_TOOLS` in `tests/test_skill_registration.py`. Add/remove a tool → edit that set (one line per tool; merges cleanly across branches). `test_tool_count`/`test_tags_coverage` derive from it — never hardcode a tool-count literal in tests. Docs/instructions say "150+ tools", not an exact count
 
 ## Architecture
 - Each skill lives in `mcp_server/skills/<name>/`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Model Context Protocol server for [OpenStudio](https://openstudio.net/) building energy simulation.** It lets MCP hosts — Claude Desktop, Claude Code, Cursor, VS Code — create, query, and modify OpenStudio models, run EnergyPlus, and read results, all in plain language. The server handles the OpenStudio/EnergyPlus complexity behind MCP tool calls.
 
-**151 tools · 12 workflow skills · 480+ integration tests**
+**150+ tools · 12 workflow skills · 480+ integration tests**
 
 ---
 
@@ -192,7 +192,7 @@ Workflow/task skills are invoked with `/name`; knowledge skills load automatical
 
 ## Tool reference
 
-151 tools, grouped by area — expand a group to see its tools. New here? `create_new_building`, `run_simulation`, and `extract_summary_metrics` cover most workflows; `list_skills()` and `recommend_tools(task)` help the AI find the rest.
+150+ tools, grouped by area — expand a group to see its tools. New here? `create_new_building`, `run_simulation`, and `extract_summary_metrics` cover most workflows; `list_skills()` and `recommend_tools(task)` help the AI find the rest.
 
 <details>
 <summary><b>Model creation & management</b> — 13 tools</summary>

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -57,7 +57,7 @@ def _build_auth():
 mcp = FastMCP(
     "openstudio-mcp",
     instructions=(
-        "Building energy simulation server (OpenStudio SDK) with 151 tools for "
+        "Building energy simulation server (OpenStudio SDK) with 150+ tools for "
         "creating, modifying, simulating, and analyzing building energy models. "
         "Use these tools for all building energy modeling tasks — if no tool "
         "exists for a task, ask the user before writing code. "

--- a/tests/test_tool_baseline.py
+++ b/tests/test_tool_baseline.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from test_skill_registration import EXPECTED_TOOLS
 
 from mcp_server.skills import register_all_skills
 
@@ -55,12 +56,21 @@ def _register_tools_with_docs() -> dict[str, dict]:
 
 
 def test_tool_count():
-    # Validates: total registered tool count matches expected 151 — catches accidental add/remove
-    """Record current tool count (151 = 142 + 4 run-retention + 5 file-transfer tools)."""
+    # Validates: registered tool count equals the EXPECTED_TOOLS manifest — catches accidental add/remove
+    """Tool count is derived from EXPECTED_TOOLS, not a hardcoded literal.
+
+    The exact set is pinned in test_skill_registration.EXPECTED_TOOLS, which
+    merges cleanly across branches (one line per tool). A scalar literal here
+    would conflict on every tool-adding PR for no added safety —
+    test_all_tool_names_registered already pins the exact set by name.
+    """
     tools = _register_tools_with_docs()
     count = len(tools)
     print(f"\nTool count: {count}")
-    assert count == 151, f"Expected 151 tools, got {count}"
+    assert count == len(EXPECTED_TOOLS), (
+        f"Registered {count} tools but EXPECTED_TOOLS pins {len(EXPECTED_TOOLS)}; "
+        "add/remove the tool in test_skill_registration.EXPECTED_TOOLS"
+    )
 
 
 def test_total_schema_chars():
@@ -82,7 +92,7 @@ def test_total_schema_chars():
 
 
 def test_tags_coverage():
-    # Validates: tag coverage measurement — all 151 tools must be tagged post-Phase 2
+    # Validates: every registered tool is tagged (100% tag coverage) — no literal count to drift
     """Check how many tools have tags. Post Phase 2: expect 100%."""
     tools = _register_tools_with_docs()
     tagged = {name: t for name, t in tools.items() if t["tags"]}
@@ -95,10 +105,10 @@ def test_tags_coverage():
 
     # Assert actual coverage matches expected state
     assert len(tools) > 0, "Should have tools to measure"
-    # Post-Phase 2: all 151 tools are tagged
-    assert len(tagged) == 151, (
-        f"Expected 151 tagged tools, found {len(tagged)}; "
-        f"untagged: {sorted(untagged)}"
+    # Post-Phase 2: every registered tool must be tagged (100% coverage)
+    assert not untagged, (
+        f"All {len(tools)} tools must be tagged; "
+        f"{len(untagged)} untagged: {sorted(untagged)}"
     )
 
 


### PR DESCRIPTION
Two related cleanups bundled as general hygiene.

## 1. Single source of truth for tool count
Every tool-adding PR conflicts on `develop` for the same reason: the exact tool count is hardcoded as a scalar literal in ~5 places. Git merges two branches *adding names to a set* cleanly, but **cannot merge two branches incrementing the same integer**. PRs #65 and #66 both hit this — their `EXPECTED_TOOLS` set additions merged cleanly; only the `== 151` literals conflicted.

- `test_tool_count` → `assert count == len(EXPECTED_TOOLS)` (no literal; the roster is already pinned by `test_all_tool_names_registered`'s set-equality, so the scalar was redundant).
- `test_tags_coverage` → `assert not untagged` — the real "100% tagged" invariant.
- Docs/instructions (`README.md` ×2, `CLAUDE.md`, `mcp_server/server.py`) → `150+ tools`, not an exact number.
- `CLAUDE.md` rule 14 documents `EXPECTED_TOOLS` as the single source of truth.

No behavior change: `len(EXPECTED_TOOLS) == 151` today. Falsifiable: a tool missing from the manifest fails `test_tool_count`; an untagged tool fails `test_tags_coverage`.

## 2. Kill duplicate CI runs
`ci.yml` had `on: {push:, pull_request:}` with no push branch filter, so any branch with an open PR fired **both** events → every job (build, arm64-build, 5 `test` shards, 2 `arm64-test`) ran **twice**.

- `ci.yml`: `push` restricted to `[main, develop]`; `pull_request` covers PRs. Added `concurrency` to cancel superseded runs.
- `security.yml`: same triggers (was pinned to the stale `feat/measure-exec-sandbox` branch, so it never ran on develop/main) — the security suite now runs like every other test: every PR + post-merge.

Tradeoff (accepted): pushes to a feature branch with **no open PR** no longer trigger CI.

## Verification
`pytest tests/test_tool_baseline.py tests/test_skill_registration.py` → 8 passed; `ruff check` clean; both workflow YAMLs parse.

## Payoff
After merge, all future tool PRs are conflict-free on counts, and CI stops running everything twice. #65/#66 collapse to a trivial "take develop's side" on count lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)