### PR TITLE
docs: Example 20 — grid-interactive demand response with Python EMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ The component-properties tools query/modify these 15 types:
 
 ## Examples
 
-19 worked examples with full tool-call sequences:
+20 worked examples with full tool-call sequences:
 
 | # | Example | # | Example |
 |---|---------|---|---------|
@@ -682,7 +682,7 @@ The component-properties tools query/modify these 15 types:
 | 7 | [Full Building Model](docs/examples/07_full_building.md) | 17 | [`/retrofit`](docs/examples/17_retrofit.md) |
 | 8 | [Geometry from Scratch](docs/examples/08_geometry_creation.md) | 18 | [`/view`](docs/examples/18_view.md) |
 | 9 | [Fenestration by Orientation](docs/examples/09_fenestration_by_orientation.md) | 19 | [Four-Pipe Beam Retrofit (E2E)](docs/examples/19_systemd_fourpipebeam_retrofit.md) |
-| 10 | [Typical Building (ComStock)](docs/examples/10_comstock_typical_building.md) | | |
+| 10 | [Typical Building (ComStock)](docs/examples/10_comstock_typical_building.md) | 20 | [Demand Response with Python EMS](docs/examples/20_python_ems_demand_response.md) |
 
 ---
 

--- a/docs/examples/20_python_ems_demand_response.md
+++ b/docs/examples/20_python_ems_demand_response.md
@@ -1,0 +1,106 @@
+# Example 20: Grid-Interactive Demand Response with Python EMS
+
+Author, tune, and evaluate a custom supervisory controller entirely through MCP tools — no custom EnergyPlus build, no hand-edited IDF, no measure boilerplate.
+
+## Scenario
+
+Commercial buildings pay **demand charges** based on their single highest 15-to-30-minute power spike each month, not just total energy consumed. In a mid-size office, air conditioning usually drives that spike. **Demand response (DR)** means shaving those spikes on purpose.
+
+A researcher wants to test a simple idea on a 10-zone office: watch the whole-building electricity draw, and when it crosses a threshold, let the zones drift a couple degrees warmer so the chillers back off and the peak is clipped. The whole loop — build the model, author the controller, simulate, read the results, revise — is done through openstudio-mcp tools, so an AI agent can run it end to end.
+
+## What this demonstrates (plain language)
+
+- **The controller is plain Python attached to the model.** A custom EnergyPlus Python Plugin ("DemandLimiter"), authored via `create_python_plugin`, watches whole-building electric demand every 10 minutes and ratchets all 10 zones' cooling setpoints up in stages (+1 / +2 / +3 K) whenever demand crosses a shed threshold. The MCP tool wires the `PythonPlugin:Instance`/`Variables`/`OutputVariable` objects and validates the source against the plugin contract before it ever runs.
+- **The iteration loop is minutes, not days.** Author → simulate → query → revise (`edit_python_plugin`) → re-simulate. Each full 3-month simulation ran in ~10 s on this testbed. It took three controller revisions, each driven by what the previous simulation revealed (see the iteration story below).
+- **Custom telemetry rides along.** The plugin publishes its own state (`DR Shed Stage`) as a normal output variable, queryable next to standard outputs via `query_timeseries`.
+- **DR that *saves* energy.** Raising cooling setpoints during events reduces consumption too, so there is no energy penalty for the peak reduction.
+
+## Testbed
+
+| Item | Value |
+|---|---|
+| Building | 10-zone, 2-story office, 100 m × 50 m (~10,000 m²), core+perimeter (`create_baseline_osm`) |
+| HVAC | ASHRAE baseline System 7: VAV w/ reheat, chiller + boiler plant (`add_baseline_system(system_type=7)`) |
+| Thermostats | 21.1 °C heating / 23.9 °C cooling |
+| Weather | Boston-Logan TMY3 (`change_building_location`) |
+| Run period | Jun 1 – Aug 31, 10-minute timesteps |
+
+## Prompt
+
+> I have a 10-zone baseline office on ASHRAE System 7 in Boston. Simulate the summer (Jun–Aug) and find its peak electricity demand. Then write me a custom controller that shaves that peak: whenever whole-building demand crosses about 82% of the baseline peak, nudge every zone's cooling setpoint up in stages so the chillers back off. Re-simulate, check whether the seasonal billing peak actually dropped, and revise the controller until it does. Tell me the peak reduction, how much less time we spend above the threshold, and any energy or comfort tradeoff.
+
+## Tool Call Sequence
+
+### Phase A — baseline testbed
+
+```
+1. create_baseline_osm(name="demo_dr")   → load_osm_model → list_thermal_zones
+2. add_baseline_system(system_type=7, thermal_zone_names=[...10 zones])
+3. change_building_location(Boston TMY3)  → set_run_period(6/1–8/31)
+4. add_output_variable ×4 (Timestep): Facility Total Electricity Demand Rate,
+   Zone Mean Air Temperature, Zone Thermostat Cooling Setpoint Temperature, Site OAT
+5. add_output_meter ×3 (Hourly): Electricity:Facility, Cooling:Electricity, Fans:Electricity
+6. save_osm_model → run_simulation → get_run_status (poll to success)
+7. query_timeseries(Facility Total Electricity Demand Rate) → true baseline peak
+   337.7 kW → threshold = 0.82 × peak = 276.9 kW
+```
+
+### Phase B — author, run, and revise the controller
+
+```
+8.  list_ems_actuators(component_type="Zone Temperature Control", control_type="Cooling")
+    — confirm a per-zone Cooling Setpoint actuator exists for every zone
+9.  create_python_plugin(name="Demand Limiter", template="custom",
+      class_name="DemandLimiter", code=<controller>,
+      global_variables=["dr_stage"], output_variable_name="DR Shed Stage")
+10. save_osm_model (plugin script travels in the model's companion files/ dir)
+    → run_simulation → get_run_status
+11. extract_simulation_errors — verify "PythonPlugin: Class DemandLimiter imported", zero severe
+12. query_timeseries (demand, DR Shed Stage, setpoints, zone temps, OAT)
+    + extract_summary_metrics + extract_end_use_breakdown
+13. edit_python_plugin ×2 (revisions v2, v3 — see iteration story) → rerun each
+```
+
+## Expected Results (v3, final)
+
+| Metric | Baseline | Demand-limited (v3) | Change |
+|---|---|---|---|
+| Summer billing peak (30-min basis) | 335.2 kW | 311.1 kW | **−7.2%** |
+| 10-min intervals above 276.9 kW threshold | 2,276 | 610 | **−73%** |
+| Summer electricity (Jun–Aug) | 811.7 MWh | 779.8 MWh | **−3.9% (saved)** |
+| Demand-charge value @ $15/kW·mo | — | — | **≈ $1,300 / summer** |
+
+On the peak weekday, zone temperatures float 23.9 → 26.9 °C during the event and the staggered release returns to schedule with ≤ +5 kW rebound.
+
+## The iteration story (the research payoff)
+
+Each revision was driven by simulated evidence, not guesswork:
+
+| Rev | Controller | What the simulation said |
+|---|---|---|
+| v1 | Weekdays 13:00–18:00, 3 stages, 30-min dwell | Sheds 37–52 kW in-window, but the building peaks at **08:30** (morning pulldown after night setback) — the seasonal peak was untouched. |
+| v2 | Weekdays 08:00–19:00, 4 stages, 20-min dwell | Weekday peaks clipped to ~290 kW, but the seasonal peak **moved to Saturday** (329 kW) because the model runs 7-day schedules; the 20-min dwell also let the 08:30 spike through. |
+| v3 | **Every day** 08:00–19:00, 10-min dwell, 2-stage jump-start when demand > 115% of threshold | Billing peak −7.2%, exceedances −73%, energy −3.9%. Residual spikes are single-timestep chiller-staging transients. |
+
+## Common Pitfalls
+
+- **The `kind_of_sim` guard is mandatory** for any plugin that actuates thermostats/setpoints. Actuation must be gated to the weather run period (`kind_of_sim == 3`) — otherwise the raised setpoints reach the sizing design days, the plant autosizes smaller, and the baseline-vs-controlled comparison is corrupted.
+- **Design-day rows in `query_timeseries`:** sizing design days share calendar dates with the run period (Boston: 7/21) and, before the fix, came back blended with run-period rows. Fixed in [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87) — `environment="run_period"` is now the default. (This demo is where that bug was found.)
+- **One output variable per plugin:** `create_python_plugin` reports one output variable (the first global). Design controllers so a single state variable plus standard E+ outputs tell the story.
+- **Feedback-only control can't preempt step changes:** the metered interval that trips the controller is itself the residual peak. Forecast or schedule-aware feed-forward is the fix.
+- **Shed capacity is finite:** the stage-3 floor is ~285–295 kW. Deeper cuts need pre-cooling, chiller demand limiting, or lighting/plug DR — all expressible as more plugin logic.
+
+## Reproduce / Assets
+
+Everything needed to rebuild this study lives in **[`python-ems-demand-response/`](python-ems-demand-response/)**:
+
+- **[`study.md`](python-ems-demand-response/study.md)** — full research writeup (results detail, comfort analysis, method caveats, figure inventory).
+- **[`dr_dashboard.html`](python-ems-demand-response/dr_dashboard.html)** — self-contained results dashboard (open in a browser).
+- `dr_demo_driver.py` / `dr_demo_driver2.py` / `dr_demo_driver3.py` — reproducibility drivers (baseline+v1, v2, v3). Each embeds its controller as the `DemandLimiter` `PLUGIN_TEMPLATE`; the rest is the frozen MCP tool-call sequence above.
+
+See [`python-ems-demand-response/README.md`](python-ems-demand-response/README.md) for the `docker run` reproduce command.
+
+## Related
+
+- Skill: `python-ems` (`get_skill("python-ems")`) — when to reach for a Python Plugin vs a packaged tool.
+- Example 2: [Custom Measure: Chilled Beams](02_custom_measure_hvac.md) — the measure-authoring path (vs. runtime EMS control here).

--- a/docs/examples/20_python_ems_demand_response.md
+++ b/docs/examples/20_python_ems_demand_response.md
@@ -85,7 +85,7 @@ Each revision was driven by simulated evidence, not guesswork:
 ## Common Pitfalls
 
 - **The `kind_of_sim` guard is mandatory** for any plugin that actuates thermostats/setpoints. Actuation must be gated to the weather run period (`kind_of_sim == 3`) — otherwise the raised setpoints reach the sizing design days, the plant autosizes smaller, and the baseline-vs-controlled comparison is corrupted.
