### PR TITLE
feat(auth): self-signed JWT for restart-free user onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ docs/review/
 # Local HTTP deployment — contains live bearer tokens + machine IPs, never commit
 .mcp.json
 HTTP-DEPLOYMENT-LOCAL.md
+
+# JWT signing keys (scripts/mint_token.py) — private key mints any user; never commit
+*.pem

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -78,13 +78,81 @@ $b = New-Object byte[] 24
 
 The server verifies the `Authorization: Bearer …` header on **every** request
 before any tool runs; a missing or unknown token is rejected (401). Rotate or
-revoke by editing `MCP_TOKENS` and restarting. For `jwt` mode, tokens are minted
-and signed by your IdP instead, and the server only verifies them.
+revoke by editing `MCP_TOKENS` and restarting. For `jwt` mode, tokens are signed
+by an IdP — or by your own key (see below) — and the server only verifies them.
 
 > **Token storage is plaintext** (`StaticTokenVerifier`). Fine for a trusted team
 > behind a VPN. For SSO/public deployments use `MCP_AUTH=jwt` and point it at your
 > IdP's verifying key (`MCP_JWT_PUBLIC_KEY`, a PEM) or JWKS endpoint
 > (`MCP_JWT_JWKS_URI`), optionally constraining `MCP_JWT_ISSUER` / `MCP_JWT_AUDIENCE`.
+
+### Adding users without a restart (self-signed JWT)
+
+Token mode is simple but **static**: every add / rotate / revoke means editing
+`MCP_TOKENS` and restarting (which drops live sessions). If your roster changes
+often, run `MCP_AUTH=jwt` and become your own tiny token issuer — no external IdP
+required. The server then holds only a **public key**; you keep the **private
+key** and mint one token per user. Adding a user touches nothing on the server,
+so **no restart**.
+
+`scripts/mint_token.py` is the whole workflow:
+
+```bash
+# one-time: generate an RSA key pair in the current dir (private.pem + public.pem)
+python scripts/mint_token.py keygen
+
+# per user, any time (no restart): prints a ready-to-paste Authorization header
+python scripts/mint_token.py issue --user alice          # 30-day token
+python scripts/mint_token.py issue --user bob --days 7
+```
+
+Start the server with the **public** key only (`issuer`/`audience` are fixed
+labels the server re-checks on every request — pick them once):
+
+```bash
+docker run -d --name openstudio-mcp -p 8000:8000 \
+  -e MCP_TRANSPORT=http -e MCP_AUTH=jwt \
+  -e MCP_JWT_PUBLIC_KEY="$(cat public.pem)" \
+  -e MCP_JWT_ISSUER=urn:openstudio-mcp \
+  -e MCP_JWT_AUDIENCE=openstudio-mcp \
+  -v /data/runs:/runs -v /data/inputs:/inputs \
+  openstudio-mcp:latest
+```
+
+```powershell
+# Windows PowerShell — pass the multi-line PEM via $env, not inline -e "..."
+$env:MCP_JWT_PUBLIC_KEY = Get-Content public.pem -Raw
+docker run -d --name openstudio-mcp -p 8000:8000 `
+  -e MCP_TRANSPORT=http -e MCP_AUTH=jwt `
+  -e MCP_JWT_PUBLIC_KEY `
+  -e MCP_JWT_ISSUER=urn:openstudio-mcp `
+  -e MCP_JWT_AUDIENCE=openstudio-mcp `
+  -v "C:/data/runs:/runs" -v "C:/data/inputs:/inputs" `
+  openstudio-mcp:latest
+```
+
+The minted token goes in the user's `.mcp.json` exactly like a static token (see
+§2). The username becomes the token's `sub` claim and scopes that user's
+`/runs/<user>/` — same isolation as token mode.
+
+**The tradeoff is revocation.** JWTs are stateless: a token is valid until it
+expires. You cannot cheaply kill one leaked token early — your options are (a)
+let it expire, so keep TTLs short enough that "wait it out" is acceptable, or (b)
+rotate the key pair (`keygen` again → update `MCP_JWT_PUBLIC_KEY` → restart once →
+re-issue everyone), which invalidates **all** tokens at once. If you need instant
+per-user revoke or SSO, graduate to a managed IdP via `MCP_JWT_JWKS_URI` (config
+only, no code change).
+
+> **Guard the private key like a root password.** Anyone holding it can mint a
+> token for any user. It lives only on your admin machine — never in the repo, a
+> `.mcp.json`, or a Docker image (`*.pem` is gitignored). The server only ever
+> sees the public key.
+>
+> **Don't let tokens carry a `client_id` or `azp` claim.** Identity resolves as
+> `client_id || azp || sub`, so a shared `azp` (common from real IdPs, where it's
+> the *application* id) would collapse every user onto one identity and one run
+> dir. `mint_token.py` sets only `sub`; if you move to a managed IdP, map the
+> per-user claim accordingly.
 
 ---
 
