### PR TITLE
Fix #87: exclude sizing design-day rows from query_timeseries run-period results

### DIFF
--- a/mcp_server/skills/results/operations.py
+++ b/mcp_server/skills/results/operations.py
@@ -336,6 +336,7 @@ def query_timeseries_op(
     end_day: int | None = None,
     frequency: str | None = None,
     max_points: int = 2000,
+    environment: str = "run_period",
 ) -> dict[str, Any]:
     """Query time-series data for a specific variable."""
     from mcp_server.skills.results.sql_extract import query_timeseries
@@ -345,7 +346,7 @@ def query_timeseries_op(
     return query_timeseries(
         sql_path, variable_name, key_value,
         start_month, start_day, end_month, end_day,
-        frequency, max_points,
+        frequency, max_points, environment=environment,
     )
 
 

--- a/mcp_server/skills/results/sql_extract.py
+++ b/mcp_server/skills/results/sql_extract.py
@@ -405,6 +405,16 @@ def extract_component_sizing(
 # Tier 2: Time-series extractor
 # ---------------------------------------------------------------------------
 
+# EnergyPlus SQL EnvironmentPeriods.EnvironmentType values per environment filter.
+# Sizing design days share calendar dates with the run period (e.g. Boston DDs
+# fall on 7/21), so unfiltered queries interleave their rows with weather data.
+_ENVIRONMENT_TYPES: dict[str, tuple[int, ...] | None] = {
+    "run_period": (3,),    # WeatherRunPeriod
+    "design_day": (1, 2),  # DesignDay, DesignRunPeriod
+    "all": None,
+}
+
+
 def query_timeseries(
     sql_path: Path,
     variable_name: str,
@@ -415,8 +425,15 @@ def query_timeseries(
     end_day: int | None = None,
     frequency: str | None = None,
     max_points: int = 2000,
+    environment: str = "run_period",
 ) -> dict:
     """Query time-series data from ReportData/ReportDataDictionary/Time tables."""
+    if environment not in _ENVIRONMENT_TYPES:
+        return {
+            "ok": False,
+            "error": (f"Invalid environment '{environment}'. "
+                      "Use 'run_period' (default), 'design_day', or 'all'."),
+        }
     conn = sqlite3.connect(str(sql_path))
     try:
         # Check if ReportData has any rows
@@ -447,8 +464,33 @@ def query_timeseries(
             where_clauses.append("(t.Month < ? OR (t.Month = ? AND t.Day <= ?))")
             params.extend([end_month, end_month, end_day or 31])
 
-        # Only run-period data (skip design days / warmup)
+        # Skip warmup rows (WarmupFlag does NOT exclude sizing environments)
         where_clauses.append("t.WarmupFlag = 0")
+
+        # Environment filter — sizing rows carry WarmupFlag=0 too, so run-period
+        # isolation needs the EnvironmentPeriods join. Trimmed/legacy SQL files
+        # may lack that table; degrade to unfiltered with a warning.
+        base_where_sql = " AND ".join(where_clauses)
+        base_params = tuple(params)
+        env_types = _ENVIRONMENT_TYPES[environment]
+        env_join = ""
+        warning = None
+        if env_types is not None:
+            has_env_table = bool(_q(
+                conn,
+                "SELECT name FROM sqlite_master "
+                "WHERE type IN ('table', 'view') AND name = 'EnvironmentPeriods'",
+            ))
+            if has_env_table:
+                env_join = ("JOIN EnvironmentPeriods ep "
+                            "ON t.EnvironmentPeriodIndex = ep.EnvironmentPeriodIndex")
+                placeholders = ", ".join("?" * len(env_types))
+                where_clauses.append(f"ep.EnvironmentType IN ({placeholders})")
+                params.extend(env_types)
+            else:
+                warning = ("EnvironmentPeriods table missing from this SQL output; "
+                           "returning all environments (sizing design-day rows may "
+                           "be included).")
 
         where_sql = " AND ".join(where_clauses)
 
@@ -458,6 +500,7 @@ def query_timeseries(
             FROM ReportData rd
             JOIN ReportDataDictionary rdd ON rd.ReportDataDictionaryIndex = rdd.ReportDataDictionaryIndex
             JOIN Time t ON rd.TimeIndex = t.TimeIndex
+            {env_join}
             WHERE {where_sql}
         """
         total_available = _q(conn, count_sql, tuple(params))[0]["c"]
@@ -469,6 +512,7 @@ def query_timeseries(
             FROM ReportData rd
             JOIN ReportDataDictionary rdd ON rd.ReportDataDictionaryIndex = rdd.ReportDataDictionaryIndex
             JOIN Time t ON rd.TimeIndex = t.TimeIndex
+            {env_join}
             WHERE {where_sql}
             ORDER BY t.Month, t.Day, t.Hour, t.Minute
             LIMIT ?
@@ -476,11 +520,33 @@ def query_timeseries(
         rows = _q(conn, data_sql, (*params, max_points))
 
         if not rows:
-            return {
+            message = f"No data found for variable '{variable_name}'."
+            if env_join:
+                # Rows may exist only in the environments the filter excluded
+                # (e.g. a design-day-only simulation queried with the default).
+                unfiltered_sql = f"""
+                    SELECT COUNT(*) as c
+                    FROM ReportData rd
+                    JOIN ReportDataDictionary rdd ON rd.ReportDataDictionaryIndex = rdd.ReportDataDictionaryIndex
+                    JOIN Time t ON rd.TimeIndex = t.TimeIndex
+                    WHERE {base_where_sql}
+                """
+                other_env_count = _q(conn, unfiltered_sql, base_params)[0]["c"]
+                if other_env_count > 0:
+                    message = (
+                        f"No '{environment}' data found for variable "
+                        f"'{variable_name}', but {other_env_count} rows exist in "
+                        'other environments. Pass environment="design_day" for '
+                        'sizing-period data or environment="all" for everything.'
+                    )
+            out = {
                 "ok": True, "variable": variable_name, "key": key_value,
-                "data": [], "count": 0,
-                "message": f"No data found for variable '{variable_name}'.",
+                "environment": environment, "data": [], "count": 0,
+                "message": message,
             }
+            if warning:
+                out["warning"] = warning
+            return out
 
         data = []
         for r in rows:
@@ -490,17 +556,21 @@ def query_timeseries(
                 "value": r["Value"],
             })
 
-        return {
+        out = {
             "ok": True,
             "variable": rows[0]["Name"],
             "key": rows[0]["KeyValue"] or "*",
             "frequency": rows[0]["ReportingFrequency"],
             "units": rows[0]["Units"],
+            "environment": environment,
             "data": data,
             "count": len(data),
             "total_available": total_available,
             "truncated": len(data) < total_available,
         }
+        if warning:
+            out["warning"] = warning
+        return out
     finally:
         conn.close()
 

--- a/mcp_server/skills/results/sql_extract.py
+++ b/mcp_server/skills/results/sql_extract.py
@@ -475,6 +475,10 @@ def query_timeseries(
         env_types = _ENVIRONMENT_TYPES[environment]
         env_join = ""
         warning = None
+        # What was actually applied — diverges from the requested `environment`
+        # only when the filter cannot be honored (missing EnvironmentPeriods),
+        # so clients can trust one field instead of parsing the warning string.
+        effective_environment = environment
         if env_types is not None:
             has_env_table = bool(_q(
                 conn,
@@ -488,6 +492,8 @@ def query_timeseries(
                 where_clauses.append(f"ep.EnvironmentType IN ({placeholders})")
                 params.extend(env_types)
             else:
+                # No filter applied — every environment came back.
+                effective_environment = "all"
                 warning = ("EnvironmentPeriods table missing from this SQL output; "
                            "returning all environments (sizing design-day rows may "
                            "be included).")
@@ -541,7 +547,9 @@ def query_timeseries(
                     )
             out = {
                 "ok": True, "variable": variable_name, "key": key_value,
-                "environment": environment, "data": [], "count": 0,
+                "environment": environment,
+                "effective_environment": effective_environment,
+                "data": [], "count": 0,
                 "message": message,
             }
             if warning:
@@ -563,6 +571,7 @@ def query_timeseries(
             "frequency": rows[0]["ReportingFrequency"],
             "units": rows[0]["Units"],
             "environment": environment,
+            "effective_environment": effective_environment,
             "data": data,
             "count": len(data),
             "total_available": total_available,

--- a/mcp_server/skills/results/tools.py
+++ b/mcp_server/skills/results/tools.py
@@ -164,11 +164,14 @@ def register(mcp):
         end_day: int | None = None,
         frequency: str | None = None,
         max_points: int = 2000,
+        environment: str = "run_period",
     ):
         """Query time-series output variable data for a date range.
 
         Default 2000 points. Use start_month/end_month to narrow time range,
-        or increase max_points for finer resolution.
+        or increase max_points for finer resolution. Returns weather run-period
+        data only by default — sizing design days share calendar dates with the
+        run period, so environment="all" may return duplicate timestamps.
 
         Args:
             run_id: Run identifier
@@ -180,10 +183,13 @@ def register(mcp):
             end_day: End day (1-31)
             frequency: "Zone Timestep", "Hourly", "Daily", "Monthly"
             max_points: Cap on returned data points (default 2000)
+            environment: "run_period" (default), "design_day" (sizing periods),
+                or "all" (every environment)
         """
         return query_timeseries_op(
             run_id=run_id, variable_name=variable_name, key_value=key_value,
             start_month=start_month, start_day=start_day,
             end_month=end_month, end_day=end_day,
             frequency=frequency, max_points=int(max_points or 2000),
+            environment=environment,
         )

--- a/mcp_server/skills/results/tools.py
+++ b/mcp_server/skills/results/tools.py
@@ -185,6 +185,11 @@ def register(mcp):
             max_points: Cap on returned data points (default 2000)
             environment: "run_period" (default), "design_day" (sizing periods),
                 or "all" (every environment)
+
+        The response echoes the requested `environment` and reports
+        `effective_environment` — what was actually applied. They differ only
+        when the SQL file lacks an EnvironmentPeriods table: the filter can't
+        run, `effective_environment` is "all", and a `warning` is set.
         """
         return query_timeseries_op(
             run_id=run_id, variable_name=variable_name, key_value=key_value,

--- a/tests/test_add_output_variable.py
+++ b/tests/test_add_output_variable.py
@@ -196,3 +196,83 @@ def test_add_multiple_output_variables():
                     "Two output variables should have distinct handles"
 
     asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_query_timeseries_excludes_design_day_rows():
+    """Sizing design-day rows must not blend into run-period query results."""
+    # Regression: #87 — Boston's cooling design days fall on 7/21; query_timeseries
+    # returned their rows interleaved with run-period rows (duplicate timestamps,
+    # phantom peaks identical across runs)
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    from conftest import EPW_PATH, poll_until_done
+
+    name = _unique_name("pytest_qts_dd")
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+                # --- Arrange: 10-zone baseline, Boston weather (DDs on 7/21),
+                # run period spanning the design-day date ---
+                create_result = unwrap(await session.call_tool(
+                    "create_baseline_osm", {"name": name}))
+                assert create_result["ok"] is True, create_result
+                load_result = unwrap(await session.call_tool(
+                    "load_osm_model", {"osm_path": create_result["osm_path"]}))
+                assert load_result["ok"] is True, load_result
+                loc_result = unwrap(await session.call_tool(
+                    "change_building_location", {"weather_file": EPW_PATH}))
+                assert loc_result["ok"] is True, loc_result
+                rp_result = unwrap(await session.call_tool("set_run_period", {
+                    "begin_month": 7, "begin_day": 20, "end_month": 7, "end_day": 22,
+                }))
+                assert rp_result["ok"] is True, rp_result
+                var_result = unwrap(await session.call_tool("add_output_variable", {
+                    "variable_name": "Zone Mean Air Temperature",
+                    "key_value": "*", "reporting_frequency": "Hourly",
+                }))
+                assert var_result["ok"] is True, var_result
+                save_result = unwrap(await session.call_tool(
+                    "save_osm_model", {"osm_path": f"/runs/{name}/model.osm"}))
+                assert save_result["ok"] is True, save_result
+
+                # --- Act: simulate, query one zone across the DD-overlapping window ---
+                sim_result = unwrap(await session.call_tool("run_simulation", {
+                    "osm_path": f"/runs/{name}/model.osm", "epw_path": EPW_PATH,
+                }))
+                assert sim_result["ok"] is True, sim_result
+                status = await poll_until_done(session, sim_result["run_id"])
+                assert status["run"]["status"] == "success", status
+                query_args = {
+                    "run_id": sim_result["run_id"],
+                    "variable_name": "Zone Mean Air Temperature",
+                    "key_value": "Story 1 Core Thermal Zone",
+                    "start_month": 7, "start_day": 20,
+                    "end_month": 7, "end_day": 22, "max_points": 2000,
+                }
+                result = unwrap(await session.call_tool("query_timeseries", query_args))
+
+                # --- Assert: exactly 3 days x 24 hourly rows, no duplicates ---
+                assert result["ok"] is True, result
+                assert result["count"] == 72, (
+                    f"3 run-period days x 24 hourly rows expected, got "
+                    f"{result['count']} — design-day rows blended in")
+                stamps = [(d["month"], d["day"], d["hour"], d["minute"])
+                          for d in result["data"]]
+                assert len(set(stamps)) == len(stamps), (
+                    "duplicate timestamps = sizing environments in results")
+
+                # environment='all' must expose the DD rows on 7/21 (proves the
+                # sizing data existed and the default filter did the work)
+                all_result = unwrap(await session.call_tool(
+                    "query_timeseries", {**query_args, "environment": "all"}))
+                assert all_result["ok"] is True, all_result
+                assert all_result["count"] > 72, (
+                    f"environment='all' should include design-day rows on 7/21, "
+                    f"got {all_result['count']}")
+
+    asyncio.run(_run())

--- a/tests/test_results_extraction.py
+++ b/tests/test_results_extraction.py
@@ -606,6 +606,9 @@ class TestQueryTimeseriesEnvironment:
         assert result["ok"] is True
         assert result["count"] == 72, f"3 run-period days x 24 h, got {result['count']}"
         assert result["total_available"] == 72
+        assert result["environment"] == "run_period"
+        assert result["effective_environment"] == "run_period", \
+            "filter applied, so effective == requested"
         stamps = [(d["month"], d["day"], d["hour"], d["minute"]) for d in result["data"]]
         assert len(set(stamps)) == len(stamps), "duplicate timestamps = blended environments"
         assert all(d["value"] != 999.0 for d in result["data"]), \
@@ -657,6 +660,12 @@ class TestQueryTimeseriesEnvironment:
         assert "EnvironmentPeriods" in filtered.get("warning", ""), \
             "fallback must be flagged with a warning"
         assert "warning" not in unfiltered, "environment='all' needs no fallback warning"
+        # Regression: fallback echoed the requested environment but returned all
+        # rows — effective_environment must reveal the filter was not applied.
+        assert filtered["environment"] == "run_period", "echoes what was requested"
+        assert filtered["effective_environment"] == "all", \
+            "fallback returned every environment; effective must say so"
+        assert unfiltered["effective_environment"] == "all"
 
     def test_design_day_only_sql_hints_environment(self, tmp_path):
         # Validates: DD-only results (no weather run period) return an actionable hint
@@ -667,6 +676,8 @@ class TestQueryTimeseriesEnvironment:
         assert result["count"] == 0
         assert "design_day" in result.get("message", ""), \
             "empty run-period result must hint at environment='design_day'"
+        # Table present, filter honored (just no matching rows) — effective stays "run_period"
+        assert result["effective_environment"] == "run_period"
 
 
 class TestMissingSql:

--- a/tests/test_results_extraction.py
+++ b/tests/test_results_extraction.py
@@ -543,6 +543,132 @@ class TestCompareRuns:
         assert gt["delta"] == 0.0
 
 
+# ---------------------------------------------------------------------------
+# Regression #87: query_timeseries must not blend sizing design-day rows into
+# run-period results (Boston design days fall on 7/21 and share calendar dates)
+# ---------------------------------------------------------------------------
+
+def _make_env_sql(path: Path, include_environment_periods: bool = True,
+                  include_run_period: bool = True) -> Path:
+    """Minimal replica of the E+ SQL schema with a cooling design day on 7/21
+    overlapping a 7/20-7/22 run period (mirrors Boston TMY3 .ddy dates)."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE Time (TimeIndex INTEGER PRIMARY KEY, Month INTEGER, "
+        "Day INTEGER, Hour INTEGER, Minute INTEGER, DayType TEXT, "
+        "EnvironmentPeriodIndex INTEGER, WarmupFlag INTEGER)")
+    conn.execute(
+        "CREATE TABLE ReportDataDictionary (ReportDataDictionaryIndex INTEGER "
+        "PRIMARY KEY, Name TEXT, KeyValue TEXT, Units TEXT, ReportingFrequency TEXT)")
+    conn.execute(
+        "CREATE TABLE ReportData (ReportDataIndex INTEGER PRIMARY KEY, "
+        "TimeIndex INTEGER, ReportDataDictionaryIndex INTEGER, Value REAL)")
+    if include_environment_periods:
+        conn.execute(
+            "CREATE TABLE EnvironmentPeriods (EnvironmentPeriodIndex INTEGER "
+            "PRIMARY KEY, EnvironmentName TEXT, EnvironmentType INTEGER)")
+        conn.execute("INSERT INTO EnvironmentPeriods VALUES (1, 'ANN CLG .4% DB=>MWB', 1)")
+        if include_run_period:
+            conn.execute("INSERT INTO EnvironmentPeriods VALUES (2, 'RUN PERIOD 1', 3)")
+    conn.execute(
+        "INSERT INTO ReportDataDictionary VALUES "
+        "(1, 'Zone Mean Air Temperature', 'CORE ZONE', 'C', 'Hourly')")
+    time_idx = 0
+    # Design day env 1: 7/21, hourly, constant sentinel value 999.0
+    for hour in range(1, 25):
+        time_idx += 1
+        conn.execute("INSERT INTO Time VALUES (?, 7, 21, ?, 0, 'SummerDesignDay', 1, 0)",
+                     (time_idx, hour))
+        conn.execute("INSERT INTO ReportData VALUES (?, ?, 1, 999.0)",
+                     (time_idx, time_idx))
+    # Run period env 2: 7/20-7/22, hourly, value = day*100 + hour
+    if include_run_period:
+        for day in (20, 21, 22):
+            for hour in range(1, 25):
+                time_idx += 1
+                conn.execute(
+                    "INSERT INTO Time VALUES (?, 7, ?, ?, 0, 'Monday', 2, 0)",
+                    (time_idx, day, hour))
+                conn.execute("INSERT INTO ReportData VALUES (?, ?, 1, ?)",
+                             (time_idx, time_idx, float(day * 100 + hour)))
+    conn.commit()
+    conn.close()
+    return path
+
+
+class TestQueryTimeseriesEnvironment:
+    def test_default_excludes_design_days(self, tmp_path):
+        # Regression: #87 — sizing design-day rows (sharing calendar dates with the
+        # run period) leaked into results as duplicate-timestamp phantom data
+        from mcp_server.skills.results.sql_extract import query_timeseries
+        sql = _make_env_sql(tmp_path / "env.sql")
+        result = query_timeseries(sql, "Zone Mean Air Temperature")
+        assert result["ok"] is True
+        assert result["count"] == 72, f"3 run-period days x 24 h, got {result['count']}"
+        assert result["total_available"] == 72
+        stamps = [(d["month"], d["day"], d["hour"], d["minute"]) for d in result["data"]]
+        assert len(set(stamps)) == len(stamps), "duplicate timestamps = blended environments"
+        assert all(d["value"] != 999.0 for d in result["data"]), \
+            "design-day sentinel value leaked into run-period results"
+        noon_21 = next(d for d in result["data"]
+                       if (d["day"], d["hour"]) == (21, 12))
+        assert noon_21["value"] == pytest.approx(2112.0), \
+            "7/21 12:00 must be the run-period row, not the design-day row"
+
+    def test_environment_design_day(self, tmp_path):
+        # Validates: environment="design_day" returns only sizing-period rows
+        from mcp_server.skills.results.sql_extract import query_timeseries
+        sql = _make_env_sql(tmp_path / "env.sql")
+        result = query_timeseries(sql, "Zone Mean Air Temperature",
+                                  environment="design_day")
+        assert result["ok"] is True
+        assert result["count"] == 24, f"one design day x 24 h, got {result['count']}"
+        assert all(d["value"] == pytest.approx(999.0) for d in result["data"])
+
+    def test_environment_all(self, tmp_path):
+        # Validates: environment="all" preserves pre-#87 behavior (every environment)
+        from mcp_server.skills.results.sql_extract import query_timeseries
+        sql = _make_env_sql(tmp_path / "env.sql")
+        result = query_timeseries(sql, "Zone Mean Air Temperature", environment="all")
+        assert result["ok"] is True
+        assert result["count"] == 96, f"72 run-period + 24 design-day rows, got {result['count']}"
+        dd21 = [d for d in result["data"] if d["day"] == 21]
+        assert len(dd21) == 48, "7/21 must carry both environments under environment='all'"
+
+    def test_invalid_environment_value(self, tmp_path):
+        # Validates: unknown environment value returns ok=False with usable message
+        from mcp_server.skills.results.sql_extract import query_timeseries
+        sql = _make_env_sql(tmp_path / "env.sql")
+        result = query_timeseries(sql, "Zone Mean Air Temperature",
+                                  environment="bogus")
+        assert result["ok"] is False
+        assert "environment" in result["error"].lower()
+
+    def test_missing_environment_periods_table_falls_back(self, sql_path):
+        # Regression: #87 — trimmed fixtures (e.g. SEB4) lack EnvironmentPeriods;
+        # the filter must degrade to old behavior with a warning, not error out
+        from mcp_server.skills.results.sql_extract import query_timeseries
+        filtered = query_timeseries(sql_path, "Electricity:Facility", frequency="Daily")
+        unfiltered = query_timeseries(sql_path, "Electricity:Facility",
+                                      frequency="Daily", environment="all")
+        assert filtered["ok"] is True
+        assert filtered["count"] == unfiltered["count"] > 0, \
+            "missing EnvironmentPeriods table must not drop rows"
+        assert "EnvironmentPeriods" in filtered.get("warning", ""), \
+            "fallback must be flagged with a warning"
+        assert "warning" not in unfiltered, "environment='all' needs no fallback warning"
+
+    def test_design_day_only_sql_hints_environment(self, tmp_path):
+        # Validates: DD-only results (no weather run period) return an actionable hint
+        from mcp_server.skills.results.sql_extract import query_timeseries
+        sql = _make_env_sql(tmp_path / "ddonly.sql", include_run_period=False)
+        result = query_timeseries(sql, "Zone Mean Air Temperature")
+        assert result["ok"] is True
+        assert result["count"] == 0
+        assert "design_day" in result.get("message", ""), \
+            "empty run-period result must hint at environment='design_day'"
+
+
 class TestMissingSql:
     def test_end_use_bad_path(self):
         # Validates: extract_end_use_breakdown raises on nonexistent SQL path


### PR DESCRIPTION
Fixes #87.

## Problem

`query_timeseries` filtered on `t.WarmupFlag = 0` with a comment claiming design days were skipped — but sizing environments report with `WarmupFlag = 0` too. When design days share calendar dates with the run period (Boston TMY3: 7/21 cooling, 1/21 heating), their rows came back interleaved with run-period rows: duplicate timestamps, inflated counts (July = 33 days x 144), and phantom peaks bit-identical across different runs.

## Fix

- Join `EnvironmentPeriods` and filter `EnvironmentType = 3` (WeatherRunPeriod) by default in both the count and data queries.
- New `environment` parameter plumbed through tool -> op -> extractor: `"run_period"` (default), `"design_day"` (types 1+2), `"all"` (pre-fix behavior). Invalid value returns `ok: False`.
- Trimmed/legacy SQL without an `EnvironmentPeriods` table (e.g. the SEB4 test fixture) degrades to unfiltered results plus a `warning` field instead of erroring.
- Empty run-period result where other environments have rows (design-day-only sims) returns an actionable `message` pointing at `environment="design_day"` / `"all"`.
- Responses now echo `environment`.

## Tests (red-green: all fail on unfixed code)

**Unit** — `tests/test_results_extraction.py::TestQueryTimeseriesEnvironment` (6 tests, synthetic SQL fixture replicating the E+ schema with a 7/21 design day overlapping a 7/20-7/22 run period): default excludes DD rows with exact counts/values and unique timestamps; `design_day` / `all` behavior; invalid value; SEB4 missing-table fallback with warning; DD-only hint message.

**Integration** — `tests/test_add_output_variable.py::test_query_timeseries_excludes_design_day_rows` (file already in CI shard 5): real 10-zone baseline + Boston EPW, run period 7/20-7/22 spanning the DD date, hourly zone-temperature query must return exactly 72 unique-timestamp rows; `environment="all"` must return more (proves the DD data existed and the filter did the work).

Red: 6/6 unit failures on develop (default returned 96 rows vs 72); integration failure against the develop image. Green: 42/42 unit (incl. 36 pre-existing), 6/6 integration in the rebuilt image.

Ruff: net +1 finding (S608 on the new count query) — same class as the two pre-existing S608s on the sibling queries in the same function; values are parameterized, query fragments are internal constants.

Found while building the Python-EMS demand-response demo, where the "seasonal peak" was the cooling design day in both baseline and controlled runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