-- **Design-day rows in `query_timeseries`:** sizing design days share calendar dates with the run period (Boston: 7/21) and, before the fix, came back blended with run-period rows. Fixed in [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87) — `environment="run_period"` is now the default. (This demo is where that bug was found.)
+- **Design-day rows in `query_timeseries`:** sizing design days share calendar dates with the run period (Boston: 7/21) and, before the fix, came back blended with run-period rows. Fixed in [#88](https://github.com/NatLabRockies/openstudio-mcp/pull/88) (closes [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87)) — `environment="run_period"` is now the default. (This demo is where that bug was found.)
 - **One output variable per plugin:** `create_python_plugin` reports one output variable (the first global). Design controllers so a single state variable plus standard E+ outputs tell the story.
 - **Feedback-only control can't preempt step changes:** the metered interval that trips the controller is itself the residual peak. Forecast or schedule-aware feed-forward is the fix.
 - **Shed capacity is finite:** the stage-3 floor is ~285–295 kW. Deeper cuts need pre-cooling, chiller demand limiting, or lighting/plug DR — all expressible as more plugin logic.

--- a/docs/examples/python-ems-demand-response/README.md
+++ b/docs/examples/python-ems-demand-response/README.md
@@ -1,0 +1,58 @@
+# Python EMS demo: staged demand-limiting controller
+
+Companion assets for **[Example 20](../20_python_ems_demand_response.md)**.
+
+Grid-interactive demand-response study on the 10-zone baseline office
+(ASHRAE System 7 VAV, Boston TMY3, Jun–Aug). A custom EnergyPlus Python Plugin
+("DemandLimiter"), authored via `create_python_plugin` and revised twice via
+`edit_python_plugin`, watches whole-building electric demand and ratchets every
+zone's cooling setpoint up in stages when demand crosses a shed threshold.
+
+## Files
+
+| File | What it is |
+|---|---|
+| [`study.md`](study.md) | Full research writeup — testbed, controller, iteration story, results, caveats |
+| [`dr_dashboard.html`](dr_dashboard.html) | Self-contained results dashboard (open in a browser; data embedded) |
+| `dr_demo_driver.py` | Driver 1 — baseline characterization + v1 controller |
+| `dr_demo_driver2.py` | Driver 2 — v2 controller (widened window); reuses driver1's baseline run |
+| `dr_demo_driver3.py` | Driver 3 — v3 final controller (the headline numbers) |
+
+The **controller itself** is the `PLUGIN_TEMPLATE` string inside each driver
+(the `DemandLimiter` class). The rest of each driver is a reproducibility
+harness: it drives the MCP server over stdio and calls the same MCP tools an AI
+agent would (`create_baseline_osm`, `add_baseline_system`, `run_simulation`,
+`create_python_plugin`, `query_timeseries`, …), frozen so the study reproduces
+exactly.
+
+## Reproduce
+
+Build the image from `origin/develop`, then run the drivers inside it. Analysis
+JSON lands in `runs/demo_dr_analysis/`; the dashboard is already self-contained.
+
+```bash
+docker build -f docker/Dockerfile -t openstudio-mcp:dev .   # from origin/develop
+cd docs/examples/python-ems-demand-response
+docker run --rm \
+  -v "C:/projects/openstudio-mcp/runs:/runs" \
+  -v "$(pwd):/scratch" \
+  openstudio-mcp:dev bash -lc "python -u /scratch/dr_demo_driver.py"   # baseline + v1
+```
+
+`driver2`/`driver3` hardcode the baseline `run_id` printed by `driver1`
+(`BASELINE_RUN = ...` near the top) — edit that value, then run each the same
+way to reproduce v2 and the final v3.
+
+## Results (v3, final)
+
+Billing (30-min) peak **−7.2%** for the summer, threshold exceedances **−73%**,
+energy **−3.9%** (setpoint DR sheds energy too, so no penalty). Full numbers and
+the three-revision iteration story in [`study.md`](study.md).
+
+## Gotcha
+
+`query_timeseries` on this testbed returned sizing design-day rows blended with
+run-period rows (Boston design days fall on 7/21). The drivers dedupe by keeping
+the last row per timestamp. Fixed in the tool as of
+[#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87)
+(`environment="run_period"` is now the default).

--- a/docs/examples/python-ems-demand-response/README.md
+++ b/docs/examples/python-ems-demand-response/README.md
@@ -54,5 +54,7 @@ the three-revision iteration story in [`study.md`](study.md).
 `query_timeseries` on this testbed returned sizing design-day rows blended with
 run-period rows (Boston design days fall on 7/21). The drivers dedupe by keeping
 the last row per timestamp. Fixed in the tool as of
-[#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87)
-(`environment="run_period"` is now the default).
+[#88](https://github.com/NatLabRockies/openstudio-mcp/pull/88)
+(closes [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87);
+`environment="run_period"` is now the default), so fresh queries no longer need
+the dedupe — the drivers keep it for reproducibility against the original runs.

--- a/docs/examples/python-ems-demand-response/dr_dashboard.html
+++ b/docs/examples/python-ems-demand-response/dr_dashboard.html
@@ -1,0 +1,495 @@
+<title>Python EMS Demand-Limiting Study — openstudio-mcp</title>
+<style>
+:root {
+  --page: #f9f9f7; --surface: #fcfcfb;
+  --ink: #0b0b0b; --ink-2: #52514e; --muted: #898781;
+  --grid: #e1e0d9; --axis: #c3c2b7; --ring: rgba(11,11,11,0.10);
+  --base: #2a78d6; --ctrl: #1baf7a; --cmd: #4a3aa7;
+  --good: #006300; --band: rgba(42,120,214,0.06);
+  --code-bg: #f3f2ee;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #0d0d0d; --surface: #1a1a19;
+    --ink: #ffffff; --ink-2: #c3c2b7; --muted: #898781;
+    --grid: #2c2c2a; --axis: #383835; --ring: rgba(255,255,255,0.10);
+    --base: #3987e5; --ctrl: #199e70; --cmd: #9085e9;
+    --good: #0ca30c; --band: rgba(57,135,229,0.10);
+    --code-bg: #111110;
+  }
+}
+:root[data-theme="dark"] {
+  --page: #0d0d0d; --surface: #1a1a19;
+  --ink: #ffffff; --ink-2: #c3c2b7; --muted: #898781;
+  --grid: #2c2c2a; --axis: #383835; --ring: rgba(255,255,255,0.10);
+  --base: #3987e5; --ctrl: #199e70; --cmd: #9085e9;
+  --good: #0ca30c; --band: rgba(57,135,229,0.10);
+  --code-bg: #111110;
+}
+:root[data-theme="light"] {
+  --page: #f9f9f7; --surface: #fcfcfb;
+  --ink: #0b0b0b; --ink-2: #52514e; --muted: #898781;
+  --grid: #e1e0d9; --axis: #c3c2b7; --ring: rgba(11,11,11,0.10);
+  --base: #2a78d6; --ctrl: #1baf7a; --cmd: #4a3aa7;
+  --good: #006300; --band: rgba(42,120,214,0.06);
+  --code-bg: #f3f2ee;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--page); color: var(--ink);
+  font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+.wrap { max-width: 1060px; margin: 0 auto; padding: 40px 24px 72px; }
+.eyebrow {
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace;
+  font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--muted); margin: 0 0 10px;
+}
+h1 { font-size: 30px; line-height: 1.2; margin: 0 0 10px; text-wrap: balance; font-weight: 650; }
+.dek { color: var(--ink-2); max-width: 66ch; margin: 0 0 28px; }
+.dek strong { color: var(--ink); }
+h2 { font-size: 19px; margin: 44px 0 6px; font-weight: 650; text-wrap: balance; }
+h2 + p.sub { color: var(--ink-2); margin: 0 0 14px; max-width: 74ch; font-size: 14px; }
+
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
+.tile {
+  background: var(--surface); border: 1px solid var(--ring); border-radius: 8px;
+  padding: 14px 16px 12px;
+}
+.tile .lbl { font-size: 12.5px; color: var(--muted); }
+.tile .val { font-size: 27px; font-weight: 650; margin: 2px 0 0; letter-spacing: -0.01em; }
+.tile .val small { font-size: 15px; font-weight: 500; color: var(--ink-2); }
+.tile .delta { font-size: 12.5px; margin-top: 2px; color: var(--ink-2);
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace; }
+.tile .delta.pos { color: var(--good); }
+
+.card {
+  background: var(--surface); border: 1px solid var(--ring); border-radius: 8px;
+  padding: 18px 18px 10px; margin-top: 14px; position: relative;
+}
+.card h3 { margin: 0 0 2px; font-size: 15.5px; font-weight: 650; }
+.card p.note { margin: 0 0 8px; font-size: 13px; color: var(--ink-2); max-width: 80ch; }
+.legend { display: flex; flex-wrap: wrap; gap: 16px; font-size: 12.5px; color: var(--ink-2); margin: 4px 0 2px; }
+.legend .key { display: inline-flex; align-items: center; gap: 6px; }
+.legend .swatch { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
+.legend .swatch.dash { background: none; border-top: 2px dashed var(--muted); height: 0; }
+.chart-box { position: relative; }
+.chart-box svg { display: block; width: 100%; height: auto; }
+.tip {
+  position: absolute; pointer-events: none; display: none; z-index: 3;
+  background: var(--surface); border: 1px solid var(--ring); border-radius: 6px;
+  padding: 6px 9px; font-size: 12px; line-height: 1.45; color: var(--ink-2);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10); white-space: nowrap;
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace;
+}
+.tip b { color: var(--ink); font-weight: 600; }
+.grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+@media (max-width: 760px) { .grid2 { grid-template-columns: 1fr; } }
+
+details { margin: 8px 0 0; }
+details summary { cursor: pointer; font-size: 13px; color: var(--ink-2); }
+details summary:focus-visible { outline: 2px solid var(--base); outline-offset: 2px; }
+.tblwrap { overflow-x: auto; margin-top: 8px; }
+table.data {
+  border-collapse: collapse; font-size: 12.5px; min-width: 380px;
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace;
+  font-variant-numeric: tabular-nums;
+}
+table.data th, table.data td { padding: 4px 12px 4px 0; text-align: right; border-bottom: 1px solid var(--grid); }
+table.data th { color: var(--muted); font-weight: 500; }
+table.data td:first-child, table.data th:first-child { text-align: left; }
+
+ol.steps { margin: 10px 0 0; padding-left: 22px; color: var(--ink-2); font-size: 14px; }
+ol.steps li { margin: 5px 0; }
+ol.steps code, p code, li code {
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace; font-size: 12.5px;
+  background: var(--code-bg); border: 1px solid var(--ring); border-radius: 4px; padding: 1px 5px;
+  color: var(--ink);
+}
+pre.code {
+  background: var(--code-bg); border: 1px solid var(--ring); border-radius: 8px;
+  padding: 14px 16px; overflow-x: auto; font-size: 12px; line-height: 1.5;
+  font-family: ui-monospace, "Cascadia Mono", Consolas, monospace; color: var(--ink);
+  margin: 10px 0 0;
+}
+table.iter { border-collapse: collapse; font-size: 13.5px; width: 100%; margin-top: 10px; }
+table.iter th, table.iter td { padding: 8px 14px 8px 0; text-align: left; vertical-align: top; border-bottom: 1px solid var(--grid); }
+table.iter th { color: var(--muted); font-weight: 550; font-size: 12.5px; }
+table.iter td:first-child { white-space: nowrap; font-weight: 600; }
+ul.foot { color: var(--ink-2); font-size: 13px; padding-left: 20px; }
+ul.foot li { margin: 5px 0; }
+.svglabel { font-family: ui-monospace, "Cascadia Mono", Consolas, monospace; }
+</style>
+
+<div class="wrap">
+  <p class="eyebrow">openstudio-mcp · EnergyPlus Python Plugin (Python EMS) demo</p>
+  <h1>A supervisory demand-limiting controller, authored as Python EMS and tuned in three simulated iterations</h1>
+  <p class="dek">
+    A staged load-shed controller — written in Python, injected into EnergyPlus with
+    <code>create_python_plugin</code>, revised twice with <code>edit_python_plugin</code> — watches
+    whole-building electric demand every 10 minutes and ratchets zone cooling setpoints up
+    (+1 / +2 / +3&nbsp;K) whenever demand crosses a shed threshold. On a 10-zone office with a
+    VAV + chiller plant in Boston, the final controller cut the summer <strong>billing peak by 7.2%</strong>
+    and <strong>threshold exceedances by 73%</strong> while <em>saving</em> 3.9% energy.
+  </p>
+
+  <div class="tiles">
+    <div class="tile"><div class="lbl">Summer billing peak (30-min)</div>
+      <div class="val" id="t-peak"></div><div class="delta pos" id="t-peak-d"></div></div>
+    <div class="tile"><div class="lbl">Intervals over 276.9 kW threshold</div>
+      <div class="val" id="t-exceed"></div><div class="delta pos" id="t-exceed-d"></div></div>
+    <div class="tile"><div class="lbl">Summer electricity (Jun–Aug)</div>
+      <div class="val" id="t-energy"></div><div class="delta pos" id="t-energy-d"></div></div>
+    <div class="tile"><div class="lbl">Demand-charge value @ $15/kW·mo</div>
+      <div class="val" id="t-dollar"></div><div class="delta" id="t-dollar-d"></div></div>
+  </div>
+
+  <h2>Peak weekday: the demand curve gets clipped</h2>
+  <p class="sub">June 27 set the baseline summer peak (337.7 kW instantaneous at 08:30). The controller
+    jump-starts two stages on the morning spike, holds ~290 kW through the afternoon, then releases one
+    stage per 30 minutes after the 08:00–19:00 window — no rebound spike.</p>
+  <div class="card">
+    <h3>Whole-building electric demand — June 27</h3>
+    <p class="note">10-minute simulation timesteps. Shaded band = demand-limiting window (08:00–19:00).</p>
+    <div class="legend" id="lg-peakday"></div>
+    <div class="chart-box" id="ch-peakday"></div>
+    <details><summary>Data table (hourly)</summary><div class="tblwrap" id="tb-peakday"></div></details>
+  </div>
+
+  <h2>Inside the controller: sensor → stage → actuation → response</h2>
+  <p class="sub">The plugin's own reported output (<code>PythonPlugin:OutputVariable "DR Shed Stage"</code>)
+    against the thermostat it actuates. As the stage steps 0→3, the cooling setpoint steps
+    23.9→26.9&nbsp;°C and the zone floats up with it; the baseline zone hugs 23.9&nbsp;°C all day.</p>
+  <div class="card">
+    <h3>Controller state and zone response — June 27, Story 2 South Perimeter zone</h3>
+    <div class="legend" id="lg-anatomy"></div>
+    <div class="chart-box" id="ch-stage"></div>
+    <div class="chart-box" id="ch-temps" style="margin-top:6px"></div>
+    <details><summary>Data table (hourly)</summary><div class="tblwrap" id="tb-anatomy"></div></details>
+  </div>
+
+  <h2>The iteration that mattered: weekends</h2>
+  <p class="sub">Revision 2 limited shedding to weekdays — and the seasonal peak simply moved to Saturday
+    June 26 (329 kW), because this building runs 7-day schedules. Revision 3 applies the window every day.</p>
+  <div class="card">
+    <h3>Whole-building electric demand — Saturday June 26</h3>
+    <div class="legend" id="lg-weekend"></div>
+    <div class="chart-box" id="ch-weekend"></div>
+    <details><summary>Data table (hourly)</summary><div class="tblwrap" id="tb-weekend"></div></details>
+  </div>
+
+  <h2>Monthly outcomes</h2>
+  <div class="grid2">
+    <div class="card">
+      <h3>Billing peak demand (30-min basis), kW</h3>
+      <div class="legend" id="lg-mpeak"></div>
+      <div class="chart-box" id="ch-mpeak"></div>
+    </div>
+    <div class="card">
+      <h3>Facility electricity, MWh</h3>
+      <div class="legend" id="lg-menergy"></div>
+      <div class="chart-box" id="ch-menergy"></div>
+    </div>
+  </div>
+  <details><summary>Monthly data table</summary><div class="tblwrap" id="tb-monthly"></div></details>
+
+  <h2>How it was built — every step through MCP tools</h2>
+  <ol class="steps">
+    <li><code>create_baseline_osm</code> → <code>add_baseline_system(system_type=7)</code> — 10-zone, 2-story office; VAV with reheat, chiller + boiler plant.</li>
+    <li><code>change_building_location(Boston TMY3)</code> → <code>set_run_period(Jun 1 – Aug 31)</code>.</li>
+    <li><code>add_output_variable</code> (facility demand, zone temps, thermostat setpoints, OAT at timestep) + <code>add_output_meter</code> (facility / cooling / fans electricity).</li>
+    <li><code>run_simulation</code> — baseline characterization; true peak 337.7 kW → shed threshold set at 82% (276.9 kW).</li>
+    <li><code>list_ems_actuators(component_type="Zone Temperature Control")</code> — confirms a <em>Cooling Setpoint</em> actuator per zone from the EnergyPlus .edd dictionary.</li>
+    <li><code>create_python_plugin(template="custom", class_name="DemandLimiter", global_variables=["dr_stage"])</code> — full controller source below; the tool wires PythonPlugin:Instance/Variables/OutputVariable and validates the code against the plugin contract.</li>
+    <li><code>save_osm_model</code> → <code>run_simulation</code> → <code>extract_simulation_errors</code> (verifies <code>PythonPlugin: Class DemandLimiter imported</code>, zero severe errors).</li>
+    <li><code>edit_python_plugin</code> ×2 — controller revisions from simulated evidence (see table below).</li>
+    <li><code>query_timeseries</code> — demand, plugin stage output, setpoints, zone temps for every figure on this page; <code>extract_summary_metrics</code> / <code>extract_end_use_breakdown</code> for totals.</li>
+  </ol>
+
+  <table class="iter">
+    <tr><th>Revision</th><th>Controller</th><th>What the simulation said</th></tr>
+    <tr><td>v1</td><td>Weekday 13:00–18:00 window, 3 stages, 30-min dwell</td>
+      <td>Sheds 37–52 kW in-window, but the building peaks at 08:30 (morning pulldown) — seasonal peak untouched. Also surfaced an analysis trap: Boston's cooling design days fall on July 21, and sizing-period rows share calendar dates with run-period rows in the SQL output.</td></tr>
+    <tr><td>v2</td><td>Weekday 08:00–19:00, 4 stages, 20-min dwell</td>
+      <td>Weekday peaks clipped to ~290 kW, but the seasonal peak moved to Saturday (329 kW) — the model runs 7-day schedules. 20-min staging also let the 08:30 spike through at 320 kW.</td></tr>
+    <tr><td>v3</td><td>Every day 08:00–19:00, 10-min dwell, 2-stage jump-start above 115% of threshold</td>
+      <td>Billing peak −7.2% (−8.7 / −10.1 / −7.2% by month), exceedances −73%, energy −3.9%. Residual instantaneous spikes are single-timestep chiller-staging transients — feedback control can't preempt a step change it hasn't metered yet.</td></tr>
+  </table>
+
+  <details>
+    <summary>Controller source (as stored in the model by <code>get_python_plugin</code>)</summary>
+    <pre class="code" id="plugin-code"></pre>
+  </details>
+
+  <h2>Findings a researcher would chase next</h2>
+  <ul class="foot">
+    <li><strong>Shed capacity is finite:</strong> at stage 3 (+3 K) the floor is ~285–295 kW; deeper cuts need pre-cooling, chiller demand limiting, or lighting/plug DR — all writable as further plugin logic.</li>
+    <li><strong>Chiller-staging transients:</strong> demand limiting induced brief plant cycling spikes (up to +19 kW over baseline for one timestep). On a 30-min billing basis they wash out; sub-metered plant control would remove them.</li>
+    <li><strong>Comfort trade:</strong> zones float to 26.9 °C during events. Reported unmet cooling hours <em>improve</em> (152.5 → 24.7 h) only because EnergyPlus scores comfort against the actuated setpoint — an artifact worth knowing about, not a comfort gain.</li>
+    <li><strong>The baseline plant is capacity-limited:</strong> baseline zones already float ~0.5–1.5 K above setpoint on peak afternoons, which is why the sizing-day demand plateau (351 kW) never appears in the run period.</li>
+  </ul>
+
+  <ul class="foot" style="margin-top:20px">
+    <li>Model: openstudio-mcp 10-zone baseline (100 m × 50 m × 2 stories, ~10,000 m²), ASHRAE baseline System 7 (VAV, chiller + boiler), Boston-Logan TMY3, Jun 1 – Aug 31, 10-min timesteps.</li>
+    <li>"Billing peak" = maximum 30-minute rolling average demand, the basis most demand charges use; instantaneous curves shown in the figures.</li>
+    <li>Design-day rows returned by <code>query_timeseries</code> were removed by keeping the last row per timestamp (the run-period environment simulates last).</li>
+  </ul>
+</div>
+
+<script>
+const DATA = {"peakday":{"label":"Jun 27 (baseline peak weekday)","base_kw":[[0.167,50.99],[0.333,54.02],[0.5,53.95],[0.667,53.89],[0.833,53.97],[1.0,54.0],[1.167,54.04],[1.333,54.08],[1.5,54.12],[1.667,54.17],[1.833,54.22],[2.0,54.27],[2.167,54.28],[2.333,54.29],[2.5,54.33],[2.667,54.44],[2.833,54.52],[3.0,54.58],[3.167,54.63],[3.333,54.67],[3.5,54.69],[3.667,54.7],[3.833,54.7],[4.0,54.69],[4.167,54.72],[4.333,54.77],[4.5,54.86],[4.667,54.99],[4.833,55.14],[5.0,55.31],[5.167,55.48],[5.333,55.63],[5.5,55.77],[5.667,55.9],[5.833,56.01],[6.0,56.11],[6.167,74.64],[6.333,74.8],[6.5,74.66],[6.667,74.55],[6.833,80.16],[7.0,75.06],[7.167,109.75],[7.333,95.93],[7.5,135.78],[7.667,95.53],[7.833,104.18],[8.0,104.25],[8.167,307.67],[8.333,318.3],[8.5,337.65],[8.667,334.07],[8.833,333.95],[9.0,329.38],[9.167,327.51],[9.333,326.05],[9.5,325.18],[9.667,324.69],[9.833,324.42],[10.0,324.31],[10.167,324.62],[10.333,325.03],[10.5,325.49],[10.667,325.96],[10.833,326.38],[11.0,326.8],[11.167,326.8],[11.333,326.75],[11.5,326.6],[11.667,326.42],[11.833,326.22],[12.0,326.01],[12.167,207.94],[12.333,178.83],[12.5,183.15],[12.667,189.85],[12.833,176.25],[13.0,193.77],[13.167,325.03],[13.333,324.48],[13.5,324.46],[13.667,324.49],[13.833,324.51],[14.0,324.58],[14.167,324.64],[14.333,324.67],[14.5,324.66],[14.667,324.61],[14.833,323.31],[15.0,323.49],[15.167,323.58],[15.333,323.68],[15.5,323.76],[15.667,323.83],[15.833,323.9],[16.0,323.97],[16.167,324.09],[16.333,324.26],[16.5,324.48],[16.667,324.74],[16.833,325.02],[17.0,325.31],[17.167,269.59],[17.333,257.87],[17.5,233.94],[17.667,240.51],[17.833,235.08],[18.0,230.73],[18.167,142.27],[18.333,143.07],[18.5,143.71],[18.667,144.35],[18.833,144.96],[19.0,145.52],[19.167,145.54],[19.333,145.47],[19.5,145.29],[19.667,145.0],[19.833,144.64],[20.0,144.23],[20.167,72.34],[20.333,72.35],[20.5,72.36],[20.667,72.37],[20.833,72.38],[21.0,72.39],[21.167,72.36],[21.333,72.33],[21.5,72.3],[21.667,72.27],[21.833,72.25],[22.0,72.24],[22.167,61.47],[22.333,61.47],[22.5,61.47],[22.667,61.47],[22.833,61.48],[23.0,64.58],[23.167,64.58],[23.333,64.58],[23.5,64.59],[23.667,64.59],[23.833,64.59],[24.0,64.59]],"shed_kw":[[0.167,51.53],[0.333,51.45],[0.5,54.48],[0.667,54.41],[0.833,54.34],[1.0,54.28],[1.167,54.3],[1.333,54.32],[1.5,54.52],[1.667,54.76],[1.833,54.99],[2.0,55.23],[2.167,55.16],[2.333,55.09],[2.5,55.0],[2.667,54.9],[2.833,54.79],[3.0,54.67],[3.167,54.57],[3.333,54.46],[3.5,54.35],[3.667,54.22],[3.833,54.46],[4.0,54.51],[4.167,54.61],[4.333,54.72],[4.5,54.86],[4.667,55.03],[4.833,55.21],[5.0,55.41],[5.167,55.61],[5.333,55.8],[5.5,56.0],[5.667,55.5],[5.833,55.66],[6.0,55.82],[6.167,75.98],[6.333,76.3],[6.5,76.62],[6.667,76.92],[6.833,78.89],[7.0,87.34],[7.167,95.59],[7.333,135.06],[7.5,130.74],[7.667,98.6],[7.833,102.87],[8.0,108.09],[8.167,303.24],[8.333,290.73],[8.5,274.2],[8.667,265.07],[8.833,273.83],[9.0,275.67],[9.167,278.54],[9.333,281.84],[9.5,280.61],[9.667,282.47],[9.833,283.29],[10.0,283.98],[10.167,285.13],[10.333,286.18],[10.5,287.16],[10.667,288.05],[10.833,288.87],[11.0,289.66],[11.167,289.63],[11.333,289.57],[11.5,289.52],[11.667,289.46],[11.833,289.41],[12.0,289.35],[12.167,170.81],[12.333,175.7],[12.5,173.33],[12.667,174.5],[12.833,174.44],[13.0,162.78],[13.167,293.47],[13.333,292.81],[13.5,297.39],[13.667,292.22],[13.833,293.55],[14.0,293.7],[14.167,293.67],[14.333,293.72],[14.5,293.74],[14.667,293.78],[14.833,293.06],[15.0,293.38],[15.167,293.09],[15.333,292.89],[15.5,292.74],[15.667,292.58],[15.833,292.46],[16.0,292.36],[16.167,292.51],[16.333,292.7],[16.5,292.9],[16.667,293.11],[16.833,293.34],[17.0,293.58],[17.167,218.54],[17.333,217.74],[17.5,216.08],[17.667,214.69],[17.833,213.41],[18.0,212.08],[18.167,138.17],[18.333,138.64],[18.5,139.0],[18.667,139.32],[18.833,139.64],[19.0,140.04],[19.167,159.64],[19.333,137.53],[19.5,143.2],[19.667,165.11],[19.833,140.36],[20.0,148.93],[20.167,108.78],[20.333,78.53],[20.5,77.44],[20.667,78.6],[20.833,77.15],[21.0,76.84],[21.167,76.05],[21.333,75.36],[21.5,74.76],[21.667,74.24],[21.833,73.78],[22.0,73.37],[22.167,61.86],[22.333,61.84],[22.5,61.82],[22.667,61.79],[22.833,61.77],[23.0,61.75],[23.167,61.71],[23.333,61.67],[23.5,61.64],[23.667,61.6],[23.833,64.66],[24.0,64.63]],"stage":[[0.167,0.0],[0.333,0.0],[0.5,0.0],[0.667,0.0],[0.833,0.0],[1.0,0.0],[1.167,0.0],[1.333,0.0],[1.5,0.0],[1.667,0.0],[1.833,0.0],[2.0,0.0],[2.167,0.0],[2.333,0.0],[2.5,0.0],[2.667,0.0],[2.833,0.0],[3.0,0.0],[3.167,0.0],[3.333,0.0],[3.5,0.0],[3.667,0.0],[3.833,0.0],[4.0,0.0],[4.167,0.0],[4.333,0.0],[4.5,0.0],[4.667,0.0],[4.833,0.0],[5.0,0.0],[5.167,0.0],[5.333,0.0],[5.5,0.0],[5.667,0.0],[5.833,0.0],[6.0,0.0],[6.167,0.0],[6.333,0.0],[6.5,0.0],[6.667,0.0],[6.833,0.0],[7.0,0.0],[7.167,0.0],[7.333,0.0],[7.5,0.0],[7.667,0.0],[7.833,0.0],[8.0,0.0],[8.167,0.0],[8.333,1.0],[8.5,2.0],[8.667,3.0],[8.833,3.0],[9.0,3.0],[9.167,3.0],[9.333,3.0],[9.5,3.0],[9.667,3.0],[9.833,3.0],[10.0,3.0],[10.167,3.0],[10.333,3.0],[10.5,3.0],[10.667,3.0],[10.833,3.0],[11.0,3.0],[11.167,3.0],[11.333,3.0],[11.5,3.0],[11.667,3.0],[11.833,3.0],[12.0,3.0],[12.167,3.0],[12.333,3.0],[12.5,3.0],[12.667,3.0],[12.833,3.0],[13.0,3.0],[13.167,3.0],[13.333,3.0],[13.5,3.0],[13.667,3.0],[13.833,3.0],[14.0,3.0],[14.167,3.0],[14.333,3.0],[14.5,3.0],[14.667,3.0],[14.833,3.0],[15.0,3.0],[15.167,3.0],[15.333,3.0],[15.5,3.0],[15.667,3.0],[15.833,3.0],[16.0,3.0],[16.167,3.0],[16.333,3.0],[16.5,3.0],[16.667,3.0],[16.833,3.0],[17.0,3.0],[17.167,3.0],[17.333,3.0],[17.5,3.0],[17.667,3.0],[17.833,3.0],[18.0,3.0],[18.167,3.0],[18.333,3.0],[18.5,3.0],[18.667,3.0],[18.833,3.0],[19.0,3.0],[19.167,2.0],[19.333,2.0],[19.5,2.0],[19.667,1.0],[19.833,1.0],[20.0,1.0],[20.167,0.0],[20.333,0.0],[20.5,0.0],[20.667,0.0],[20.833,0.0],[21.0,0.0],[21.167,0.0],[21.333,0.0],[21.5,0.0],[21.667,0.0],[21.833,0.0],[22.0,0.0],[22.167,0.0],[22.333,0.0],[22.5,0.0],[22.667,0.0],[22.833,0.0],[23.0,0.0],[23.167,0.0],[23.333,0.0],[23.5,0.0],[23.667,0.0],[23.833,0.0],[24.0,0.0]],"sp_shed":[[0.167,23.9],[0.333,23.9],[0.5,23.9],[0.667,23.9],[0.833,23.9],[1.0,23.9],[1.167,23.9],[1.333,23.9],[1.5,23.9],[1.667,23.9],[1.833,23.9],[2.0,23.9],[2.167,23.9],[2.333,23.9],[2.5,23.9],[2.667,23.9],[2.833,23.9],[3.0,23.9],[3.167,23.9],[3.333,23.9],[3.5,23.9],[3.667,23.9],[3.833,23.9],[4.0,23.9],[4.167,23.9],[4.333,23.9],[4.5,23.9],[4.667,23.9],[4.833,23.9],[5.0,23.9],[5.167,23.9],[5.333,23.9],[5.5,23.9],[5.667,23.9],[5.833,23.9],[6.0,23.9],[6.167,23.9],[6.333,23.9],[6.5,23.9],[6.667,23.9],[6.833,23.9],[7.0,23.9],[7.167,23.9],[7.333,23.9],[7.5,23.9],[7.667,23.9],[7.833,23.9],[8.0,23.9],[8.167,23.9],[8.333,24.9],[8.5,25.9],[8.667,26.9],[8.833,26.9],[9.0,26.9],[9.167,26.9],[9.333,26.9],[9.5,26.9],[9.667,26.9],[9.833,26.9],[10.0,26.9],[10.167,26.9],[10.333,26.9],[10.5,26.9],[10.667,26.9],[10.833,26.9],[11.0,26.9],[11.167,26.9],[11.333,26.9],[11.5,26.9],[11.667,26.9],[11.833,26.9],[12.0,26.9],[12.167,26.9],[12.333,26.9],[12.5,26.9],[12.667,26.9],[12.833,26.9],[13.0,26.9],[13.167,26.9],[13.333,26.9],[13.5,26.9],[13.667,26.9],[13.833,26.9],[14.0,26.9],[14.167,26.9],[14.333,26.9],[14.5,26.9],[14.667,26.9],[14.833,26.9],[15.0,26.9],[15.167,26.9],[15.333,26.9],[15.5,26.9],[15.667,26.9],[15.833,26.9],[16.0,26.9],[16.167,26.9],[16.333,26.9],[16.5,26.9],[16.667,26.9],[16.833,26.9],[17.0,26.9],[17.167,26.9],[17.333,26.9],[17.5,26.9],[17.667,26.9],[17.833,26.9],[18.0,26.9],[18.167,26.9],[18.333,26.9],[18.5,26.9],[18.667,26.9],[18.833,26.9],[19.0,26.9],[19.167,25.9],[19.333,25.9],[19.5,25.9],[19.667,24.9],[19.833,24.9],[20.0,24.9],[20.167,23.9],[20.333,23.9],[20.5,23.9],[20.667,23.9],[20.833,23.9],[21.0,23.9],[21.167,23.9],[21.333,23.9],[21.5,23.9],[21.667,23.9],[21.833,23.9],[22.0,23.9],[22.167,23.9],[22.333,23.9],[22.5,23.9],[22.667,23.9],[22.833,23.9],[23.0,23.9],[23.167,23.9],[23.333,23.9],[23.5,23.9],[23.667,23.9],[23.833,23.9],[24.0,23.9]],"tz_shed":[[0.167,23.9],[0.333,23.9],[0.5,23.9],[0.667,23.9],[0.833,23.9],[1.0,23.9],[1.167,23.9],[1.333,23.9],[1.5,23.9],[1.667,23.9],[1.833,23.9],[2.0,23.9],[2.167,23.9],[2.333,23.9],[2.5,23.9],[2.667,23.9],[2.833,23.9],[3.0,23.9],[3.167,23.9],[3.333,23.9],[3.5,23.9],[3.667,23.9],[3.833,23.9],[4.0,23.88],[4.167,23.87],[4.333,23.86],[4.5,23.86],[4.667,23.87],[4.833,23.87],[5.0,23.87],[5.167,23.88],[5.333,23.88],[5.5,23.89],[5.667,23.9],[5.833,23.9],[6.0,23.9],[6.167,23.9],[6.333,23.9],[6.5,23.9],[6.667,23.9],[6.833,23.89],[7.0,23.58],[7.167,23.84],[7.333,23.89],[7.5,23.89],[7.667,24.07],[7.833,23.96],[8.0,24.03],[8.167,24.01],[8.333,24.8],[8.5,25.63],[8.667,26.32],[8.833,26.55],[9.0,26.62],[9.167,26.68],[9.333,26.74],[9.5,26.83],[9.667,26.9],[9.833,26.9],[10.0,26.9],[10.167,26.9],[10.333,26.9],[10.5,26.9],[10.667,26.9],[10.833,26.9],[11.0,26.9],[11.167,26.9],[11.333,26.9],[11.5,26.9],[11.667,26.9],[11.833,26.9],[12.0,26.9],[12.167,26.54],[12.333,26.57],[12.5,26.86],[12.667,26.93],[12.833,27.02],[13.0,26.98],[13.167,26.9],[13.333,26.9],[13.5,26.9],[13.667,26.9],[13.833,26.9],[14.0,26.9],[14.167,26.9],[14.333,26.9],[14.5,26.9],[14.667,26.9],[14.833,26.9],[15.0,26.9],[15.167,26.9],[15.333,26.9],[15.5,26.9],[15.667,26.9],[15.833,26.9],[16.0,26.9],[16.167,26.9],[16.333,26.9],[16.5,26.9],[16.667,26.9],[16.833,26.9],[17.0,26.9],[17.167,26.9],[17.333,26.9],[17.5,26.9],[17.667,26.9],[17.833,26.9],[18.0,26.9],[18.167,26.9],[18.333,26.9],[18.5,26.9],[18.667,26.9],[18.833,26.9],[19.0,26.9],[19.167,25.95],[19.333,25.83],[19.5,25.89],[19.667,25.06],[19.833,24.9],[20.0,24.9],[20.167,24.08],[20.333,23.9],[20.5,23.9],[20.667,23.9],[20.833,23.9],[21.0,23.9],[21.167,23.9],[21.333,23.9],[21.5,23.9],[21.667,23.9],[21.833,23.9],[22.0,23.9],[22.167,23.9],[22.333,23.9],[22.5,23.9],[22.667,23.9],[22.833,23.9],[23.0,23.9],[23.167,23.9],[23.333,23.9],[23.5,23.9],[23.667,23.9],[23.833,23.9],[24.0,23.9]],"tz_base":[[0.167,23.9],[0.333,23.9],[0.5,23.9],[0.667,23.9],[0.833,23.89],[1.0,23.85],[1.167,23.82],[1.333,23.82],[1.5,23.83],[1.667,23.84],[1.833,23.85],[2.0,23.87],[2.167,23.86],[2.333,23.84],[2.5,23.81],[2.667,23.77],[2.833,23.73],[3.0,23.7],[3.167,23.66],[3.333,23.63],[3.5,23.59],[3.667,23.56],[3.833,23.52],[4.0,23.49],[4.167,23.47],[4.333,23.46],[4.5,23.46],[4.667,23.47],[4.833,23.47],[5.0,23.48],[5.167,23.48],[5.333,23.49],[5.5,23.5],[5.667,23.52],[5.833,23.53],[6.0,23.55],[6.167,23.65],[6.333,23.79],[6.5,23.89],[6.667,23.9],[6.833,23.71],[7.0,23.75],[7.167,23.62],[7.333,23.87],[7.5,23.9],[7.667,24.16],[7.833,24.26],[8.0,24.25],[8.167,24.07],[8.333,23.95],[8.5,23.9],[8.667,23.9],[8.833,23.9],[9.0,23.9],[9.167,23.9],[9.333,23.9],[9.5,23.9],[9.667,23.9],[9.833,23.9],[10.0,23.9],[10.167,23.9],[10.333,23.9],[10.5,23.9],[10.667,23.9],[10.833,23.9],[11.0,23.9],[11.167,23.9],[11.333,23.9],[11.5,23.9],[11.667,23.9],[11.833,23.9],[12.0,23.9],[12.167,23.9],[12.333,23.9],[12.5,23.9],[12.667,23.9],[12.833,23.9],[13.0,23.9],[13.167,23.98],[13.333,24.07],[13.5,24.14],[13.667,24.18],[13.833,24.2],[14.0,24.23],[14.167,24.25],[14.333,24.27],[14.5,24.29],[14.667,24.3],[14.833,24.32],[15.0,24.33],[15.167,24.34],[15.333,24.34],[15.5,24.33],[15.667,24.32],[15.833,24.31],[16.0,24.3],[16.167,24.3],[16.333,24.3],[16.5,24.3],[16.667,24.3],[16.833,24.3],[17.0,24.29],[17.167,24.01],[17.333,23.9],[17.5,23.9],[17.667,23.9],[17.833,23.9],[18.0,23.9],[18.167,23.9],[18.333,23.9],[18.5,23.9],[18.667,23.9],[18.833,23.9],[19.0,23.9],[19.167,23.9],[19.333,23.9],[19.5,23.9],[19.667,23.9],[19.833,23.9],[20.0,23.9],[20.167,23.9],[20.333,23.9],[20.5,23.9],[20.667,23.9],[20.833,23.9],[21.0,23.9],[21.167,23.9],[21.333,23.9],[21.5,23.9],[21.667,23.9],[21.833,23.9],[22.0,23.89],[22.167,23.77],[22.333,23.64],[22.5,23.57],[22.667,23.54],[22.833,23.53],[23.0,23.51],[23.167,23.48],[23.333,23.44],[23.5,23.4],[23.667,23.36],[23.833,23.32],[24.0,23.28]],"sp_base":[[0.167,23.9],[0.333,23.9],[0.5,23.9],[0.667,23.9],[0.833,23.9],[1.0,23.9],[1.167,23.9],[1.333,23.9],[1.5,23.9],[1.667,23.9],[1.833,23.9],[2.0,23.9],[2.167,23.9],[2.333,23.9],[2.5,23.9],[2.667,23.9],[2.833,23.9],[3.0,23.9],[3.167,23.9],[3.333,23.9],[3.5,23.9],[3.667,23.9],[3.833,23.9],[4.0,23.9],[4.167,23.9],[4.333,23.9],[4.5,23.9],[4.667,23.9],[4.833,23.9],[5.0,23.9],[5.167,23.9],[5.333,23.9],[5.5,23.9],[5.667,23.9],[5.833,23.9],[6.0,23.9],[6.167,23.9],[6.333,23.9],[6.5,23.9],[6.667,23.9],[6.833,23.9],[7.0,23.9],[7.167,23.9],[7.333,23.9],[7.5,23.9],[7.667,23.9],[7.833,23.9],[8.0,23.9],[8.167,23.9],[8.333,23.9],[8.5,23.9],[8.667,23.9],[8.833,23.9],[9.0,23.9],[9.167,23.9],[9.333,23.9],[9.5,23.9],[9.667,23.9],[9.833,23.9],[10.0,23.9],[10.167,23.9],[10.333,23.9],[10.5,23.9],[10.667,23.9],[10.833,23.9],[11.0,23.9],[11.167,23.9],[11.333,23.9],[11.5,23.9],[11.667,23.9],[11.833,23.9],[12.0,23.9],[12.167,23.9],[12.333,23.9],[12.5,23.9],[12.667,23.9],[12.833,23.9],[13.0,23.9],[13.167,23.9],[13.333,23.9],[13.5,23.9],[13.667,23.9],[13.833,23.9],[14.0,23.9],[14.167,23.9],[14.333,23.9],[14.5,23.9],[14.667,23.9],[14.833,23.9],[15.0,23.9],[15.167,23.9],[15.333,23.9],[15.5,23.9],[15.667,23.9],[15.833,23.9],[16.0,23.9],[16.167,23.9],[16.333,23.9],[16.5,23.9],[16.667,23.9],[16.833,23.9],[17.0,23.9],[17.167,23.9],[17.333,23.9],[17.5,23.9],[17.667,23.9],[17.833,23.9],[18.0,23.9],[18.167,23.9],[18.333,23.9],[18.5,23.9],[18.667,23.9],[18.833,23.9],[19.0,23.9],[19.167,23.9],[19.333,23.9],[19.5,23.9],[19.667,23.9],[19.833,23.9],[20.0,23.9],[20.167,23.9],[20.333,23.9],[20.5,23.9],[20.667,23.9],[20.833,23.9],[21.0,23.9],[21.167,23.9],[21.333,23.9],[21.5,23.9],[21.667,23.9],[21.833,23.9],[22.0,23.9],[22.167,23.9],[22.333,23.9],[22.5,23.9],[22.667,23.9],[22.833,23.9],[23.0,23.9],[23.167,23.9],[23.333,23.9],[23.5,23.9],[23.667,23.9],[23.833,23.9],[24.0,23.9]],"oat":[[0.167,25.4],[0.333,25.2],[0.5,25.0],[0.667,24.8],[0.833,24.6],[1.0,24.4],[1.167,24.5],[1.333,24.6],[1.5,24.7],[1.667,24.8],[1.833,24.9],[2.0,25.0],[2.167,24.9],[2.333,24.8],[2.5,24.7],[2.667,24.6],[2.833,24.5],[3.0,24.4],[3.167,24.32],[3.333,24.23],[3.5,24.15],[3.667,24.07],[3.833,23.98],[4.0,23.9],[4.167,23.98],[4.333,24.07],[4.5,24.15],[4.667,24.23],[4.833,24.32],[5.0,24.4],[5.167,24.5],[5.333,24.6],[5.5,24.7],[5.667,24.8],[5.833,24.9],[6.0,25.0],[6.167,25.28],[6.333,25.57],[6.5,25.85],[6.667,26.13],[6.833,26.42],[7.0,26.7],[7.167,26.97],[7.333,27.23],[7.5,27.5],[7.667,27.77],[7.833,28.03],[8.0,28.3],[8.167,28.4],[8.333,28.5],[8.5,28.6],[8.667,28.7],[8.833,28.8],[9.0,28.9],[9.167,28.98],[9.333,29.07],[9.5,29.15],[9.667,29.23],[9.833,29.32],[10.0,29.4],[10.167,29.68],[10.333,29.97],[10.5,30.25],[10.667,30.53],[10.833,30.82],[11.0,31.1],[11.167,31.1],[11.333,31.1],[11.5,31.1],[11.667,31.1],[11.833,31.1],[12.0,31.1],[12.167,31.28],[12.333,31.47],[12.5,31.65],[12.667,31.83],[12.833,32.02],[13.0,32.2],[13.167,32.3],[13.333,32.4],[13.5,32.5],[13.667,32.6],[13.833,32.7],[14.0,32.8],[14.167,32.8],[14.333,32.8],[14.5,32.8],[14.667,32.8],[14.833,32.8],[15.0,32.8],[15.167,32.62],[15.333,32.43],[15.5,32.25],[15.667,32.07],[15.833,31.88],[16.0,31.7],[16.167,31.6],[16.333,31.5],[16.5,31.4],[16.667,31.3],[16.833,31.2],[17.0,31.1],[17.167,29.9],[17.333,28.7],[17.5,27.5],[17.667,26.3],[17.833,25.1],[18.0,23.9],[18.167,23.9],[18.333,23.9],[18.5,23.9],[18.667,23.9],[18.833,23.9],[19.0,23.9],[19.167,23.62],[19.333,23.33],[19.5,23.05],[19.667,22.77],[19.833,22.48],[20.0,22.2],[20.167,22.33],[20.333,22.47],[20.5,22.6],[20.667,22.73],[20.833,22.87],[21.0,23.0],[21.167,22.87],[21.333,22.73],[21.5,22.6],[21.667,22.47],[21.833,22.33],[22.0,22.2],[22.167,22.2],[22.333,22.2],[22.5,22.2],[22.667,22.2],[22.833,22.2],[23.0,22.2],[23.167,22.12],[23.333,22.03],[23.5,21.95],[23.667,21.87],[23.833,21.78],[24.0,21.7]]},"weekend":{"base_kw":[[0.167,47.36],[0.333,47.29],[0.5,47.26],[0.667,47.23],[0.833,47.22],[1.0,47.2],[1.167,47.19],[1.333,47.19],[1.5,47.2],[1.667,47.22],[1.833,47.24],[2.0,47.26],[2.167,47.27],[2.333,47.28],[2.5,47.28],[2.667,47.26],[2.833,47.25],[3.0,47.24],[3.167,47.23],[3.333,47.2],[3.5,47.13],[3.667,47.05],[3.833,46.97],[4.0,46.89],[4.167,46.82],[4.333,46.75],[4.5,46.68],[4.667,46.61],[4.833,46.55],[5.0,47.84],[5.167,49.07],[5.333,50.27],[5.5,51.43],[5.667,52.57],[5.833,53.34],[6.0,53.37],[6.167,74.92],[6.333,74.95],[6.5,74.97],[6.667,75.0],[6.833,75.02],[7.0,75.04],[7.167,93.48],[7.333,93.51],[7.5,93.53],[7.667,93.56],[7.833,93.58],[8.0,93.6],[8.167,269.05],[8.333,284.34],[8.5,295.94],[8.667,291.33],[8.833,293.68],[9.0,297.79],[9.167,298.75],[9.333,299.98],[9.5,301.96],[9.667,303.9],[9.833,306.03],[10.0,308.17],[10.167,310.03],[10.333,311.91],[10.5,313.83],[10.667,315.35],[10.833,316.42],[11.0,317.55],[11.167,318.65],[11.333,319.67],[11.5,320.59],[11.667,321.43],[11.833,322.18],[12.0,322.83],[12.167,214.21],[12.333,180.59],[12.5,170.54],[12.667,191.09],[12.833,190.92],[13.0,202.32],[13.167,325.12],[13.333,324.74],[13.5,324.07],[13.667,323.45],[13.833,322.82],[14.0,322.28],[14.167,321.89],[14.333,321.68],[14.5,321.62],[14.667,321.66],[14.833,321.79],[15.0,321.97],[15.167,322.21],[15.333,322.49],[15.5,322.8],[15.667,323.13],[15.833,323.46],[16.0,323.81],[16.167,324.22],[16.333,324.73],[16.5,325.35],[16.667,326.04],[16.833,326.79],[17.0,327.55],[17.167,269.48],[17.333,261.86],[17.5,246.74],[17.667,258.29],[17.833,256.56],[18.0,256.13],[18.167,149.12],[18.333,177.61],[18.5,173.94],[18.667,168.72],[18.833,147.2],[19.0,153.03],[19.167,171.64],[19.333,150.7],[19.5,171.21],[19.667,169.28],[19.833,144.41],[20.0,172.42],[20.167,74.11],[20.333,75.2],[20.5,72.64],[20.667,76.14],[20.833,74.49],[21.0,75.05],[21.167,74.51],[21.333,74.42],[21.5,73.96],[21.667,73.72],[21.833,73.29],[22.0,72.98],[22.167,61.9],[22.333,61.83],[22.5,62.55],[22.667,61.92],[22.833,62.0],[23.0,61.86],[23.167,61.87],[23.333,61.89],[23.5,61.91],[23.667,61.94],[23.833,61.97],[24.0,62.0]],"shed_kw":[[0.167,47.38],[0.333,47.31],[0.5,47.26],[0.667,47.24],[0.833,47.22],[1.0,47.21],[1.167,47.19],[1.333,47.19],[1.5,47.21],[1.667,47.22],[1.833,47.24],[2.0,47.26],[2.167,47.28],[2.333,47.28],[2.5,47.28],[2.667,47.27],[2.833,47.26],[3.0,47.24],[3.167,47.24],[3.333,47.2],[3.5,47.13],[3.667,47.05],[3.833,46.97],[4.0,46.89],[4.167,46.82],[4.333,46.75],[4.5,46.68],[4.667,46.62],[4.833,46.56],[5.0,47.84],[5.167,49.07],[5.333,50.27],[5.5,51.43],[5.667,52.57],[5.833,53.34],[6.0,53.37],[6.167,74.92],[6.333,74.95],[6.5,74.97],[6.667,75.0],[6.833,75.02],[7.0,75.04],[7.167,93.49],[7.333,93.51],[7.5,93.53],[7.667,93.56],[7.833,93.58],[8.0,93.6],[8.167,269.14],[8.333,262.0],[8.5,255.2],[8.667,260.36],[8.833,269.46],[9.0,269.27],[9.167,269.89],[9.333,272.38],[9.5,274.11],[9.667,275.66],[9.833,277.15],[10.0,255.64],[10.167,274.04],[10.333,269.72],[10.5,283.23],[10.667,277.66],[10.833,264.59],[11.0,277.24],[11.167,283.06],[11.333,283.71],[11.5,286.07],[11.667,288.29],[11.833,262.29],[12.0,294.46],[12.167,160.0],[12.333,160.52],[12.5,160.82],[12.667,174.5],[12.833,160.38],[13.0,160.38],[13.167,297.48],[13.333,296.75],[13.5,293.57],[13.667,309.34],[13.833,310.91],[14.0,297.72],[14.167,286.57],[14.333,286.3],[14.5,285.95],[14.667,286.02],[14.833,286.2],[15.0,286.45],[15.167,287.13],[15.333,287.84],[15.5,288.55],[15.667,289.33],[15.833,290.08],[16.0,290.82],[16.167,290.51],[16.333,290.34],[16.5,290.39],[16.667,290.49],[16.833,290.68],[17.0,290.91],[17.167,237.54],[17.333,215.77],[17.5,212.1],[17.667,236.13],[17.833,220.5],[18.0,223.59],[18.167,151.37],[18.333,139.3],[18.5,151.85],[18.667,139.49],[18.833,152.8],[19.0,139.94],[19.167,168.12],[19.333,155.08],[19.5,150.91],[19.667,202.64],[19.833,137.54],[20.0,170.29],[20.167,117.91],[20.333,84.06],[20.5,85.4],[20.667,84.79],[20.833,79.78],[21.0,83.92],[21.167,78.48],[21.333,82.55],[21.5,93.38],[21.667,72.72],[21.833,89.43],[22.0,83.52],[22.167,64.1],[22.333,62.98],[22.5,64.18],[22.667,63.31],[22.833,66.07],[23.0,64.53],[23.167,64.51],[23.333,62.17],[23.5,67.97],[23.667,62.39],[23.833,73.91],[24.0,62.79]],"stage":[[0.167,0.0],[0.333,0.0],[0.5,0.0],[0.667,0.0],[0.833,0.0],[1.0,0.0],[1.167,0.0],[1.333,0.0],[1.5,0.0],[1.667,0.0],[1.833,0.0],[2.0,0.0],[2.167,0.0],[2.333,0.0],[2.5,0.0],[2.667,0.0],[2.833,0.0],[3.0,0.0],[3.167,0.0],[3.333,0.0],[3.5,0.0],[3.667,0.0],[3.833,0.0],[4.0,0.0],[4.167,0.0],[4.333,0.0],[4.5,0.0],[4.667,0.0],[4.833,0.0],[5.0,0.0],[5.167,0.0],[5.333,0.0],[5.5,0.0],[5.667,0.0],[5.833,0.0],[6.0,0.0],[6.167,0.0],[6.333,0.0],[6.5,0.0],[6.667,0.0],[6.833,0.0],[7.0,0.0],[7.167,0.0],[7.333,0.0],[7.5,0.0],[7.667,0.0],[7.833,0.0],[8.0,0.0],[8.167,0.0],[8.333,1.0],[8.5,2.0],[8.667,2.0],[8.833,2.0],[9.0,2.0],[9.167,2.0],[9.333,2.0],[9.5,2.0],[9.667,2.0],[9.833,2.0],[10.0,3.0],[10.167,3.0],[10.333,3.0],[10.5,3.0],[10.667,3.0],[10.833,3.0],[11.0,3.0],[11.167,3.0],[11.333,3.0],[11.5,3.0],[11.667,3.0],[11.833,3.0],[12.0,3.0],[12.167,3.0],[12.333,3.0],[12.5,3.0],[12.667,3.0],[12.833,3.0],[13.0,3.0],[13.167,3.0],[13.333,3.0],[13.5,3.0],[13.667,3.0],[13.833,3.0],[14.0,3.0],[14.167,3.0],[14.333,3.0],[14.5,3.0],[14.667,3.0],[14.833,3.0],[15.0,3.0],[15.167,3.0],[15.333,3.0],[15.5,3.0],[15.667,3.0],[15.833,3.0],[16.0,3.0],[16.167,3.0],[16.333,3.0],[16.5,3.0],[16.667,3.0],[16.833,3.0],[17.0,3.0],[17.167,3.0],[17.333,3.0],[17.5,3.0],[17.667,3.0],[17.833,3.0],[18.0,3.0],[18.167,3.0],[18.333,3.0],[18.5,3.0],[18.667,3.0],[18.833,3.0],[19.0,3.0],[19.167,2.0],[19.333,2.0],[19.5,2.0],[19.667,1.0],[19.833,1.0],[20.0,1.0],[20.167,0.0],[20.333,0.0],[20.5,0.0],[20.667,0.0],[20.833,0.0],[21.0,0.0],[21.167,0.0],[21.333,0.0],[21.5,0.0],[21.667,0.0],[21.833,0.0],[22.0,0.0],[22.167,0.0],[22.333,0.0],[22.5,0.0],[22.667,0.0],[22.833,0.0],[23.0,0.0],[23.167,0.0],[23.333,0.0],[23.5,0.0],[23.667,0.0],[23.833,0.0],[24.0,0.0]]},"monthly":{"labels":["Jun","Jul","Aug"],"peak_base":[335.2,333.8,335.1],"peak_shed":[306.0,300.2,311.1],"energy_base":[258.5,272.6,280.5],"energy_shed":[251.6,259.1,269.0]},"threshold_kw":276.9,"stats":{"billing_peak_base":335.2,"billing_peak_shed":311.1,"exceed_base":2276,"exceed_shed":610,"energy_base":811.7,"energy_shed":779.8,"unmet_clg_base":152.5,"unmet_clg_shed":24.67,"dc_savings":1302},"zone_label":"Story 2 South Perimeter zone","code":"\nfrom pyenergyplus.plugin import EnergyPlusPlugin\n\nZONES = [\"Story 1 Core Thermal Zone\", \"Story 1 East Perimeter Thermal Zone\", \"Story 1 North Perimeter Thermal Zone\", \"Story 1 South Perimeter Thermal Zone\", \"Story 1 West Perimeter Thermal Zone\", \"Story 2 Core Thermal Zone\", \"Story 2 East Perimeter Thermal Zone\", \"Story 2 North Perimeter Thermal Zone\", \"Story 2 South Perimeter Thermal Zone\", \"Story 2 West Perimeter Thermal Zone\"]\nTHRESHOLD_W = 276900.0     # shed target: clip demand to this level\nOFFSETS_K = [0.0, 1.0, 2.0, 3.0]  # cooling setpoint offset per shed stage\nWINDOW_START_HOUR = 8             # on-peak window 08:00-19:00, every day\nWINDOW_END_HOUR = 19              # (this building runs 7-day schedules)\nDWELL_MINUTES = 10.0              # min time between stage moves\nJUMP_RATIO = 1.15                 # >115% of threshold from idle -> jump 2 stages\nRELEASE_MINUTES = 30.0            # staggered post-event release (anti-rebound)\nFALLBACK_BASE_C = 23.9\n\n\nclass DemandLimiter(EnergyPlusPlugin):\n    \"\"\"Staged demand-limiting supervisory controller (revision 3).\n\n    Each zone timestep: read last timestep's whole-facility electric demand;\n    inside the daily on-peak window, ratchet the shed stage up (never down)\n    whenever demand exceeds THRESHOLD_W -- jumping two stages from idle on\n    large excursions -- raising every zone's cooling setpoint by\n    OFFSETS_K[stage]. After the window, release one stage per RELEASE_MINUTES\n    so recovery load returns gradually (no rebound spike).\n    \"\"\"\n\n    def __init__(self):\n        super().__init__()\n        self.handles_ready = False\n        self.h_demand = -1\n        self.h_stage = -1\n        self.h_clg_act = {}\n        self.h_clg_sens = {}\n        self.base_clg = {}\n        self.stage = 0\n        self.minutes_since_change = 1.0e9\n\n    def _lookup_handles(self, state):\n        ex = self.api.exchange\n        self.h_demand = ex.get_variable_handle(\n            state, \"Facility Total Electricity Demand Rate\", \"Whole Building\")\n        self.h_stage = ex.get_global_handle(state, \"dr_stage\")\n        for zone in ZONES:\n            self.h_clg_act[zone] = ex.get_actuator_handle(\n                state, \"Zone Temperature Control\", \"Cooling Setpoint\", zone)\n            self.h_clg_sens[zone] = ex.get_variable_handle(\n                state, \"Zone Thermostat Cooling Setpoint Temperature\", zone)\n        bad = []\n        if self.h_demand == -1:\n            bad.append(\"facility demand sensor\")\n        if self.h_stage == -1:\n            bad.append(\"dr_stage global\")\n        bad += [\"actuator \" + z for z, h in self.h_clg_act.items() if h == -1]\n        bad += [\"setpoint sensor \" + z for z, h in self.h_clg_sens.items() if h == -1]\n        return bad\n\n    def _weather_run(self, state):\n        # Only actuate during the weather-file run period -- overriding\n        # setpoints during sizing design days would shrink the cooling plant\n        # and corrupt the baseline-vs-controlled comparison.\n        try:\n            return int(self.api.exchange.kind_of_sim(state)) == 3\n        except Exception:\n            return True\n\n    def on_begin_timestep_before_predictor(self, state) -> int:\n        ex = self.api.exchange\n        if not ex.api_data_fully_ready(state):\n            return 0\n        if not self.handles_ready:\n            bad = self._lookup_handles(state)\n            if bad:\n                self.api.runtime.issue_severe(\n                    state, \"DemandLimiter handle lookup failed: \" + \", \".join(bad))\n                return 1\n            self.handles_ready = True\n        if not self._weather_run(state):\n            ex.set_global_value(state, self.h_stage, 0.0)\n            return 0\n\n        dt_minutes = 60.0 * ex.zone_time_step(state)\n        self.minutes_since_change += dt_minutes\n        hour = ex.hour(state)              # 0-23\n        demand_w = ex.get_variable_value(state, self.h_demand)\n        in_window = WINDOW_START_HOUR <= hour < WINDOW_END_HOUR\n\n        if not in_window and self.stage == 0:\n            # Unoverridden: remember each zone's scheduled cooling setpoint so\n            # shed offsets stack on the schedule, not on our own override.\n            for zone in ZONES:\n                self.base_clg[zone] = ex.get_variable_value(\n                    state, self.h_clg_sens[zone])\n\n        max_stage = len(OFFSETS_K) - 1\n        if in_window:\n            if (demand_w > THRESHOLD_W and self.stage < max_stage\n                    and self.minutes_since_change >= DWELL_MINUTES):\n                step = 2 if (self.stage == 0\n                             and demand_w > JUMP_RATIO * THRESHOLD_W) else 1\n                self.stage = min(self.stage + step, max_stage)\n                self.minutes_since_change = 0.0\n        elif self.stage > 0 and self.minutes_since_change >= RELEASE_MINUTES:\n            self.stage -= 1\n            self.minutes_since_change = 0.0\n\n        for zone in ZONES:\n            if self.stage == 0:\n                ex.reset_actuator(state, self.h_clg_act[zone])\n            else:\n                base = self.base_clg.get(zone, FALLBACK_BASE_C)\n                ex.set_actuator_value(\n                    state, self.h_clg_act[zone], base + OFFSETS_K[self.stage])\n        ex.set_global_value(state, self.h_stage, float(self.stage))\n        return 0\n"};
+
+const css = n => getComputedStyle(document.documentElement).getPropertyValue(n).trim();
+const FMT = new Intl.NumberFormat("en-US");
+function hhmm(t){ const h = Math.floor(t), m = Math.round((t-h)*60); return String(h).padStart(2,"0")+":"+String(m).padStart(2,"0"); }
+
+/* ---- stat tiles ---- */
+(function(){
+  const s = DATA.stats;
+  const set = (id, html) => document.getElementById(id).innerHTML = html;
+  set("t-peak", `${s.billing_peak_shed} <small>kW</small>`);
+  set("t-peak-d", `−${(100*(s.billing_peak_base-s.billing_peak_shed)/s.billing_peak_base).toFixed(1)}% vs ${s.billing_peak_base} kW baseline`);
+  set("t-exceed", FMT.format(s.exceed_shed));
+  set("t-exceed-d", `−${Math.round(100*(s.exceed_base-s.exceed_shed)/s.exceed_base)}% vs ${FMT.format(s.exceed_base)} baseline`);
+  set("t-energy", `${s.energy_shed} <small>MWh</small>`);
+  set("t-energy-d", `−${(100*(s.energy_base-s.energy_shed)/s.energy_base).toFixed(1)}% vs ${s.energy_base} MWh baseline`);
+  set("t-dollar", `$${FMT.format(s.dc_savings)}`);
+  set("t-dollar-d", "3 summer months, this building");
+})();
+
+/* ---- chart helpers ---- */
+const M = {l:52, r:14, t:10, b:26};
+function mkSvg(w, h){
+  const s = document.createElementNS("http://www.w3.org/2000/svg","svg");
+  s.setAttribute("viewBox",`0 0 ${w} ${h}`);
+  return s;
+}
+function el(name, attrs, text){
+  const e = document.createElementNS("http://www.w3.org/2000/svg", name);
+  for (const k in attrs) e.setAttribute(k, attrs[k]);
+  if (text != null) e.textContent = text;
+  return e;
+}
+function niceTicks(max, n){
+  const raw = max/n, mag = Math.pow(10, Math.floor(Math.log10(raw)));
+  const step = [1,2,2.5,5,10].map(m=>m*mag).find(s=>s>=raw);
+  const out = []; for (let v=0; v<=max+1e-9; v+=step) out.push(v);
+  return out;
+}
+
+/* Time-series line chart. cfg: {series:[{pts,color,name,width,dash}], yMax, yLabel,
+   band:[h0,h1], ref:{y,label}, stepped:bool, yTicks, h} */
+function lineChart(boxId, cfg){
+  const box = document.getElementById(boxId);
+  const W = 980, H = cfg.h || 300;
+  const svg = mkSvg(W, H);
+  const x = t => M.l + (t/24)*(W-M.l-M.r);
+  const yMax = cfg.yMax, yMin = cfg.yMin || 0;
+  const y = v => H-M.b - ((v-yMin)/(yMax-yMin))*(H-M.b-M.t);
+
+  if (cfg.band){
+    svg.appendChild(el("rect",{x:x(cfg.band[0]), y:M.t, width:x(cfg.band[1])-x(cfg.band[0]),
+      height:H-M.b-M.t, fill:"var(--band)"}));
+    svg.appendChild(el("text",{x:x(cfg.band[0])+6, y:M.t+13, "font-size":10.5,
+      fill:"var(--muted)", class:"svglabel"}, cfg.bandLabel||""));
+  }
+  const ticks = cfg.yTicks || niceTicks(yMax, 4);
+  for (const tv of ticks){
+    if (tv < yMin) continue;
+    svg.appendChild(el("line",{x1:M.l, x2:W-M.r, y1:y(tv), y2:y(tv), stroke:"var(--grid)","stroke-width":1}));
+    svg.appendChild(el("text",{x:M.l-8, y:y(tv)+3.5, "text-anchor":"end","font-size":10.5,
+      fill:"var(--muted)", class:"svglabel"}, FMT.format(tv)));
+  }
+  for (let h=0; h<=24; h+=3){
+    svg.appendChild(el("text",{x:x(h), y:H-M.b+16, "text-anchor":"middle","font-size":10.5,
+      fill:"var(--muted)", class:"svglabel"}, hhmm(h)));
+  }
+  svg.appendChild(el("line",{x1:M.l, x2:W-M.r, y1:y(yMin), y2:y(yMin), stroke:"var(--axis)","stroke-width":1}));
+  if (cfg.yLabel) svg.appendChild(el("text",{x:M.l-8, y:M.t+2, "text-anchor":"end","font-size":10.5,
+      fill:"var(--muted)", class:"svglabel"}, cfg.yLabel));
+
+  if (cfg.ref){
+    svg.appendChild(el("line",{x1:M.l, x2:W-M.r, y1:y(cfg.ref.y), y2:y(cfg.ref.y),
+      stroke:"var(--muted)","stroke-width":1.5,"stroke-dasharray":"5 4"}));
+    svg.appendChild(el("text",{x:W-M.r-4, y:y(cfg.ref.y)-5, "text-anchor":"end","font-size":10.5,
+      fill:"var(--ink-2)", class:"svglabel"}, cfg.ref.label));
+  }
+  for (const s of cfg.series){
+    let d = "";
+    s.pts.forEach((p,i)=>{
+      const X = x(p[0]).toFixed(1), Y = y(p[1]).toFixed(1);
+      if (i===0) d += `M${X} ${Y}`;
+      else if (cfg.stepped || s.stepped) d += `H${X}V${Y}`;
+      else d += `L${X} ${Y}`;
+    });
+    svg.appendChild(el("path",{d, fill:"none", stroke:s.color,
+      "stroke-width":s.width||2, "stroke-linejoin":"round","stroke-linecap":"round",
+      ...(s.dash?{"stroke-dasharray":s.dash}:{})}));
+  }
+  for (const a of (cfg.annot||[])){
+    svg.appendChild(el("text",{x:x(a.t), y:y(a.v)-8, "text-anchor":a.anchor||"middle",
+      "font-size":11, fill:"var(--ink-2)", class:"svglabel"}, a.text));
+  }
+  box.appendChild(svg);
+
+  /* hover crosshair + tooltip */
+  const tip = document.createElement("div"); tip.className = "tip"; box.appendChild(tip);
+  const cross = el("line",{y1:M.t, y2:H-M.b, stroke:"var(--axis)","stroke-width":1, visibility:"hidden"});
+  svg.appendChild(cross);
+  svg.addEventListener("mousemove", ev => {
+    const r = svg.getBoundingClientRect();
+    const t = ((ev.clientX-r.left)/r.width*W - M.l)/(W-M.l-M.r)*24;
+    if (t < 0 || t > 24){ tip.style.display="none"; cross.setAttribute("visibility","hidden"); return; }
+    cross.setAttribute("x1", x(t)); cross.setAttribute("x2", x(t));
+    cross.setAttribute("visibility","visible");
+    let html = `<b>${hhmm(Math.min(t,23.99))}</b>`;
+    for (const s of cfg.series){
+      let best = s.pts[0];
+      for (const p of s.pts) if (Math.abs(p[0]-t) < Math.abs(best[0]-t)) best = p;
+      html += `<br><span style="color:${s.color}">●</span> ${s.name}: <b>${best[1]}${cfg.unit||""}</b>`;
+    }
+    tip.innerHTML = html;
+    tip.style.display = "block";
+    const bx = box.getBoundingClientRect();
+    let left = ev.clientX-bx.left+14;
+    if (left + tip.offsetWidth > bx.width-8) left = ev.clientX-bx.left-tip.offsetWidth-14;
+    tip.style.left = left+"px";
+    tip.style.top = (ev.clientY-bx.top+8)+"px";
+  });
+  svg.addEventListener("mouseleave", ()=>{ tip.style.display="none"; cross.setAttribute("visibility","hidden"); });
+}
+
+function legend(id, items){
+  document.getElementById(id).innerHTML = items.map(i =>
+    `<span class="key"><span class="swatch${i.dash?" dash":""}" style="${i.dash?"":`background:${i.color}`}"></span>${i.name}</span>`).join("");
+}
+
+/* grouped bars: cfg {labels, groups:[{name,color,vals}], unit, h, yMin} */
+function barChart(boxId, cfg){
+  const box = document.getElementById(boxId);
+  const W = 470, H = cfg.h || 260, Mb = {l:46, r:8, t:22, b:24};
+  const svg = mkSvg(W, H);
+  const vmax = Math.max(...cfg.groups.flatMap(g=>g.vals));
+  const yMax = vmax*1.12;
+  const y = v => H-Mb.b - (v/yMax)*(H-Mb.b-Mb.t);
+  for (const tv of niceTicks(yMax,4)){
+    svg.appendChild(el("line",{x1:Mb.l, x2:W-Mb.r, y1:y(tv), y2:y(tv), stroke:"var(--grid)","stroke-width":1}));
+    svg.appendChild(el("text",{x:Mb.l-7, y:y(tv)+3.5,"text-anchor":"end","font-size":10.5,
+      fill:"var(--muted)", class:"svglabel"}, FMT.format(tv)));
+  }
+  const n = cfg.labels.length, gN = cfg.groups.length;
+  const slot = (W-Mb.l-Mb.r)/n, bw = 24, gap = 6;
+  cfg.labels.forEach((lb,i)=>{
+    const cx = Mb.l + slot*(i+0.5);
+    const total = gN*bw + (gN-1)*gap;
+    cfg.groups.forEach((g,j)=>{
+      const bx = cx - total/2 + j*(bw+gap);
+      const top = y(g.vals[i]), bh = (H-Mb.b)-top;
+      svg.appendChild(el("path",{d:
+        `M${bx} ${H-Mb.b}V${top+4}Q${bx} ${top} ${bx+4} ${top}H${bx+bw-4}Q${bx+bw} ${top} ${bx+bw} ${top+4}V${H-Mb.b}Z`,
+        fill:g.color}));
+      svg.appendChild(el("text",{x:bx+bw/2, y:top-5,"text-anchor":"middle","font-size":10,
+        fill:"var(--ink-2)", class:"svglabel"}, g.vals[i]));
+    });
+    svg.appendChild(el("text",{x:cx, y:H-Mb.b+16,"text-anchor":"middle","font-size":11,
+      fill:"var(--ink-2)"}, lb));
+  });
+  svg.appendChild(el("line",{x1:Mb.l, x2:W-Mb.r, y1:H-Mb.b, y2:H-Mb.b, stroke:"var(--axis)","stroke-width":1}));
+  box.appendChild(svg);
+}
+
+/* ---- build ---- */
+const C_BASE = "var(--base)", C_CTRL = "var(--ctrl)", C_CMD = "var(--cmd)";
+const P = DATA.peakday, WK = DATA.weekend, TH = DATA.threshold_kw;
+
+legend("lg-peakday", [
+  {name:"Baseline", color:"var(--base)"},
+  {name:"Demand-limited (v3)", color:"var(--ctrl)"},
+  {name:`Shed threshold ${TH} kW`, dash:true},
+]);
+lineChart("ch-peakday", {
+  series: [
+    {pts:P.base_kw, color:C_BASE, name:"Baseline"},
+    {pts:P.shed_kw, color:C_CTRL, name:"Demand-limited"},
+  ],
+  yMax: 360, yTicks:[0,100,200,300], yLabel:"kW", unit:" kW",
+  band: [8,19], bandLabel:"DR window 08:00–19:00",
+  ref: {y: TH, label:`threshold ${TH} kW`}, h: 320,
+});
+
+legend("lg-anatomy", [
+  {name:"Shed stage (plugin output)", color:"var(--cmd)"},
+  {name:"Cooling setpoint (actuated)", color:"var(--cmd)"},
+  {name:"Zone temp — demand-limited", color:"var(--ctrl)"},
+  {name:"Zone temp — baseline", color:"var(--base)"},
+]);
+lineChart("ch-stage", {
+  series: [{pts:P.stage, color:C_CMD, name:"Shed stage", stepped:true}],
+  yMax: 3.4, yTicks:[0,1,2,3], yLabel:"stage", h: 130, band:[8,19],
+});
+lineChart("ch-temps", {
+  series: [
+    {pts:P.sp_shed, color:C_CMD, name:"Cooling setpoint (actuated)", width:1.6},
+    {pts:P.tz_shed, color:C_CTRL, name:"Zone temp — demand-limited"},
+    {pts:P.tz_base, color:C_BASE, name:"Zone temp — baseline"},
+  ],
+  yMax: 28, yMin: 20, yTicks:[20,22,24,26,28], yLabel:"°C", unit:" °C",
+  h: 210, band:[8,19],
+});
+
+legend("lg-weekend", [
+  {name:"Baseline", color:"var(--base)"},
+  {name:"Demand-limited (v3)", color:"var(--ctrl)"},
+  {name:`Shed threshold ${TH} kW`, dash:true},
+]);
+lineChart("ch-weekend", {
+  series: [
+    {pts:WK.base_kw, color:C_BASE, name:"Baseline"},
+    {pts:WK.shed_kw, color:C_CTRL, name:"Demand-limited"},
+  ],
+  yMax: 360, yTicks:[0,100,200,300], yLabel:"kW", unit:" kW",
+  band: [8,19], bandLabel:"DR window 08:00–19:00",
+  ref: {y: TH, label:`threshold ${TH} kW`}, h: 280,
+});
+
+const MO = DATA.monthly;
+legend("lg-mpeak", [
+  {name:"Baseline", color:"var(--base)"},
+  {name:"Demand-limited", color:"var(--ctrl)"},
+]);
+barChart("ch-mpeak", {labels: MO.labels, groups: [
+  {name:"Baseline", color:C_BASE, vals:MO.peak_base},
+  {name:"Demand-limited", color:C_CTRL, vals:MO.peak_shed},
+]});
+legend("lg-menergy", [
+  {name:"Baseline", color:"var(--base)"},
+  {name:"Demand-limited", color:"var(--ctrl)"},
+]);
+barChart("ch-menergy", {labels: MO.labels, groups: [
+  {name:"Baseline", color:C_BASE, vals:MO.energy_base},
+  {name:"Demand-limited", color:C_CTRL, vals:MO.energy_shed},
+]});
+
+/* ---- tables ---- */
+function hourly(pts){ return pts.filter(p => Math.abs(p[0]-Math.round(p[0])) < 1e-6); }
+function tbl(id, heads, rows){
+  document.getElementById(id).innerHTML =
+    `<table class="data"><tr>${heads.map(h=>`<th>${h}</th>`).join("")}</tr>` +
+    rows.map(r=>`<tr>${r.map(c=>`<td>${c}</td>`).join("")}</tr>`).join("") + "</table>";
+}
+(function(){
+  const b = hourly(P.base_kw), s = hourly(P.shed_kw);
+  tbl("tb-peakday", ["Hour","Baseline kW","Demand-limited kW"],
+    b.map((p,i)=>[hhmm(p[0]), p[1], s[i]?s[i][1]:""]));
+  const st = hourly(P.stage), sp = hourly(P.sp_shed), tz = hourly(P.tz_shed), tb0 = hourly(P.tz_base);
+  tbl("tb-anatomy", ["Hour","Stage","Setpoint °C","Zone °C (DL)","Zone °C (base)"],
+    st.map((p,i)=>[hhmm(p[0]), p[1], sp[i]?sp[i][1]:"", tz[i]?tz[i][1]:"", tb0[i]?tb0[i][1]:""]));
+  const wb = hourly(WK.base_kw), ws = hourly(WK.shed_kw);
+  tbl("tb-weekend", ["Hour","Baseline kW","Demand-limited kW"],
+    wb.map((p,i)=>[hhmm(p[0]), p[1], ws[i]?ws[i][1]:""]));
+  tbl("tb-monthly", ["Month","Peak base kW","Peak DL kW","Energy base MWh","Energy DL MWh"],
+    MO.labels.map((m,i)=>[m, MO.peak_base[i], MO.peak_shed[i], MO.energy_base[i], MO.energy_shed[i]]));
+})();
+
+document.getElementById("plugin-code").textContent = DATA.code;
+</script>

--- a/docs/examples/python-ems-demand-response/dr_demo_driver.py
+++ b/docs/examples/python-ems-demand-response/dr_demo_driver.py
@@ -1,0 +1,362 @@
+"""Grid-interactive demand-limiting demo driver.
+
+Runs inside the openstudio-mcp:dev container and drives the MCP server over
+stdio (same pattern as the integration tests). Everything model-related goes
+through MCP tools:
+
+  Phase A (baseline characterization)
+    create_baseline_osm -> add_baseline_system(7) -> change_building_location
+    -> set_run_period(Jun-Aug) -> output variables/meters -> run_simulation
+
+  Phase B (controller research loop)
+    list_ems_actuators -> create_python_plugin(template="custom") with a staged
+    demand-limiting supervisory controller -> run_simulation -> verify plugin
+    loaded -> query_timeseries for baseline-vs-controlled comparison.
+
+Timeseries/metrics JSON is dumped to /runs/demo_dr_analysis for plotting.
+"""
+import asyncio
+import json
+import time
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+EPW = ("/opt/comstock-measures/ChangeBuildingLocation"
+       "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
+OUT = Path("/runs/demo_dr_analysis")
+POLL_S = 10
+SIM_TIMEOUT_S = 2400
+MONTHS = [(6, 30), (7, 31), (8, 31)]
+DEMAND_VAR = "Facility Total Electricity Demand Rate"
+
+PLUGIN_TEMPLATE = '''
+from pyenergyplus.plugin import EnergyPlusPlugin
+
+ZONES = __ZONES__
+THRESHOLD_W = __THRESHOLD_W__     # shed target: clip demand to this level
+OFFSETS_K = [0.0, 1.5, 3.0]       # cooling setpoint offset per shed stage
+WINDOW_START_HOUR = 13            # weekday peak window 13:00-18:00
+WINDOW_END_HOUR = 18
+DWELL_MINUTES = 30.0              # min time between stage-ups (stability)
+RELEASE_MINUTES = 30.0            # staggered post-event release (anti-rebound)
+FALLBACK_BASE_C = 23.9
+
+
+class DemandLimiter(EnergyPlusPlugin):
+    """Staged demand-limiting supervisory controller.
+
+    Each zone timestep: read last timestep's whole-facility electric demand;
+    inside the weekday peak window, ratchet the shed stage up (never down)
+    whenever demand exceeds THRESHOLD_W, raising every zone's cooling setpoint
+    by OFFSETS_K[stage]. After the window, release one stage per
+    RELEASE_MINUTES so the recovery load returns gradually instead of as a
+    rebound spike.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.handles_ready = False
+        self.h_demand = -1
+        self.h_stage = -1
+        self.h_clg_act = {}
+        self.h_clg_sens = {}
+        self.base_clg = {}
+        self.stage = 0
+        self.minutes_since_change = 1.0e9
+
+    def _lookup_handles(self, state):
+        ex = self.api.exchange
+        self.h_demand = ex.get_variable_handle(
+            state, "Facility Total Electricity Demand Rate", "Whole Building")
+        self.h_stage = ex.get_global_handle(state, "dr_stage")
+        for zone in ZONES:
+            self.h_clg_act[zone] = ex.get_actuator_handle(
+                state, "Zone Temperature Control", "Cooling Setpoint", zone)
+            self.h_clg_sens[zone] = ex.get_variable_handle(
+                state, "Zone Thermostat Cooling Setpoint Temperature", zone)
+        bad = []
+        if self.h_demand == -1:
+            bad.append("facility demand sensor")
+        if self.h_stage == -1:
+            bad.append("dr_stage global")
+        bad += ["actuator " + z for z, h in self.h_clg_act.items() if h == -1]
+        bad += ["setpoint sensor " + z for z, h in self.h_clg_sens.items() if h == -1]
+        return bad
+
+    def _weather_run(self, state):
+        # Only actuate during the weather-file run period -- overriding
+        # setpoints during sizing design days would shrink the cooling plant
+        # and corrupt the baseline-vs-controlled comparison.
+        try:
+            return int(self.api.exchange.kind_of_sim(state)) == 3
+        except Exception:
+            return True
+
+    def on_begin_timestep_before_predictor(self, state) -> int:
+        ex = self.api.exchange
+        if not ex.api_data_fully_ready(state):
+            return 0
+        if not self.handles_ready:
+            bad = self._lookup_handles(state)
+            if bad:
+                self.api.runtime.issue_severe(
+                    state, "DemandLimiter handle lookup failed: " + ", ".join(bad))
+                return 1
+            self.handles_ready = True
+        if not self._weather_run(state):
+            ex.set_global_value(state, self.h_stage, 0.0)
+            return 0
+
+        dt_minutes = 60.0 * ex.zone_time_step(state)
+        self.minutes_since_change += dt_minutes
+        hour = ex.hour(state)              # 0-23
+        dow = ex.day_of_week(state)        # 1=Sunday .. 7=Saturday
+        weekday = 2 <= dow <= 6
+        demand_w = ex.get_variable_value(state, self.h_demand)
+        in_window = weekday and WINDOW_START_HOUR <= hour < WINDOW_END_HOUR
+
+        if not in_window and self.stage == 0:
+            # Unoverridden: remember each zone's scheduled cooling setpoint so
+            # shed offsets stack on the schedule, not on our own override.
+            for zone in ZONES:
+                self.base_clg[zone] = ex.get_variable_value(
+                    state, self.h_clg_sens[zone])
+
+        if in_window:
+            if (demand_w > THRESHOLD_W
+                    and self.stage < len(OFFSETS_K) - 1
+                    and self.minutes_since_change >= DWELL_MINUTES):
+                self.stage += 1
+                self.minutes_since_change = 0.0
+        elif self.stage > 0 and self.minutes_since_change >= RELEASE_MINUTES:
+            self.stage -= 1
+            self.minutes_since_change = 0.0
+
+        for zone in ZONES:
+            if self.stage == 0:
+                ex.reset_actuator(state, self.h_clg_act[zone])
+            else:
+                base = self.base_clg.get(zone, FALLBACK_BASE_C)
+                ex.set_actuator_value(
+                    state, self.h_clg_act[zone], base + OFFSETS_K[self.stage])
+        ex.set_global_value(state, self.h_stage, float(self.stage))
+        return 0
+'''
+
+
+def unwrap(res):
+    content = getattr(res, "content", None)
+    if not content:
+        return res if isinstance(res, dict) else {"_raw": str(res)}
+    text = getattr(content[0], "text", None)
+    if text is None:
+        return str(content[0])
+    try:
+        return json.loads(text.strip())
+    except Exception:
+        return text.strip()
+
+
+async def call(s, tool, args=None, must=True):
+    res = unwrap(await s.call_tool(tool, args or {}))
+    ok = isinstance(res, dict) and res.get("ok") is True
+    print(f"[{time.strftime('%H:%M:%S')}] {tool} -> {'ok' if ok else 'FAIL'}",
+          flush=True)
+    if must and not ok:
+        raise SystemExit(f"{tool} failed: {json.dumps(res, default=str)[:3000]}")
+    return res
+
+
+async def poll_run(s, run_id):
+    terminal = {"success", "failed", "error", "cancelled"}
+    started = time.time()
+    while True:
+        if time.time() - started > SIM_TIMEOUT_S:
+            raise SystemExit(f"run {run_id} timed out")
+        status = unwrap(await s.call_tool("get_run_status", {"run_id": run_id}))
+        state = (status.get("run", {}).get("status") or "unknown").lower()
+        print(f"[{time.strftime('%H:%M:%S')}] run {run_id}: {state}", flush=True)
+        if state in terminal:
+            if state != "success":
+                errs = unwrap(await s.call_tool(
+                    "extract_simulation_errors", {"run_id": run_id}))
+                raise SystemExit(
+                    f"run {run_id} ended {state}: "
+                    f"{json.dumps(errs, default=str)[:4000]}")
+            return status
+        await asyncio.sleep(POLL_S)
+
+
+async def month_series(s, run_id, var, key, month, mdays):
+    r = await call(s, "query_timeseries", {
+        "run_id": run_id, "variable_name": var, "key_value": key,
+        "start_month": month, "start_day": 1,
+        "end_month": month, "end_day": mdays, "max_points": 6000,
+    })
+    return r["data"]
+
+
+async def day_series(s, run_id, var, key, month, day):
+    r = await call(s, "query_timeseries", {
+        "run_id": run_id, "variable_name": var, "key_value": key,
+        "start_month": month, "start_day": day,
+        "end_month": month, "end_day": day, "max_points": 400,
+    })
+    return r["data"]
+
+
+def dump(name, obj):
+    OUT.mkdir(parents=True, exist_ok=True)
+    path = OUT / f"{name}.json"
+    path.write_text(json.dumps(obj, indent=1, default=str))
+    print(f"wrote {path}", flush=True)
+
+
+async def collect_run_outputs(s, run_id, tag, zones_to_plot, peak):
+    """Dump demand (3 summer months), peak-day zone temps/setpoints/OAT."""
+    demand = {}
+    for month, mdays in MONTHS:
+        demand[str(month)] = await month_series(
+            s, run_id, DEMAND_VAR, "Whole Building", month, mdays)
+    dump(f"{tag}_demand", demand)
+
+    pm, pd = peak
+    day = {"oat": await day_series(
+        s, run_id, "Site Outdoor Air Drybulb Temperature", "Environment", pm, pd)}
+    for z in zones_to_plot:
+        day[f"temp::{z}"] = await day_series(
+            s, run_id, "Zone Mean Air Temperature", z, pm, pd)
+        day[f"clgsp::{z}"] = await day_series(
+            s, run_id, "Zone Thermostat Cooling Setpoint Temperature", z, pm, pd)
+    dump(f"{tag}_peakday", day)
+
+    metrics = await call(s, "extract_summary_metrics", {"run_id": run_id})
+    enduse = await call(s, "extract_end_use_breakdown", {"run_id": run_id})
+    dump(f"{tag}_metrics", {"summary": metrics, "end_use": enduse})
+
+
+async def main():
+    params = StdioServerParameters(command="openstudio-mcp", args=[], env=None)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as s:
+            await s.initialize()
+
+            # ---- Phase A: baseline testbed --------------------------------
+            cr = await call(s, "create_baseline_osm", {"name": "demo_dr"})
+            await call(s, "load_osm_model", {"osm_path": cr["osm_path"]})
+            zr = await call(s, "list_thermal_zones", {"max_results": 0})
+            zones = [z["name"] for z in zr["thermal_zones"]]
+            print("zones:", zones, flush=True)
+            await call(s, "add_baseline_system",
+                       {"system_type": 7, "thermal_zone_names": zones})
+            await call(s, "change_building_location", {"weather_file": EPW})
+            await call(s, "set_run_period", {"begin_month": 6, "begin_day": 1,
+                                             "end_month": 8, "end_day": 31})
+            for var in [DEMAND_VAR,
+                        "Zone Mean Air Temperature",
+                        "Zone Thermostat Cooling Setpoint Temperature",
+                        "Site Outdoor Air Drybulb Temperature"]:
+                await call(s, "add_output_variable",
+                           {"variable_name": var, "key_value": "*",
+                            "reporting_frequency": "Timestep"})
+            for meter in ["Electricity:Facility", "Cooling:Electricity",
+                          "Fans:Electricity"]:
+                await call(s, "add_output_meter",
+                           {"meter_name": meter, "reporting_frequency": "Hourly"})
+            await call(s, "save_osm_model",
+                       {"osm_path": "/runs/demo_dr_baseline/model.osm"})
+            sim = await call(s, "run_simulation", {
+                "osm_path": "/runs/demo_dr_baseline/model.osm",
+                "epw_path": EPW, "name": "demo_dr_baseline"})
+            base_run = sim["run_id"]
+            await poll_run(s, base_run)
+
+            # Baseline peak + peak day (true peak: timestep resolution)
+            peak_w, peak = 0.0, (7, 15)
+            for month, mdays in MONTHS:
+                for d in await month_series(
+                        s, base_run, DEMAND_VAR, "Whole Building", month, mdays):
+                    if d["value"] > peak_w:
+                        peak_w, peak = d["value"], (d["month"], d["day"])
+            print(f"baseline peak {peak_w:.0f} W on {peak}", flush=True)
+
+            # ---- Phase B: author + run the controller ---------------------
+            act = await call(s, "list_ems_actuators", {
+                "component_type": "Zone Temperature Control",
+                "control_type": "Cooling", "max_results": 0})
+            dump("actuators", act)
+            found = {a["actuator_key"].upper() for a in act["actuators"]}
+            missing = [z for z in zones if z.upper() not in found]
+            if missing:
+                raise SystemExit(f"cooling setpoint actuators missing: {missing}")
+
+            threshold_w = round(0.80 * peak_w, -2)
+            code = (PLUGIN_TEMPLATE
+                    .replace("__ZONES__", json.dumps(zones))
+                    .replace("__THRESHOLD_W__", str(threshold_w)))
+            created = await call(s, "create_python_plugin", {
+                "name": "Demand Limiter", "template": "custom",
+                "class_name": "DemandLimiter", "code": code,
+                "global_variables": ["dr_stage"],
+                "output_variable_name": "DR Shed Stage", "units": ""})
+            dump("plugin_created", created)
+            inspected = await call(s, "get_python_plugin", {"name": "Demand Limiter"})
+            dump("plugin_inspect", inspected)
+
+            await call(s, "save_osm_model",
+                       {"osm_path": "/runs/demo_dr_shed/model.osm"})
+            sim2 = await call(s, "run_simulation", {
+                "osm_path": "/runs/demo_dr_shed/model.osm",
+                "epw_path": EPW, "name": "demo_dr_shed"})
+            shed_run = sim2["run_id"]
+            await poll_run(s, shed_run)
+
+            errs = await call(s, "extract_simulation_errors", {"run_id": shed_run})
+            dump("shed_sim_errors", errs)
+            errtxt = await call(s, "read_file", {
+                "file_path": f"/runs/{shed_run}/run/eplusout.err",
+                "max_bytes": 200000})
+            imported = [ln for ln in errtxt.get("text", "").splitlines()
+                        if "PythonPlugin" in ln]
+            dump("plugin_import_lines", imported)
+
+            # ---- Outputs for plotting -------------------------------------
+            zones_to_plot = []
+            for want in ("Core", "South"):
+                match = [z for z in zones if want.lower() in z.lower()
+                         and "2" in z]
+                zones_to_plot += match[:1]
+            if not zones_to_plot:
+                zones_to_plot = zones[:2]
+            print("plot zones:", zones_to_plot, flush=True)
+
+            await collect_run_outputs(s, base_run, "baseline", zones_to_plot, peak)
+            await collect_run_outputs(s, shed_run, "shed", zones_to_plot, peak)
+
+            pm, pd = peak
+            stage = await day_series(s, shed_run, "PythonPlugin:OutputVariable",
+                                     "DR Shed Stage", pm, pd)
+            dump("shed_stage_peakday", stage)
+
+            shed_peak_w = 0.0
+            for month, mdays in MONTHS:
+                for d in await month_series(
+                        s, shed_run, DEMAND_VAR, "Whole Building", month, mdays):
+                    shed_peak_w = max(shed_peak_w, d["value"])
+
+            dump("manifest", {
+                "epw": EPW, "zones": zones, "zones_to_plot": zones_to_plot,
+                "baseline_run": base_run, "shed_run": shed_run,
+                "baseline_peak_w": peak_w, "shed_peak_w": shed_peak_w,
+                "threshold_w": threshold_w, "peak_day": {"month": pm, "day": pd},
+                "window": "weekdays 13:00-18:00",
+                "offsets_k": [0.0, 1.5, 3.0],
+                "dwell_min": 30, "release_min": 30,
+            })
+            print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/python-ems-demand-response/dr_demo_driver2.py
+++ b/docs/examples/python-ems-demand-response/dr_demo_driver2.py
@@ -1,0 +1,335 @@
+"""DR demo iteration 2 — controller revision via edit_python_plugin.
+
+Iteration 1 finding: the 13:00-18:00 event window missed the building's true
+daily peak (08:30 morning-recovery spike), so the seasonal billing peak was
+untouched. Revision: cover the full utility on-peak window (weekdays
+08:00-19:00), 4 shed stages, threshold set from the *run-period* (design-day
+deduped) baseline peak.
+
+Reuses the existing baseline run; edits the plugin in the shed model in place,
+reruns it, and re-collects analysis JSON.
+"""
+import asyncio
+import json
+import time
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+EPW = ("/opt/comstock-measures/ChangeBuildingLocation"
+       "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
+OUT = Path("/runs/demo_dr_analysis")
+POLL_S = 8
+SIM_TIMEOUT_S = 2400
+MONTHS = [(6, 30), (7, 31), (8, 31)]
+DEMAND_VAR = "Facility Total Electricity Demand Rate"
+BASELINE_RUN = "run_demo_dr_baseline_ce6de7f0a0c1"
+ZONES_TO_PLOT = ["Story 2 Core Thermal Zone", "Story 2 South Perimeter Thermal Zone"]
+
+PLUGIN_TEMPLATE = '''
+from pyenergyplus.plugin import EnergyPlusPlugin
+
+ZONES = __ZONES__
+THRESHOLD_W = __THRESHOLD_W__     # shed target: clip demand to this level
+OFFSETS_K = [0.0, 1.0, 2.0, 3.0]  # cooling setpoint offset per shed stage
+WINDOW_START_HOUR = 8             # weekday utility on-peak window 08:00-19:00
+WINDOW_END_HOUR = 19
+DWELL_MINUTES = 20.0              # min time between stage-ups (stability)
+RELEASE_MINUTES = 30.0            # staggered post-event release (anti-rebound)
+FALLBACK_BASE_C = 23.9
+
+
+class DemandLimiter(EnergyPlusPlugin):
+    """Staged demand-limiting supervisory controller (revision 2).
+
+    Each zone timestep: read last timestep's whole-facility electric demand;
+    inside the weekday on-peak window, ratchet the shed stage up (never down)
+    whenever demand exceeds THRESHOLD_W, raising every zone's cooling setpoint
+    by OFFSETS_K[stage]. After the window, release one stage per
+    RELEASE_MINUTES so recovery load returns gradually (no rebound spike).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.handles_ready = False
+        self.h_demand = -1
+        self.h_stage = -1
+        self.h_clg_act = {}
+        self.h_clg_sens = {}
+        self.base_clg = {}
+        self.stage = 0
+        self.minutes_since_change = 1.0e9
+
+    def _lookup_handles(self, state):
+        ex = self.api.exchange
+        self.h_demand = ex.get_variable_handle(
+            state, "Facility Total Electricity Demand Rate", "Whole Building")
+        self.h_stage = ex.get_global_handle(state, "dr_stage")
+        for zone in ZONES:
+            self.h_clg_act[zone] = ex.get_actuator_handle(
+                state, "Zone Temperature Control", "Cooling Setpoint", zone)
+            self.h_clg_sens[zone] = ex.get_variable_handle(
+                state, "Zone Thermostat Cooling Setpoint Temperature", zone)
+        bad = []
+        if self.h_demand == -1:
+            bad.append("facility demand sensor")
+        if self.h_stage == -1:
+            bad.append("dr_stage global")
+        bad += ["actuator " + z for z, h in self.h_clg_act.items() if h == -1]
+        bad += ["setpoint sensor " + z for z, h in self.h_clg_sens.items() if h == -1]
+        return bad
+
+    def _weather_run(self, state):
+        # Only actuate during the weather-file run period -- overriding
+        # setpoints during sizing design days would shrink the cooling plant
+        # and corrupt the baseline-vs-controlled comparison.
+        try:
+            return int(self.api.exchange.kind_of_sim(state)) == 3
+        except Exception:
+            return True
+
+    def on_begin_timestep_before_predictor(self, state) -> int:
+        ex = self.api.exchange
+        if not ex.api_data_fully_ready(state):
+            return 0
+        if not self.handles_ready:
+            bad = self._lookup_handles(state)
+            if bad:
+                self.api.runtime.issue_severe(
+                    state, "DemandLimiter handle lookup failed: " + ", ".join(bad))
+                return 1
+            self.handles_ready = True
+        if not self._weather_run(state):
+            ex.set_global_value(state, self.h_stage, 0.0)
+            return 0
+
+        dt_minutes = 60.0 * ex.zone_time_step(state)
+        self.minutes_since_change += dt_minutes
+        hour = ex.hour(state)              # 0-23
+        dow = ex.day_of_week(state)        # 1=Sunday .. 7=Saturday
+        weekday = 2 <= dow <= 6
+        demand_w = ex.get_variable_value(state, self.h_demand)
+        in_window = weekday and WINDOW_START_HOUR <= hour < WINDOW_END_HOUR
+
+        if not in_window and self.stage == 0:
+            # Unoverridden: remember each zone's scheduled cooling setpoint so
+            # shed offsets stack on the schedule, not on our own override.
+            for zone in ZONES:
+                self.base_clg[zone] = ex.get_variable_value(
+                    state, self.h_clg_sens[zone])
+
+        if in_window:
+            if (demand_w > THRESHOLD_W
+                    and self.stage < len(OFFSETS_K) - 1
+                    and self.minutes_since_change >= DWELL_MINUTES):
+                self.stage += 1
+                self.minutes_since_change = 0.0
+        elif self.stage > 0 and self.minutes_since_change >= RELEASE_MINUTES:
+            self.stage -= 1
+            self.minutes_since_change = 0.0
+
+        for zone in ZONES:
+            if self.stage == 0:
+                ex.reset_actuator(state, self.h_clg_act[zone])
+            else:
+                base = self.base_clg.get(zone, FALLBACK_BASE_C)
+                ex.set_actuator_value(
+                    state, self.h_clg_act[zone], base + OFFSETS_K[self.stage])
+        ex.set_global_value(state, self.h_stage, float(self.stage))
+        return 0
+'''
+
+
+def unwrap(res):
+    content = getattr(res, "content", None)
+    if not content:
+        return res if isinstance(res, dict) else {"_raw": str(res)}
+    text = getattr(content[0], "text", None)
+    if text is None:
+        return str(content[0])
+    try:
+        return json.loads(text.strip())
+    except Exception:
+        return text.strip()
+
+
+async def call(s, tool, args=None, must=True):
+    res = unwrap(await s.call_tool(tool, args or {}))
+    ok = isinstance(res, dict) and res.get("ok") is True
+    print(f"[{time.strftime('%H:%M:%S')}] {tool} -> {'ok' if ok else 'FAIL'}",
+          flush=True)
+    if must and not ok:
+        raise SystemExit(f"{tool} failed: {json.dumps(res, default=str)[:3000]}")
+    return res
+
+
+async def poll_run(s, run_id):
+    terminal = {"success", "failed", "error", "cancelled"}
+    started = time.time()
+    while True:
+        if time.time() - started > SIM_TIMEOUT_S:
+            raise SystemExit(f"run {run_id} timed out")
+        status = unwrap(await s.call_tool("get_run_status", {"run_id": run_id}))
+        state = (status.get("run", {}).get("status") or "unknown").lower()
+        if state in terminal:
+            if state != "success":
+                errs = unwrap(await s.call_tool(
+                    "extract_simulation_errors", {"run_id": run_id}))
+                raise SystemExit(
+                    f"run {run_id} ended {state}: "
+                    f"{json.dumps(errs, default=str)[:4000]}")
+            print(f"run {run_id}: {state}", flush=True)
+            return status
+        await asyncio.sleep(POLL_S)
+
+
+async def month_series(s, run_id, var, key, month, mdays, freq=None):
+    args = {"run_id": run_id, "variable_name": var, "key_value": key,
+            "start_month": month, "start_day": 1,
+            "end_month": month, "end_day": mdays, "max_points": 6000}
+    if freq:
+        args["frequency"] = freq
+    r = await call(s, "query_timeseries", args)
+    return r["data"]
+
+
+async def day_series(s, run_id, var, key, month, day, freq=None):
+    args = {"run_id": run_id, "variable_name": var, "key_value": key,
+            "start_month": month, "start_day": day,
+            "end_month": month, "end_day": day, "max_points": 2000}
+    if freq:
+        args["frequency"] = freq
+    r = await call(s, "query_timeseries", args)
+    return r["data"]
+
+
+def dedupe(rows):
+    """Sizing design days share calendar dates with the run period; the
+    run-period environment is simulated last, so keep the last row per stamp."""
+    out = {}
+    for d in rows:
+        out[(d["month"], d["day"], d["hour"], d["minute"])] = d["value"]
+    return out
+
+
+def dump(name, obj):
+    OUT.mkdir(parents=True, exist_ok=True)
+    path = OUT / f"{name}.json"
+    path.write_text(json.dumps(obj, indent=1, default=str))
+    print(f"wrote {path}", flush=True)
+
+
+async def main():
+    params = StdioServerParameters(command="openstudio-mcp", args=[], env=None)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as s:
+            await s.initialize()
+
+            # True baseline peak from design-day-deduped series
+            base_demand = {}
+            for month, mdays in MONTHS:
+                base_demand[str(month)] = await month_series(
+                    s, BASELINE_RUN, DEMAND_VAR, "Whole Building", month, mdays)
+            ball = dedupe([d for m in base_demand.values() for d in m])
+            (pm, pd_, ph, pmin), peak_w = max(ball.items(), key=lambda kv: kv[1])
+            threshold_w = round(0.82 * peak_w, -2)
+            print(f"true baseline peak {peak_w/1000:.1f} kW at "
+                  f"{pm}/{pd_} {ph:02d}:{pmin:02d}; threshold {threshold_w/1000:.1f} kW",
+                  flush=True)
+
+            # ---- Revise controller via edit_python_plugin -----------------
+            await call(s, "load_osm_model",
+                       {"osm_path": "/runs/demo_dr_shed/model.osm"})
+            zr = await call(s, "list_thermal_zones", {"max_results": 0})
+            zones = [z["name"] for z in zr["thermal_zones"]]
+            code = (PLUGIN_TEMPLATE
+                    .replace("__ZONES__", json.dumps(zones))
+                    .replace("__THRESHOLD_W__", str(threshold_w)))
+            edited = await call(s, "edit_python_plugin",
+                                {"name": "Demand Limiter", "code": code})
+            dump("plugin_edited_v2", edited)
+            await call(s, "save_osm_model",
+                       {"osm_path": "/runs/demo_dr_shed/model.osm"})
+            sim = await call(s, "run_simulation", {
+                "osm_path": "/runs/demo_dr_shed/model.osm",
+                "epw_path": EPW, "name": "demo_dr_shed_v2"})
+            shed_run = sim["run_id"]
+            await poll_run(s, shed_run)
+            errs = await call(s, "extract_simulation_errors", {"run_id": shed_run})
+            dump("shed2_sim_errors", errs)
+
+            # ---- Collect comparison data ----------------------------------
+            shed_demand = {}
+            for month, mdays in MONTHS:
+                shed_demand[str(month)] = await month_series(
+                    s, shed_run, DEMAND_VAR, "Whole Building", month, mdays)
+            dump("shed2_demand", shed_demand)
+            sall = dedupe([d for m in shed_demand.values() for d in m])
+            speak = max(sall.values())
+            print(f"shed v2 peak {speak/1000:.1f} kW "
+                  f"({100*(peak_w-speak)/peak_w:.1f}% below baseline)", flush=True)
+
+            # Peak-day detail (baseline peak day), both runs
+            for tag, run_id in (("baseline", BASELINE_RUN), ("shed2", shed_run)):
+                day = {
+                    "demand": await day_series(
+                        s, run_id, DEMAND_VAR, "Whole Building", pm, pd_),
+                    "oat": await day_series(
+                        s, run_id, "Site Outdoor Air Drybulb Temperature",
+                        "Environment", pm, pd_),
+                }
+                for z in ZONES_TO_PLOT:
+                    day[f"temp::{z}"] = await day_series(
+                        s, run_id, "Zone Mean Air Temperature", z, pm, pd_)
+                    day[f"clgsp::{z}"] = await day_series(
+                        s, run_id, "Zone Thermostat Cooling Setpoint Temperature",
+                        z, pm, pd_)
+                for meter in ("Cooling:Electricity", "Fans:Electricity"):
+                    day[f"meter::{meter}"] = await day_series(
+                        s, run_id, meter, "*", pm, pd_)
+                dump(f"{tag}_peakday_v2", day)
+
+            stage = await day_series(s, shed_run, "PythonPlugin:OutputVariable",
+                                     "DR Shed Stage", pm, pd_)
+            dump("shed2_stage_peakday", stage)
+
+            metrics = await call(s, "extract_summary_metrics", {"run_id": shed_run})
+            enduse = await call(s, "extract_end_use_breakdown", {"run_id": shed_run})
+            dump("shed2_metrics", {"summary": metrics, "end_use": enduse})
+
+            # Monthly energy (hourly facility meter, deduped) for both runs
+            energy = {}
+            for tag, run_id in (("baseline", BASELINE_RUN), ("shed2", shed_run)):
+                energy[tag] = {}
+                for month, mdays in MONTHS:
+                    rows = await month_series(
+                        s, run_id, "Electricity:Facility", "*", month, mdays)
+                    per_stamp = dedupe(rows)
+                    energy[tag][str(month)] = sum(per_stamp.values()) / 3.6e9  # J->MWh
+            dump("monthly_energy_mwh", energy)
+
+            # Monthly true peaks
+            peaks = {"baseline": {}, "shed2": {}}
+            for month, _ in MONTHS:
+                peaks["baseline"][str(month)] = max(
+                    v for k, v in ball.items() if k[0] == month)
+                peaks["shed2"][str(month)] = max(
+                    v for k, v in sall.items() if k[0] == month)
+            dump("monthly_peaks_w", peaks)
+
+            dump("manifest_v2", {
+                "baseline_run": BASELINE_RUN, "shed_run": shed_run,
+                "baseline_peak_w": peak_w, "shed_peak_w": speak,
+                "threshold_w": threshold_w,
+                "peak_stamp": {"month": pm, "day": pd_, "hour": ph, "minute": pmin},
+                "window": "weekdays 08:00-19:00",
+                "offsets_k": [0.0, 1.0, 2.0, 3.0],
+                "dwell_min": 20, "release_min": 30,
+                "zones_to_plot": ZONES_TO_PLOT,
+            })
+            print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/python-ems-demand-response/dr_demo_driver3.py
+++ b/docs/examples/python-ems-demand-response/dr_demo_driver3.py
@@ -1,0 +1,302 @@
+"""DR demo iteration 3 — final controller revision.
+
+Iteration 2 findings: (a) this building runs 7-day schedules, so weekend peaks
+(329 kW Sat 6/26) escape a weekday-only window; (b) 20-min dwell lets the 08:30
+startup spike through (320 kW residual). Revision: window applies every day,
+10-min dwell, and a 2-stage jump when demand exceeds 115% of threshold.
+Threshold unchanged (276.9 kW) for comparability.
+"""
+import asyncio
+import json
+import time
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+EPW = ("/opt/comstock-measures/ChangeBuildingLocation"
+       "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
+OUT = Path("/runs/demo_dr_analysis")
+POLL_S = 8
+SIM_TIMEOUT_S = 2400
+MONTHS = [(6, 30), (7, 31), (8, 31)]
+DEMAND_VAR = "Facility Total Electricity Demand Rate"
+BASELINE_RUN = "run_demo_dr_baseline_ce6de7f0a0c1"
+ZONES_TO_PLOT = ["Story 2 Core Thermal Zone", "Story 2 South Perimeter Thermal Zone"]
+THRESHOLD_W = 276900.0
+PEAK_DAY = (6, 27)     # baseline peak weekday (morning spike + full afternoon)
+WEEKEND_DAY = (6, 26)  # Saturday that set the v2 residual seasonal peak
+
+PLUGIN_TEMPLATE = '''
+from pyenergyplus.plugin import EnergyPlusPlugin
+
+ZONES = __ZONES__
+THRESHOLD_W = __THRESHOLD_W__     # shed target: clip demand to this level
+OFFSETS_K = [0.0, 1.0, 2.0, 3.0]  # cooling setpoint offset per shed stage
+WINDOW_START_HOUR = 8             # on-peak window 08:00-19:00, every day
+WINDOW_END_HOUR = 19              # (this building runs 7-day schedules)
+DWELL_MINUTES = 10.0              # min time between stage moves
+JUMP_RATIO = 1.15                 # >115% of threshold from idle -> jump 2 stages
+RELEASE_MINUTES = 30.0            # staggered post-event release (anti-rebound)
+FALLBACK_BASE_C = 23.9
+
+
+class DemandLimiter(EnergyPlusPlugin):
+    """Staged demand-limiting supervisory controller (revision 3).
+
+    Each zone timestep: read last timestep's whole-facility electric demand;
+    inside the daily on-peak window, ratchet the shed stage up (never down)
+    whenever demand exceeds THRESHOLD_W -- jumping two stages from idle on
+    large excursions -- raising every zone's cooling setpoint by
+    OFFSETS_K[stage]. After the window, release one stage per RELEASE_MINUTES
+    so recovery load returns gradually (no rebound spike).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.handles_ready = False
+        self.h_demand = -1
+        self.h_stage = -1
+        self.h_clg_act = {}
+        self.h_clg_sens = {}
+        self.base_clg = {}
+        self.stage = 0
+        self.minutes_since_change = 1.0e9
+
+    def _lookup_handles(self, state):
+        ex = self.api.exchange
+        self.h_demand = ex.get_variable_handle(
+            state, "Facility Total Electricity Demand Rate", "Whole Building")
+        self.h_stage = ex.get_global_handle(state, "dr_stage")
+        for zone in ZONES:
+            self.h_clg_act[zone] = ex.get_actuator_handle(
+                state, "Zone Temperature Control", "Cooling Setpoint", zone)
+            self.h_clg_sens[zone] = ex.get_variable_handle(
+                state, "Zone Thermostat Cooling Setpoint Temperature", zone)
+        bad = []
+        if self.h_demand == -1:
+            bad.append("facility demand sensor")
+        if self.h_stage == -1:
+            bad.append("dr_stage global")
+        bad += ["actuator " + z for z, h in self.h_clg_act.items() if h == -1]
+        bad += ["setpoint sensor " + z for z, h in self.h_clg_sens.items() if h == -1]
+        return bad
+
+    def _weather_run(self, state):
+        # Only actuate during the weather-file run period -- overriding
+        # setpoints during sizing design days would shrink the cooling plant
+        # and corrupt the baseline-vs-controlled comparison.
+        try:
+            return int(self.api.exchange.kind_of_sim(state)) == 3
+        except Exception:
+            return True
+
+    def on_begin_timestep_before_predictor(self, state) -> int:
+        ex = self.api.exchange
+        if not ex.api_data_fully_ready(state):
+            return 0
+        if not self.handles_ready:
+            bad = self._lookup_handles(state)
+            if bad:
+                self.api.runtime.issue_severe(
+                    state, "DemandLimiter handle lookup failed: " + ", ".join(bad))
+                return 1
+            self.handles_ready = True
+        if not self._weather_run(state):
+            ex.set_global_value(state, self.h_stage, 0.0)
+            return 0
+
+        dt_minutes = 60.0 * ex.zone_time_step(state)
+        self.minutes_since_change += dt_minutes
+        hour = ex.hour(state)              # 0-23
+        demand_w = ex.get_variable_value(state, self.h_demand)
+        in_window = WINDOW_START_HOUR <= hour < WINDOW_END_HOUR
+
+        if not in_window and self.stage == 0:
+            # Unoverridden: remember each zone's scheduled cooling setpoint so
+            # shed offsets stack on the schedule, not on our own override.
+            for zone in ZONES:
+                self.base_clg[zone] = ex.get_variable_value(
+                    state, self.h_clg_sens[zone])
+
+        max_stage = len(OFFSETS_K) - 1
+        if in_window:
+            if (demand_w > THRESHOLD_W and self.stage < max_stage
+                    and self.minutes_since_change >= DWELL_MINUTES):
+                step = 2 if (self.stage == 0
+                             and demand_w > JUMP_RATIO * THRESHOLD_W) else 1
+                self.stage = min(self.stage + step, max_stage)
+                self.minutes_since_change = 0.0
+        elif self.stage > 0 and self.minutes_since_change >= RELEASE_MINUTES:
+            self.stage -= 1
+            self.minutes_since_change = 0.0
+
+        for zone in ZONES:
+            if self.stage == 0:
+                ex.reset_actuator(state, self.h_clg_act[zone])
+            else:
+                base = self.base_clg.get(zone, FALLBACK_BASE_C)
+                ex.set_actuator_value(
+                    state, self.h_clg_act[zone], base + OFFSETS_K[self.stage])
+        ex.set_global_value(state, self.h_stage, float(self.stage))
+        return 0
+'''
+
+
+def unwrap(res):
+    content = getattr(res, "content", None)
+    if not content:
+        return res if isinstance(res, dict) else {"_raw": str(res)}
+    text = getattr(content[0], "text", None)
+    if text is None:
+        return str(content[0])
+    try:
+        return json.loads(text.strip())
+    except Exception:
+        return text.strip()
+
+
+async def call(s, tool, args=None, must=True):
+    res = unwrap(await s.call_tool(tool, args or {}))
+    ok = isinstance(res, dict) and res.get("ok") is True
+    print(f"[{time.strftime('%H:%M:%S')}] {tool} -> {'ok' if ok else 'FAIL'}",
+          flush=True)
+    if must and not ok:
+        raise SystemExit(f"{tool} failed: {json.dumps(res, default=str)[:3000]}")
+    return res
+
+
+async def poll_run(s, run_id):
+    terminal = {"success", "failed", "error", "cancelled"}
+    started = time.time()
+    while True:
+        if time.time() - started > SIM_TIMEOUT_S:
+            raise SystemExit(f"run {run_id} timed out")
+        status = unwrap(await s.call_tool("get_run_status", {"run_id": run_id}))
+        state = (status.get("run", {}).get("status") or "unknown").lower()
+        if state in terminal:
+            if state != "success":
+                errs = unwrap(await s.call_tool(
+                    "extract_simulation_errors", {"run_id": run_id}))
+                raise SystemExit(
+                    f"run {run_id} ended {state}: "
+                    f"{json.dumps(errs, default=str)[:4000]}")
+            print(f"run {run_id}: {state}", flush=True)
+            return status
+        await asyncio.sleep(POLL_S)
+
+
+async def series(s, run_id, var, key, m1, d1, m2, d2, cap):
+    r = await call(s, "query_timeseries", {
+        "run_id": run_id, "variable_name": var, "key_value": key,
+        "start_month": m1, "start_day": d1,
+        "end_month": m2, "end_day": d2, "max_points": cap})
+    return r["data"]
+
+
+def dedupe(rows):
+    """Sizing design days share calendar dates with the run period; the
+    run-period environment is simulated last, so keep the last row per stamp."""
+    out = {}
+    for d in rows:
+        out[(d["month"], d["day"], d["hour"], d["minute"])] = d["value"]
+    return out
+
+
+def dump(name, obj):
+    OUT.mkdir(parents=True, exist_ok=True)
+    (OUT / f"{name}.json").write_text(json.dumps(obj, indent=1, default=str))
+    print(f"wrote {name}.json", flush=True)
+
+
+async def main():
+    params = StdioServerParameters(command="openstudio-mcp", args=[], env=None)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as s:
+            await s.initialize()
+
+            await call(s, "load_osm_model",
+                       {"osm_path": "/runs/demo_dr_shed/model.osm"})
+            zr = await call(s, "list_thermal_zones", {"max_results": 0})
+            zones = [z["name"] for z in zr["thermal_zones"]]
+            code = (PLUGIN_TEMPLATE
+                    .replace("__ZONES__", json.dumps(zones))
+                    .replace("__THRESHOLD_W__", str(THRESHOLD_W)))
+            await call(s, "edit_python_plugin",
+                       {"name": "Demand Limiter", "code": code})
+            plugin = await call(s, "get_python_plugin", {"name": "Demand Limiter"})
+            dump("plugin_v3", plugin)
+            await call(s, "save_osm_model",
+                       {"osm_path": "/runs/demo_dr_shed/model.osm"})
+            sim = await call(s, "run_simulation", {
+                "osm_path": "/runs/demo_dr_shed/model.osm",
+                "epw_path": EPW, "name": "demo_dr_shed_v3"})
+            shed_run = sim["run_id"]
+            await poll_run(s, shed_run)
+            errs = await call(s, "extract_simulation_errors", {"run_id": shed_run})
+            dump("shed3_sim_errors", errs)
+
+            shed_demand = {}
+            for month, mdays in MONTHS:
+                shed_demand[str(month)] = await series(
+                    s, shed_run, DEMAND_VAR, "Whole Building",
+                    month, 1, month, mdays, 6000)
+            dump("shed3_demand", shed_demand)
+            sall = dedupe([d for m in shed_demand.values() for d in m])
+            speak_stamp, speak = max(sall.items(), key=lambda kv: kv[1])
+            print(f"shed v3 peak {speak/1000:.1f} kW at {speak_stamp}", flush=True)
+
+            for tag, (pm, pd_) in (("peakday", PEAK_DAY), ("weekend", WEEKEND_DAY)):
+                day = {"demand": await series(
+                    s, shed_run, DEMAND_VAR, "Whole Building", pm, pd_, pm, pd_, 2000)}
+                if tag == "peakday":
+                    day["oat"] = await series(
+                        s, shed_run, "Site Outdoor Air Drybulb Temperature",
+                        "Environment", pm, pd_, pm, pd_, 2000)
+                    for z in ZONES_TO_PLOT:
+                        day[f"temp::{z}"] = await series(
+                            s, shed_run, "Zone Mean Air Temperature",
+                            z, pm, pd_, pm, pd_, 2000)
+                        day[f"clgsp::{z}"] = await series(
+                            s, shed_run,
+                            "Zone Thermostat Cooling Setpoint Temperature",
+                            z, pm, pd_, pm, pd_, 2000)
+                day["stage"] = await series(
+                    s, shed_run, "PythonPlugin:OutputVariable", "DR Shed Stage",
+                    pm, pd_, pm, pd_, 2000)
+                dump(f"shed3_{tag}", day)
+
+            # Baseline weekend-day demand for the weekend comparison panel
+            wm, wd = WEEKEND_DAY
+            dump("baseline_weekend", {"demand": await series(
+                s, BASELINE_RUN, DEMAND_VAR, "Whole Building", wm, wd, wm, wd, 2000)})
+
+            metrics = await call(s, "extract_summary_metrics", {"run_id": shed_run})
+            enduse = await call(s, "extract_end_use_breakdown", {"run_id": shed_run})
+            dump("shed3_metrics", {"summary": metrics, "end_use": enduse})
+
+            energy = {}
+            for month, mdays in MONTHS:
+                rows = await series(s, shed_run, "Electricity:Facility", "*",
+                                    month, 1, month, mdays, 6000)
+                energy[str(month)] = sum(dedupe(rows).values()) / 3.6e9  # J->MWh
+            dump("shed3_monthly_energy_mwh", energy)
+
+            peaks = {}
+            for month, _ in MONTHS:
+                peaks[str(month)] = max(v for k, v in sall.items() if k[0] == month)
+            dump("shed3_monthly_peaks_w", peaks)
+
+            dump("manifest_v3", {
+                "baseline_run": BASELINE_RUN, "shed_run": shed_run,
+                "shed_peak_w": speak, "shed_peak_stamp": speak_stamp,
+                "threshold_w": THRESHOLD_W,
+                "window": "every day 08:00-19:00",
+                "offsets_k": [0.0, 1.0, 2.0, 3.0],
+                "dwell_min": 10, "jump_ratio": 1.15, "release_min": 30,
+            })
+            print("DONE", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/python-ems-demand-response/study.md
+++ b/docs/examples/python-ems-demand-response/study.md
@@ -1,0 +1,170 @@
+# Grid-Interactive Demand Limiting with Python EMS
+## An openstudio-mcp research demo: authoring, tuning, and evaluating a supervisory controller entirely through MCP tools
+
+**Date:** 2026-07-07 · **Image:** openstudio-mcp:dev @ origin/develop `9d76327` (v1.1.0)
+**Interactive dashboard:** `dr_dashboard.html` (self-contained, this directory) · https://claude.ai/code/artifact/4139f7ac-85d0-44b7-9d65-fa53c264c12b
+**Repro assets:** this directory (drivers + dashboard HTML) · data regenerated to `runs/demo_dr_analysis/*.json`
+**Runs:** baseline `run_demo_dr_baseline_ce6de7f0a0c1` · final `run_demo_dr_shed_v3_8953d5dbc6ec`
+
+---
+
+## One-slide summary
+
+A custom **EnergyPlus Python Plugin** ("DemandLimiter") authored via `create_python_plugin`
+watches whole-building electric demand every 10 minutes and ratchets all 10 zones' cooling
+setpoints up in stages (+1/+2/+3 K) whenever demand crosses a shed threshold. Two controller
+revisions via `edit_python_plugin`, each driven by simulated evidence. Final result on a
+10-zone VAV office in Boston (Jun–Aug):
+
+| Metric | Baseline | Demand-limited (v3) | Change |
+|---|---|---|---|
+| Summer billing peak (30-min basis) | 335.2 kW | 311.1 kW | **−7.2%** |
+| 10-min intervals above 276.9 kW threshold | 2,276 | 610 | **−73%** |
+| Summer electricity (Jun–Aug) | 811.7 MWh | 779.8 MWh | **−3.9% (saved)** |
+| Demand-charge value @ $15/kW·mo | — | — | **≈ $1,300 / summer** |
+
+Demand response that *saves* energy: raising cooling setpoints during events reduces
+consumption too, so there is no energy penalty for the peak reduction.
+
+## Why researchers should care
+
+- **No custom E+ builds, no IDF hacking, no measure boilerplate:** control logic is plain
+  Python attached to the model; the MCP tool wires PythonPlugin:Instance/Variables/
+  OutputVariable and validates the source against the plugin contract before it ever runs.
+- **The controller iteration loop is minutes, not days:** author → simulate → query →
+  revise (`edit_python_plugin`) → re-simulate. Each full 3-month simulation ran in ~10 s
+  on this testbed.
+- **Custom telemetry:** the plugin publishes its own state (`DR Shed Stage`) as a normal
+  output variable, queryable alongside standard outputs via `query_timeseries`.
+- The whole study — model creation, HVAC, weather, control authoring, simulation,
+  extraction — is a reproducible tool-call script (an AI agent can run the entire loop).
+
+## Testbed
+
+| Item | Value |
+|---|---|
+| Building | 10-zone, 2-story office, 100 m × 50 m (~10,000 m²), core+perimeter zoning (`create_baseline_osm`) |
+| HVAC | ASHRAE baseline System 7: VAV w/ reheat, chiller + boiler plant (`add_baseline_system(system_type=7)`) |
+| Thermostats | 21.1 °C heating / 23.9 °C cooling |
+| Weather | Boston-Logan TMY3 (`change_building_location`, sets EPW + design days) |
+| Run period | Jun 1 – Aug 31, 10-minute timesteps |
+| Outputs | Facility Total Electricity Demand Rate, Zone Mean Air Temperature, Zone Thermostat Cooling Setpoint Temperature, Site OAT (timestep); Electricity:Facility / Cooling / Fans meters (hourly) |
+
+## Controller (final, v3)
+
+**Sensor:** Facility Total Electricity Demand Rate (previous timestep — realistic metering lag).
+**Actuators:** `Zone Temperature Control / Cooling Setpoint` per zone (discovered and confirmed with `list_ems_actuators`).
+**Logic, each zone timestep:**
+
+- Window: 08:00–19:00, **every day** (building runs 7-day schedules).
+- If demand > threshold (276.9 kW = 82% of true baseline peak): ratchet stage up
+  (never down in-window). 10-min dwell between moves; from idle, jump 2 stages when
+  demand > 115% of threshold (catches the 08:30 startup spike).
+- Stage offsets on the *scheduled* cooling setpoint: 0 / +1 / +2 / +3 K
+  (23.9 → 24.9 / 25.9 / 26.9 °C). Base setpoint sampled from the schedule whenever
+  unoverridden, so offsets never stack on the controller's own override.
+- After the window: release one stage per 30 min (staggered recovery — no rebound spike).
+- Publishes `dr_stage` as PythonPlugin:OutputVariable "DR Shed Stage".
+- Guards: handles looked up lazily after `api_data_fully_ready`, `-1` handles raise
+  a severe error and abort; actuation gated on `kind_of_sim == 3` so sizing design
+  days are untouched (otherwise the raised setpoints would shrink the autosized plant
+  and corrupt the comparison).
+
+Full source: `dr_demo_driver3.py` (PLUGIN_TEMPLATE), or
+`get_python_plugin("Demand Limiter")` on the saved model `runs/demo_dr_shed/model.osm`.
+
+## Tool workflow (the entire study)
+
+1. `create_baseline_osm` → `load_osm_model` → `list_thermal_zones`
+2. `add_baseline_system(system_type=7, thermal_zone_names=[...10 zones])`
+3. `change_building_location(Boston TMY3)` → `set_run_period(6/1–8/31)`
+4. `add_output_variable` ×4 (timestep) + `add_output_meter` ×3 (hourly)
+5. `save_osm_model` → `run_simulation` → `get_run_status` (baseline)
+6. `query_timeseries` → true baseline peak 337.7 kW → threshold = 0.82 × peak
+7. `list_ems_actuators(component_type="Zone Temperature Control")` — verify per-zone Cooling Setpoint actuator triples from the E+ .edd
+8. `create_python_plugin(name="Demand Limiter", template="custom", class_name="DemandLimiter", global_variables=["dr_stage"], output_variable_name="DR Shed Stage")`
+9. `save_osm_model` (plugin script travels in the model's companion `files/` dir) → `run_simulation`
+10. `extract_simulation_errors` — verify `PythonPlugin: Class DemandLimiter imported`, zero severe
+11. `edit_python_plugin` ×2 (revisions below) → rerun
+12. `query_timeseries` (demand, stage, setpoints, zone temps, OAT, meters) + `extract_summary_metrics` + `extract_end_use_breakdown`
+
+## The iteration story (the research-workflow payoff)
+
+| Rev | Controller | What the simulation said |
+|---|---|---|
+| v1 | Weekdays 13:00–18:00, 3 stages, 30-min dwell | Sheds 37–52 kW in-window, but the building peaks at **08:30** (morning pulldown after night setback) — seasonal peak untouched. Also surfaced the design-day/SQL analysis trap (below). |
+| v2 | Weekdays 08:00–19:00, 4 stages, 20-min dwell | Weekday peaks clipped to ~290 kW; seasonal peak **moved to Saturday** (329 kW, 6/26) because the model runs 7-day schedules; 20-min staging let the 08:30 spike through at 320 kW. |
+| v3 | Every day 08:00–19:00, 10-min dwell, 2-stage jump-start >115% of threshold | Billing peak −7.2%; exceedances −73%; energy −3.9%. Residual instantaneous spikes are single-timestep chiller-staging transients. |
+
+## Results detail
+
+**Monthly billing peak (30-min rolling basis, the demand-charge metric):**
+
+| Month | Baseline kW | v3 kW | Reduction |
+|---|---|---|---|
+| Jun | 335.2 | 306.0 | −8.7% |
+| Jul | 333.8 | 300.2 | −10.1% |
+| Aug | 335.1 | 311.1 | −7.2% |
+
+**Monthly facility electricity (MWh):** Jun 258.5→251.6, Jul 272.6→259.1, Aug 280.5→269.0.
+
+**Peak weekday (Jun 27) anatomy:** baseline holds ~324–327 kW from 08:30 to 17:30;
+controller jump-starts 2 stages on the 08:30 spike (337.7 → 320.6 kW at first trip, one
+timestep of irreducible metering lag), reaches stage 3 by 09:00, holds ~283–293 kW all
+day, zone temps float 23.9 → 26.9 °C, and the staggered release (19:00–20:30) returns to
+schedule with ≤ +5 kW rebound.
+
+**Comfort:** zones spend event hours up to 26.9 °C. Reported unmet cooling hours
+*improve* (152.5 → 24.7 h) — an artifact, not a comfort gain: EnergyPlus scores unmet
+hours against the **actuated** setpoint. The honest comfort story is the zone-temperature
+traces.
+
+## Findings a researcher would chase next
+
+1. **Shed capacity is finite:** stage 3 floor ≈ 285–295 kW. Deeper cuts need pre-cooling,
+   chiller demand limiting, or lighting/plug DR — all expressible as more plugin logic.
+2. **Demand limiting induces plant cycling:** brief chiller-staging transients up to
+   +19 kW *above baseline* for a single timestep. They wash out on a 30-min billing basis;
+   plant-level control (CHW reset, compressor limiting) would remove them.
+3. **Feedback-only control cannot preempt step changes:** the metered interval that trips
+   the controller is itself the residual peak. Forecast or schedule-aware feed-forward is
+   the fix.
+4. **The baseline plant is capacity-limited:** baseline zones already float 0.5–1.5 K above
+   setpoint on peak afternoons — why the 351 kW sizing-day plateau never appears in the
+   run period, and a reminder that setpoint-based DR sheds nothing from saturated equipment.
+
+## Method caveats / gotchas (worth keeping)
+
+- **Design-day rows in `query_timeseries`:** sizing design days share calendar dates with
+  the run period (Boston: 7/21, 1/21) and are returned blended with run-period rows.
+  Workaround: keep the last row per timestamp (run period simulates last). Tool fix filed
+  as [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87).
+- **`kind_of_sim` guard is mandatory** for any plugin that actuates thermostats/setpoints —
+  otherwise sizing runs see the overrides and the plant autosizes smaller.
+- "Billing peak" = max 30-minute rolling average of 10-min instantaneous demand.
+- Custom plugins report **one** output variable per `create_python_plugin` call (the first
+  global); design controllers so one state variable + standard E+ outputs tell the story.
+- TMY3 single-year weather; demand-charge $ uses a $15/kW·mo placeholder tariff.
+
+## Figure inventory (for slides)
+
+All figures live in the self-contained dashboard (`dr_dashboard.html`,
+same as the artifact link). Underlying series JSON regenerated to `runs/demo_dr_analysis/`:
+
+| Figure | Data files |
+|---|---|
+| Peak-day demand, baseline vs v3, threshold + window band | `baseline_demand.json`, `shed3_demand.json` (Jun 27 slice) |
+| Controller anatomy: stage step + setpoint/zone-temp traces | `shed3_peakday.json`, `baseline_peakday_v2.json` |
+| Weekend clip (Sat Jun 26, the v2 miss) | `baseline_weekend.json`, `shed3_weekend.json` |
+| Monthly billing peaks + monthly energy bars | `monthly_peaks_w.json`, `monthly_energy_mwh.json`, `shed3_monthly_*` |
+| Stat tiles (peak, exceedances, energy, $) | `manifest_v3.json`, metrics JSONs |
+
+## Reproduce
+
+```bash
+docker build -f docker/Dockerfile -t openstudio-mcp:dev .   # from origin/develop
+cd docs/examples/python-ems-demand-response
+docker run --rm -v "C:/projects/openstudio-mcp/runs:/runs" -v "$(pwd):/scratch" \
+  openstudio-mcp:dev bash -lc "python -u /scratch/dr_demo_driver.py"   # baseline + v1
+# driver2/driver3 hardcode the baseline run id printed by driver1 — edit, then run the same way
+```

--- a/docs/examples/python-ems-demand-response/study.md
+++ b/docs/examples/python-ems-demand-response/study.md
@@ -137,8 +137,10 @@ traces.
 
 - **Design-day rows in `query_timeseries`:** sizing design days share calendar dates with
   the run period (Boston: 7/21, 1/21) and are returned blended with run-period rows.
-  Workaround: keep the last row per timestamp (run period simulates last). Tool fix filed
-  as [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87).
+  Workaround at study time: keep the last row per timestamp (run period simulates last).
+  Since fixed in [#88](https://github.com/NatLabRockies/openstudio-mcp/pull/88)
+  (closes [#87](https://github.com/NatLabRockies/openstudio-mcp/issues/87)):
+  `environment="run_period"` is now the default.
 - **`kind_of_sim` guard is mandatory** for any plugin that actuates thermostats/setpoints —
   otherwise sizing runs see the overrides and the plant autosizes smaller.
 - "Billing peak" = max 30-minute rolling average of 10-min instantaneous demand.


### PR DESCRIPTION
Packages the Python-EMS demand-response study as an official worked example (#20), consistent with examples 1-19. No code/behavior changes — docs + reproducibility assets only.

## What it is

A custom EnergyPlus Python Plugin ("DemandLimiter"), authored via `create_python_plugin` and revised twice via `edit_python_plugin`, watches whole-building electric demand every 10 min and ratchets all 10 zones' cooling setpoints up in stages when demand crosses a shed threshold. On a 10-zone System-7 office in Boston (Jun-Aug):

| Metric | Baseline | v3 | Change |
|---|---|---|---|
| Summer billing peak (30-min) | 335.2 kW | 311.1 kW | **-7.2%** |
| Intervals above 276.9 kW threshold | 2,276 | 610 | **-73%** |
| Summer electricity | 811.7 MWh | 779.8 MWh | **-3.9% (saved)** |

The point for the repo: author -> simulate -> query -> revise, entirely through MCP tools, with the controller as plain Python attached to the model.

## Files

- `docs/examples/20_python_ems_demand_response.md` — the example: scenario, plain-language walkthrough, natural-language prompt, full tool-call sequence, results, three-revision iteration story, pitfalls.
- `docs/examples/python-ems-demand-response/` — companion assets:
  - `study.md` — full research writeup (results detail, comfort, method caveats, figure inventory)
  - `dr_dashboard.html` — self-contained results dashboard (data embedded)
  - `dr_demo_driver{,2,3}.py` — the three reproducibility drivers (baseline+v1, v2, v3). Each embeds its controller as the `DemandLimiter` `PLUGIN_TEMPLATE`; the rest is the frozen MCP tool-call sequence. `README.md` has the `docker run` reproduce command.
- `README.md` — examples table + count (19 -> 20).

## Notes

- Drivers are kept verbatim as a frozen reproducible transcript (not reformatted); the pre-commit `ruff-check` hook is scoped to json/yaml/toml/txt, so `.py` style findings don't gate them.
- This demo is where the `query_timeseries` design-day blending bug (#87) was found; the example's pitfalls section links it.
- Relocated from the untracked `dev/` scratch area into tracked `docs/` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)