### PR TITLE
CI-prep fixes for gbXML import branch (pre-PR dry run findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: ci
 # an open PR fires BOTH push and pull_request → every job runs twice.
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, "ci-dryrun/**"]
     tags: ["*"]
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: ci
 # an open PR fires BOTH push and pull_request → every job runs twice.
 on:
   push:
-    branches: [main, develop, "ci-dryrun/**"]
+    branches: [main, develop]
     tags: ["*"]
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,15 +285,15 @@ jobs:
               ;;
             4)
               # vrf, radiant, query skills, creation, air terminals, results extraction
-              FILES="tests/test_vrf_system.py tests/test_radiant_system.py tests/test_loads.py tests/test_spaces.py tests/test_space_types.py tests/test_schedules.py tests/test_constructions.py tests/test_create_space.py tests/test_create_thermal_zone.py tests/test_add_air_loop.py tests/test_create_schedule_ruleset.py tests/test_add_output_variable.py tests/test_add_output_meter.py tests/test_load_save_model.py tests/test_versions.py tests/test_create_example_osm.py tests/test_inspect_osm_summary.py tests/test_copy_file.py tests/test_replace_air_terminals.py tests/test_results_extraction.py tests/test_swig_memleak_cleanup.py tests/test_skill_tools_integration.py tests/test_stdio_smoke.py tests/test_response_sizes.py tests/test_response_guard.py"
+              # + gbxml_import (Revit gbXML -> OSM via gbxml-to-openstudio measures)
+              FILES="tests/test_vrf_system.py tests/test_radiant_system.py tests/test_loads.py tests/test_spaces.py tests/test_space_types.py tests/test_schedules.py tests/test_constructions.py tests/test_create_space.py tests/test_create_thermal_zone.py tests/test_add_air_loop.py tests/test_create_schedule_ruleset.py tests/test_add_output_variable.py tests/test_add_output_meter.py tests/test_load_save_model.py tests/test_versions.py tests/test_create_example_osm.py tests/test_inspect_osm_summary.py tests/test_copy_file.py tests/test_replace_air_terminals.py tests/test_results_extraction.py tests/test_swig_memleak_cleanup.py tests/test_skill_tools_integration.py tests/test_stdio_smoke.py tests/test_response_sizes.py tests/test_response_guard.py tests/test_gbxml_import.py"
               EXTRA_ENV=""
               ;;
             5)
               # HVAC supply sim smoke tests + hvac_validation + bar_building + concurrent regression
               # + sim queue (concurrency cap) & per-user run-dir isolation + run retention/cleanup
               # + python_ems phase 2 (packages/numpy-in-plugin, edit, node reset, trend)
-              # + gbxml_import (Revit gbXML -> OSM via gbxml-to-openstudio measures)
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py tests/test_gbxml_import.py"
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -2,7 +2,7 @@ name: format-and-lint
 
 on:
   push:
-    branches: [main, develop, "ci-dryrun/**"]
+    branches: [main, develop]
   pull_request:
 
 jobs:

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -2,7 +2,7 @@ name: format-and-lint
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, "ci-dryrun/**"]
   pull_request:
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^tests/assets/(sddc_office/floorplan\.json|eplusout_seb4\.sql)$
+exclude: ^tests/assets/(sddc_office/floorplan\.json|eplusout_seb4\.sql|gbxml/25_SpacesOneZE\.xml)$
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/tests/test_gbxml_import.py
+++ b/tests/test_gbxml_import.py
@@ -197,7 +197,7 @@ def test_validate_gbxml_geometry_on_real_import():
                     "aim2156", "aim0426", "aim1583", "aim1895", "aim0513", "aim1634",
                     "aim0635", "aim0845",
                 }, flagged
-                assert flagged["aim2860"]["floor_area_m2"] == pytest.approx(7.456443749999997), flagged
+                assert flagged["aim2860"]["floor_area_m2"] == pytest.approx(7.456443749999997, rel=1e-9), flagged
                 assert flagged["aim2860"]["has_floor"] is True, flagged
                 assert flagged["aim2860"]["has_roofceiling"] is True, flagged
 


### PR DESCRIPTION
Ran the full CI suite against this branch before the develop PR (dry-run branch + `workflow_dispatch`). Results: `ci` all 9 jobs green (22 min), `security` green, `format-and-lint` **failed** — fixed here, plus two small convention fixes.

## Fixes

1. **Shard rebalance** — `test_gbxml_import.py` was appended to shard 5, which at 620s was already the heaviest (CLAUDE.md: append to the lightest). Moved to shard 4 (317s). The gbXML tests add ~90s.
2. **Explicit approx tolerance** — `pytest.approx(7.456..., rel=1e-9)`; `.claude/rules/testing.md` requires explicit `rel=`/`abs=` on every float comparison.
3. **Lint exclude for the fixture** — pre-commit's `end-of-file-fixer` + `mixed-line-ending` hooks fail on `tests/assets/gbxml/25_SpacesOneZE.xml` (no trailing newline, mixed CRLF/LF — authentic for a Revit-style export). Added it to the `.pre-commit-config.yaml` `exclude:` regex rather than normalizing the file, same precedent as `floorplan.json` / `eplusout_seb4.sql`. Without this, format-and-lint fails on your develop PR.

The branch also carries a temporary `ci-dryrun/**` CI trigger commit + its revert (net-zero diff) — that's how the dry run was executed.

## Suggestion (not changed here)

`validate_gbxml_geometry` runs `match_surfaces()` first, which **mutates** the loaded model before validating. It's disclosed in the docstring, but an agent (or user) calling a "validate" tool won't expect side effects, and there's no way to check geometry without also repairing it. Consider either renaming (e.g. `repair_and_validate_gbxml_geometry`) or making the repair opt-in via a `repair: bool = True` arg so the mutation is explicit in the signature. Happy to discuss — the rest of the tool's design (true-overlap via `intersect()` vs `intersects()`, `isEnclosedVolume()` over `volume()==0`) is excellent.

## Validation

- Local Docker (fresh build): `test_gbxml_import.py` + `test_runner_message_caps.py` + `test_skill_registration.py` — 13/13 passed
- Exclude regex verified to match only the fixture; this PR's own checks re-run the full suite via the `pull_request` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)