@@ -330,8 +398,9 @@ absolute origin is resolved from the request host; behind a reverse proxy, set
 
 - **Single box only** — in-memory model state isn't shared across machines.
   Horizontal scale would need a per-user-container topology behind a router.
-- **Static token auth is plaintext** — use `MCP_AUTH=jwt` (IdP-signed JWTs) for
-  SSO/public deployments.
+- **Static token auth is plaintext, and adding/revoking a token needs a restart**
+  — for restart-free onboarding use `MCP_AUTH=jwt` (self-signed key or an IdP); see
+  [Adding users without a restart](#adding-users-without-a-restart-self-signed-jwt).
 
 See `docs/plans/multi-user-remote-mcp.md` for the full design rationale.
 

--- a/docs/remote-multi-user.md
+++ b/docs/remote-multi-user.md
@@ -116,7 +116,7 @@ docker run -d --name openstudio-mcp -p 8000:8000 \
   -e MCP_JWT_ISSUER=urn:openstudio-mcp \
   -e MCP_JWT_AUDIENCE=openstudio-mcp \
   -v /data/runs:/runs -v /data/inputs:/inputs \
-  openstudio-mcp:latest
+  openstudio-mcp:dev openstudio-mcp
 ```
 
 ```powershell
@@ -128,7 +128,7 @@ docker run -d --name openstudio-mcp -p 8000:8000 `
   -e MCP_JWT_ISSUER=urn:openstudio-mcp `
   -e MCP_JWT_AUDIENCE=openstudio-mcp `
   -v "C:/data/runs:/runs" -v "C:/data/inputs:/inputs" `
-  openstudio-mcp:latest
+  openstudio-mcp:dev openstudio-mcp
 ```
 
 The minted token goes in the user's `.mcp.json` exactly like a static token (see

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -85,6 +85,7 @@ def issue_token(
 
     if not subject or not subject.strip():
         raise ValueError("subject (username) must be a non-empty string")
+    subject = subject.strip()  # normalize: " alice " and "alice" must be one identity
     issued = now or datetime.now(UTC)
     payload = {
         "sub": subject,

--- a/scripts/mint_token.py
+++ b/scripts/mint_token.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Mint RSA-signed JWTs for an openstudio-mcp HTTP server running ``MCP_AUTH=jwt``.
+
+You become a tiny token issuer: generate one RSA key pair, hand the PUBLIC key
+to the server (``MCP_JWT_PUBLIC_KEY``), and keep the PRIVATE key here on your
+admin machine. Issue one token per user with ``issue`` — adding or rotating a
+user needs NO server restart, because the server stores only the public key,
+never a roster.
+
+The token carries the username in the ``sub`` claim and nothing else that the
+server treats as identity. openstudio-mcp scopes each user's run directory by
+that identity (``/runs/<user>/``), so two users stay isolated. Do NOT add a
+``client_id`` or ``azp`` claim: FastMCP's JWTVerifier prefers those over ``sub``,
+which would collapse every user onto one identity.
+
+Usage
+-----
+One-time, generate a key pair (writes private.pem + public.pem to the cwd)::
+
+    python scripts/mint_token.py keygen
+
+Per user (prints a ready-to-paste Authorization header)::
+
+    python scripts/mint_token.py issue --user alice
+    python scripts/mint_token.py issue --user bob --days 7
+
+Server side (give it the PUBLIC key only)::
+
+    MCP_AUTH=jwt
+    MCP_JWT_PUBLIC_KEY="$(cat public.pem)"
+    MCP_JWT_ISSUER=urn:openstudio-mcp
+    MCP_JWT_AUDIENCE=openstudio-mcp
+
+Revocation: tokens are stateless and valid until they expire. To kill ONE token
+early you must either wait out its TTL or rotate the key pair (keygen again +
+update the server's public key + re-issue everyone). Keep TTLs short enough that
+"wait it out" is acceptable, or move to a managed IdP if you need instant revoke.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+DEFAULT_ISSUER = "urn:openstudio-mcp"
+DEFAULT_AUDIENCE = "openstudio-mcp"
+DEFAULT_DAYS = 30
+
+
+def generate_keypair(key_size: int = 2048) -> tuple[str, str]:
+    """Return (private_pem, public_pem) as PEM strings for an RSA key pair."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    public_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    return private_pem, public_pem
+
+
+def issue_token(
+    private_pem: str,
+    subject: str,
+    *,
+    issuer: str = DEFAULT_ISSUER,
+    audience: str = DEFAULT_AUDIENCE,
+    days: int = DEFAULT_DAYS,
+    now: datetime | None = None,
+) -> str:
+    """Sign an RS256 JWT carrying ``sub=subject`` and an expiry ``days`` out.
+
+    Deliberately sets only sub/iss/aud/iat/exp — no client_id/azp, so the
+    server's identity (and thus the per-user run dir) resolves to ``subject``.
+    """
+    import jwt  # PyJWT
+
+    if not subject or not subject.strip():
+        raise ValueError("subject (username) must be a non-empty string")
+    issued = now or datetime.now(UTC)
+    payload = {
+        "sub": subject,
+        "iss": issuer,
+        "aud": audience,
+        "iat": issued,
+        "exp": issued + timedelta(days=days),
+    }
+    return jwt.encode(payload, private_pem, algorithm="RS256")
+
+
+def _cmd_keygen(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    priv_path = out_dir / args.private_name
+    pub_path = out_dir / args.public_name
+    if priv_path.exists() and not args.force:
+        print(
+            f"refusing to overwrite existing {priv_path} (use --force to replace; "
+            f"replacing the key invalidates every token already issued)",
+            file=sys.stderr,
+        )
+        return 1
+    private_pem, public_pem = generate_keypair(key_size=args.key_size)
+    priv_path.write_text(private_pem, encoding="ascii")
+    pub_path.write_text(public_pem, encoding="ascii")
+    with contextlib.suppress(OSError):  # best effort; a no-op on Windows
+        priv_path.chmod(0o600)
+    print(f"wrote {priv_path}  (PRIVATE — keep secret, never commit, never bake into an image)")
+    print(f"wrote {pub_path}   (PUBLIC — give to the server via MCP_JWT_PUBLIC_KEY)")
+    print()
+    print("Start the server with:")
+    print("  MCP_AUTH=jwt \\")
+    print(f'  MCP_JWT_PUBLIC_KEY="$(cat {pub_path})" \\')
+    print(f"  MCP_JWT_ISSUER={DEFAULT_ISSUER} \\")
+    print(f"  MCP_JWT_AUDIENCE={DEFAULT_AUDIENCE}")
+    return 0
+
+
+def _cmd_issue(args: argparse.Namespace) -> int:
+    priv_path = Path(args.private)
+    if not priv_path.exists():
+        print(f"private key not found: {priv_path} (run `keygen` first?)", file=sys.stderr)
+        return 1
+    token = issue_token(
+        priv_path.read_text(encoding="ascii"),
+        args.user,
+        issuer=args.issuer,
+        audience=args.audience,
+        days=args.days,
+    )
+    expires = (datetime.now(UTC) + timedelta(days=args.days)).date().isoformat()
+    print(f"# user={args.user}  expires={expires}  (in {args.days} days)")
+    print(f"Authorization: Bearer {token}")
+    print()
+    print("Put it in the user's .mcp.json header:")
+    print(f'  "headers": {{ "Authorization": "Bearer {token}" }}')
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    g = sub.add_parser("keygen", help="generate an RSA key pair (one-time)")
+    g.add_argument("--out-dir", default=".", help="directory to write the keys (default: cwd)")
+    g.add_argument("--private-name", default="private.pem")
+    g.add_argument("--public-name", default="public.pem")
+    g.add_argument("--key-size", type=int, default=2048)
+    g.add_argument("--force", action="store_true", help="overwrite an existing private key")
+    g.set_defaults(func=_cmd_keygen)
+
+    i = sub.add_parser("issue", help="mint a bearer token for a user")
+    i.add_argument("--user", required=True, help="username -> token subject -> /runs/<user>/")
+    i.add_argument("--days", type=int, default=DEFAULT_DAYS, help=f"TTL in days (default: {DEFAULT_DAYS})")
+    i.add_argument("--private", default="private.pem", help="path to the private key")
+    i.add_argument("--issuer", default=DEFAULT_ISSUER)
+    i.add_argument("--audience", default=DEFAULT_AUDIENCE)
+    i.set_defaults(func=_cmd_issue)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,6 +89,157 @@ def test_http_jwt_auth_accepts_signed_rejects_unsigned():
         asyncio.run(_run())
 
 
+# --- Self-signed JWT: restart-free user onboarding (scripts/mint_token.py) ------
+# These exercise the SAME minting code an operator runs to add a user, then prove
+# the server accepts tokens it never saw at startup and keeps users isolated.
+import sys  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import mint_token  # noqa: E402
+
+JWT_ISSUER = "urn:openstudio-mcp"
+JWT_AUDIENCE = "openstudio-mcp"
+
+
+def _jwt_env(public_pem: str) -> dict:
+    return {
+        "MCP_AUTH": "jwt",
+        "MCP_JWT_PUBLIC_KEY": public_pem,
+        "MCP_JWT_ISSUER": JWT_ISSUER,
+        "MCP_JWT_AUDIENCE": JWT_AUDIENCE,
+    }
+
+
+def _mint(private_pem: str, user: str, **kw) -> str:
+    kw.setdefault("issuer", JWT_ISSUER)
+    kw.setdefault("audience", JWT_AUDIENCE)
+    return mint_token.issue_token(private_pem, user, **kw)
+
+
+@pytest.mark.integration
+def test_jwt_add_user_after_startup_needs_no_restart_and_scopes_run_dir():
+    # Validates: the headline property. The server boots holding only the public
+    # key (no roster). A token minted AFTER startup for a never-seen subject is
+    # accepted with no restart, and the subject (sub claim) scopes its run dir.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    private_pem, public_pem = mint_token.generate_keypair()
+    with http_server(_jwt_env(public_pem)) as (url, _proc):
+        async def _run():
+            # First user.
+            tok_a = _mint(private_pem, "alice_jwt")
+            async with http_session(url, token=tok_a) as s:
+                res = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("jwtA")}))
+                assert res["ok"] is True, res
+                assert "/alice_jwt/" in res["out_dir"], \
+                    f"JWT sub must scope the run dir: {res['out_dir']}"
+
+            # Second user minted now — server is NOT restarted between the two.
+            tok_b = _mint(private_pem, "bob_jwt")
+            async with http_session(url, token=tok_b) as s:
+                res = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("jwtB")}))
+                assert res["ok"] is True, res
+                assert "/bob_jwt/" in res["out_dir"], \
+                    f"a user added after startup must get its own scoped dir: {res['out_dir']}"
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_jwt_users_cannot_read_each_others_files():
+    # Validates: two distinct JWT subjects are isolated — one cannot load a file
+    # under the other's run root (path scoping), same guarantee as token mode.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    private_pem, public_pem = mint_token.generate_keypair()
+    with http_server(_jwt_env(public_pem)) as (url, _proc):
+        async def _run():
+            tok_a = _mint(private_pem, "alice_jwt")
+            tok_b = _mint(private_pem, "bob_jwt")
+            async with http_session(url, token=tok_a) as sa, http_session(url, token=tok_b) as sb:
+                cr = unwrap(await sa.call_tool("create_example_osm", {"name": _uniq("ua")}))
+                assert cr["ok"] is True, cr
+                alice_osm = cr["osm_path"]
+                assert "/alice_jwt/" in alice_osm, alice_osm
+
+                # bob must not read a file under alice's run root.
+                ld = unwrap(await sb.call_tool("load_osm_model", {"osm_path": alice_osm}))
+                assert ld["ok"] is False, f"bob must not read alice's file: {ld}"
+                assert "not allowed" in ld["error"].lower(), ld
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_jwt_client_id_claim_overrides_sub_identity():
+    # Validates (guardrail): FastMCP resolves identity as client_id || azp || sub.
+    # A token carrying azp/client_id therefore scopes the run dir to THAT claim,
+    # not sub — the footgun that collapses many users onto one identity if an IdP
+    # stamps a shared azp. mint_token omits these claims on purpose; this locks in
+    # the precedence so a regression (or a misconfigured IdP) is caught loudly.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    from datetime import UTC, datetime, timedelta
+
+    import jwt as pyjwt
+
+    private_pem, public_pem = mint_token.generate_keypair()
+    now = datetime.now(UTC)
+    token = pyjwt.encode(
+        {
+            "sub": "real_user",
+            "azp": "shared_app",  # an IdP's application id, NOT the human
+            "iss": JWT_ISSUER, "aud": JWT_AUDIENCE,
+            "iat": now, "exp": now + timedelta(days=1),
+        },
+        private_pem, algorithm="RS256",
+    )
+    with http_server(_jwt_env(public_pem)) as (url, _proc):
+        async def _run():
+            async with http_session(url, token=token) as s:
+                res = unwrap(await s.call_tool("create_example_osm", {"name": _uniq("azp")}))
+                assert res["ok"] is True, res
+                assert "/shared_app/" in res["out_dir"], \
+                    f"azp/client_id must win over sub (documented footgun): {res['out_dir']}"
+                assert "/real_user/" not in res["out_dir"], res["out_dir"]
+
+        asyncio.run(_run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("kind", ["expired", "wrong_issuer", "wrong_audience"])
+def test_jwt_rejects_bad_tokens(kind):
+    # Validates: signature is necessary but not sufficient — expired tokens and
+    # tokens with the wrong issuer/audience are rejected even though they are
+    # signed by the configured key.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    private_pem, public_pem = mint_token.generate_keypair()
+    if kind == "expired":
+        bad = _mint(private_pem, "alice_jwt", days=-1)
+    elif kind == "wrong_issuer":
+        bad = _mint(private_pem, "alice_jwt", issuer="urn:evil")
+    else:
+        bad = _mint(private_pem, "alice_jwt", audience="not-this-server")
+
+    with http_server(_jwt_env(public_pem)) as (url, _proc):
+        async def _run():
+            rejected = False
+            try:
+                async with http_session(url, token=bad) as s:
+                    await s.call_tool("create_example_osm", {"name": "x"})
+            except Exception:
+                rejected = True
+            assert rejected, f"{kind} token must be rejected by the server"
+
+        asyncio.run(_run())
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize("bad_tokens", ["not-json", "[1, 2, 3]"])
 def test_invalid_mcp_tokens_fails_fast_with_clear_error(bad_tokens):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -92,11 +92,15 @@ def test_http_jwt_auth_accepts_signed_rejects_unsigned():
 # --- Self-signed JWT: restart-free user onboarding (scripts/mint_token.py) ------
 # These exercise the SAME minting code an operator runs to add a user, then prove
 # the server accepts tokens it never saw at startup and keeps users isolated.
-import sys  # noqa: E402
+import importlib.util  # noqa: E402
 from pathlib import Path  # noqa: E402
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-import mint_token  # noqa: E402
+# Load scripts/mint_token.py by path without mutating sys.path (no global shadowing).
+_mint_spec = importlib.util.spec_from_file_location(
+    "mint_token", Path(__file__).resolve().parent.parent / "scripts" / "mint_token.py",
+)
+mint_token = importlib.util.module_from_spec(_mint_spec)
+_mint_spec.loader.exec_module(mint_token)
 
 JWT_ISSUER = "urn:openstudio-mcp"
 JWT_AUDIENCE = "openstudio-mcp"
@@ -115,6 +119,19 @@ def _mint(private_pem: str, user: str, **kw) -> str:
     kw.setdefault("issuer", JWT_ISSUER)
     kw.setdefault("audience", JWT_AUDIENCE)
     return mint_token.issue_token(private_pem, user, **kw)
+
+
+def test_issue_token_normalizes_subject_whitespace():
+    # Regression: issue_token validated subject.strip() but signed the UNstripped
+    # subject, so "  alice  " and "alice" minted different identities -> different
+    # /runs/<user>/ dirs. The subject must be normalized before signing. Unit-level
+    # (no server, no openstudio import): mint and decode without verifying.
+    import jwt as pyjwt
+
+    private_pem, _ = mint_token.generate_keypair()
+    token = mint_token.issue_token(private_pem, "  alice  ", issuer=JWT_ISSUER, audience=JWT_AUDIENCE)
+    claims = pyjwt.decode(token, options={"verify_signature": False, "verify_aud": False})
+    assert claims["sub"] == "alice", f"subject must be stripped before signing: {claims!r}"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## What & why

Token mode (`MCP_AUTH=token` + `StaticTokenVerifier`) reads `MCP_TOKENS` **once at startup**, so adding/rotating/revoking a user means editing the map and **restarting** (dropping live sessions). This adds a path to onboard users with **no restart**: run `MCP_AUTH=jwt` as your own tiny self-signed issuer — no external IdP. The server holds only a public key; you mint one short-lived token per user.

JWT *verification* already shipped (1.0.0) and was CI-tested. The gaps were tooling to mint tokens and proof that multi-user **isolation holds under JWT** — both closed here.

## Commits
1. `feat(auth)` — `scripts/mint_token.py`: `keygen` (RSA pair) + `issue --user --days` (sub-only RS256 JWT, 30-day default, PyJWT+cryptography) printing a ready-to-paste `Authorization` header. gitignore `*.pem`.
2. `test(auth)` — new tests in `tests/test_auth.py` (already CI shard 4, no `ci.yml` change): add-user-after-startup-no-restart **+ sub scopes run dir**, cross-user file isolation, the `azp`/`client_id` guardrail, and expired/wrong-issuer/wrong-audience negatives.
3. `docs(remote)` — "Adding users without a restart (self-signed JWT)" section in `docs/remote-multi-user.md` (keygen → server env w/ Windows+bash PEM handling → issue → TTL/revocation reality → key custody + azp warning); §7 limitation updated.

## Reviewer notes
- **`azp`/`client_id` footgun (locked by a test):** FastMCP resolves identity as `client_id || azp || sub`. A real IdP that stamps a shared `azp` (the *application* id) would collapse every user onto one identity and one `/runs/<id>/` — silent isolation break. `mint_token.py` sets **only `sub`**; `test_jwt_client_id_claim_overrides_sub_identity` pins the precedence so a regression or IdP misconfig fails loudly.
- **Revocation tradeoff:** JWTs are stateless → valid until `exp`. No cheap per-user revoke; mitigate with short TTL or key rotation (invalidates all). Instant revoke/SSO = graduate to a managed IdP via `MCP_JWT_JWKS_URI` (config only).
- No server-code change (JWT path already existed); no `EXPECTED_TOOLS` change (it's a script).
- Validated in Docker: 10/10 `test_auth.py`, plus a Phase-4 end-to-end run of the literal operator workflow (keygen CLI → real `openstudio-mcp` reading the PEM from env → issue CLI → client connects as alice → bob added with no restart → bogus token rejected).
- I did not run the rest of shard 4 locally (unaffected by these changes); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)