### PR TITLE
Stage EPW measure args into run dir; portable weather url (fixes #104)

### DIFF
--- a/mcp_server/skills/common_measures/wrappers.py
+++ b/mcp_server/skills/common_measures/wrappers.py
@@ -320,10 +320,34 @@ def change_building_location_op(
         weather_file: Absolute path to .epw file (must have .stat + .ddy alongside)
         climate_zone: ASHRAE climate zone or "Lookup From Stat File" for auto-detect
     """
-    return _run("ChangeBuildingLocation", {
+    result = _run("ChangeBuildingLocation", {
         "weather_file_name": weather_file,
         "climate_zone": climate_zone,
     })
+    if result.get("ok"):
+        _make_weather_url_portable(result)
+    return result
+
+
+def _make_weather_url_portable(result: dict[str, Any]) -> None:
+    """Rewrite the model's OS:WeatherFile url to the bare EPW filename.
+
+    The measure records the staged run-dir path, which resolves only inside
+    this container (issue #104, secondary). The bare filename is the portable
+    OSM convention: a host OpenStudio App resolves it via the model's
+    companion files/ dir, and run_simulation re-resolves it against known
+    weather dirs at sim time.
+    """
+    from mcp_server.model_manager import get_model
+    try:
+        model = get_model()
+        wf = model.weatherFile()
+        if wf.is_initialized() and wf.get().makeUrlRelative():
+            url = wf.get().url()
+            if url.is_initialized():
+                result["weather_url"] = str(url.get())
+    except Exception as e:  # measure succeeded — don't fail the tool on cleanup
+        result["weather_url_error"] = str(e)
 
 
 # ===================================================================

--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -35,8 +35,9 @@ from mcp_server.config import (
     user_run_root,
 )
 from mcp_server.model_manager import get_model, load_model
-from mcp_server.skills.measures.osw_weather import resolve_osw_weather
+from mcp_server.skills.measures.osw_weather import resolve_osw_weather, stage_epw_into_run
 from mcp_server.skills.measures.runner_messages import parse_runner_messages
+from mcp_server.skills.weather.operations import find_epw_by_name
 from mcp_server.util import create_run_dir, reject_escaping_symlinks, resolve_run_dir
 
 
@@ -759,17 +760,34 @@ def apply_measure(
         file_paths = weather["file_paths"]
         osw_weather_file = weather["weather_file"]
 
-        # Also add directories of any EPW paths passed as arguments
-        # (e.g. ChangeBuildingLocation's weather_file_name argument).
-        # An explicit argument EPW overrides model-based resolution.
-        if arguments:
-            for v in arguments.values():
-                v_str = str(v)
-                if v_str.endswith(".epw") and Path(v_str).is_file():
-                    parent = str(Path(v_str).parent)
-                    if parent not in file_paths:
-                        file_paths.append(parent)
-                    osw_weather_file = v_str
+        # Stage any EPW passed as an argument (e.g. ChangeBuildingLocation's
+        # weather_file_name) into the run dir and rewrite the argument to the
+        # staged copy. The sandboxed subprocess can only read its own run dir,
+        # so passing an /inputs path through raw gets EACCES from Landlock
+        # (issue #104). An explicit argument EPW overrides model-based
+        # resolution. Bare filenames resolve against known weather dirs.
+        for k, v in list(measure_args.items()):
+            v_str = str(v)
+            if not v_str.endswith(".epw"):
+                continue
+            src = Path(v_str)
+            if src.is_file():
+                # is_path_allowed resolves symlinks, so this also blocks a
+                # link under an allowed root pointing at a forbidden target
+                if not is_path_allowed(src):
+                    return {"ok": False, "error": f"EPW path not allowed: {v_str}"}
+                src = src.resolve()
+            else:
+                found = find_epw_by_name(src.name) if src.name == v_str else None
+                if found is None:
+                    continue
+                src = found
+            rel = stage_epw_into_run(src, run_dir)
+            staged = run_dir / rel
+            measure_args[k] = str(staged)
+            if str(staged.parent) not in file_paths:
+                file_paths.append(str(staged.parent))
+            osw_weather_file = rel
 
         # Build minimal OSW — use relative path to local copy
         osw = {

--- a/mcp_server/skills/measures/osw_weather.py
+++ b/mcp_server/skills/measures/osw_weather.py
@@ -63,6 +63,27 @@ def resolve_osw_weather(model: Any, run_dir: Path, temp_osm: Path) -> dict[str, 
     return out
 
 
+def stage_epw_into_run(epw_src: Path, run_dir: Path) -> str:
+    """Copy an EPW plus companion .ddy/.stat into run_dir/files.
+
+    The confined measure subprocess can read only its own run dir — the
+    sandbox deliberately denies shared roots like /inputs (issue #104) — so
+    a referenced weather file must be staged, never passed by original path.
+    Companions travel too: ChangeBuildingLocation reads the .ddy (design
+    days) and .stat (climate zone) from the EPW's directory.
+
+    Returns the OSW-relative reference ('files/<name>').
+    """
+    files_dir = run_dir / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(epw_src), str(files_dir / epw_src.name))
+    for ext in (".ddy", ".stat"):
+        companion = epw_src.with_suffix(ext)
+        if companion.is_file():
+            shutil.copy2(str(companion), str(files_dir / companion.name))
+    return f"files/{epw_src.name}"
+
+
 def strip_weather_from_seed(temp_osm: Path) -> Any | None:
     """Remove OS:WeatherFile from a saved seed OSM; return its IdfObject.
 

--- a/mcp_server/skills/measures/osw_weather.py
+++ b/mcp_server/skills/measures/osw_weather.py
@@ -79,8 +79,13 @@ def stage_epw_into_run(epw_src: Path, run_dir: Path) -> str:
     shutil.copy2(str(epw_src), str(files_dir / epw_src.name))
     for ext in (".ddy", ".stat"):
         companion = epw_src.with_suffix(ext)
-        if companion.is_file():
-            shutil.copy2(str(companion), str(files_dir / companion.name))
+        # Companions are derived paths that never went through is_path_allowed
+        # (the EPW itself did, resolved). A tenant can write its own run dir,
+        # so a planted leaf symlink (x.ddy -> /etc/shadow) would make the root
+        # server copy the target into the tenant-readable run dir — skip links.
+        if companion.is_symlink() or not companion.is_file():
+            continue
+        shutil.copy2(str(companion), str(files_dir / companion.name))
     return f"files/{epw_src.name}"
 
 

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -885,6 +885,18 @@ def run_simulation(osm_path: str, epw_path: str | None = None, name: str | None 
         if not is_path_allowed(epw):
             return {"ok": False, "error": f"EPW path not allowed: {epw_path}"}
         epw_abs = str(epw.resolve())
+    else:
+        # No override: resolve the model's own OS:WeatherFile url so run_osw
+        # stages it into the run's files/ dir. A bare-filename url (the
+        # portable form change_building_location writes — issue #104) is
+        # unresolvable by the CLI alone, and a container-absolute /inputs url
+        # is unreadable by the sandboxed sim child; staging fixes both.
+        # Unresolvable stays None — the CLI then fails with its own weather
+        # error, unchanged from before.
+        from mcp_server.skills.weather.operations import resolve_model_weather_epw
+        resolved = resolve_model_weather_epw(osm)
+        if resolved is not None:
+            epw_abs = str(resolved)
 
     # Stage the minimal OSW in a throwaway temp dir. run_osw() copies the staged
     # files into the real per-user run dir before it returns, so nothing here

--- a/mcp_server/skills/weather/operations.py
+++ b/mcp_server/skills/weather/operations.py
@@ -12,7 +12,12 @@ from typing import Any
 
 import openstudio
 
-from mcp_server.config import COMSTOCK_MEASURES_DIR, INPUT_ROOT, OSCLI_GEM_PATH
+from mcp_server.config import (
+    COMSTOCK_MEASURES_DIR,
+    INPUT_ROOT,
+    OSCLI_GEM_PATH,
+    is_path_allowed,
+)
 from mcp_server.model_manager import get_model
 
 
@@ -181,6 +186,37 @@ def find_epw_by_name(basename: str) -> Path | None:
             if candidate.is_file():
                 return candidate
     return None
+
+
+def resolve_model_weather_epw(osm_path: Path) -> Path | None:
+    """Resolve a saved OSM's OS:WeatherFile url to a readable EPW, or None.
+
+    Lets run_simulation stage the model's own weather when no epw_path
+    override is given — required since change_building_location writes the
+    portable bare-filename url (issue #104): the CLI alone can't resolve a
+    bare name, and a container-absolute /inputs url is unreadable by the
+    sandboxed sim child.
+
+    The url is caller-controlled model content, so an absolute url is honored
+    only when it passes is_path_allowed — without that gate a crafted model
+    could make the server stage another tenant's file into this caller's run
+    dir. Unresolvable urls fall back to bare-filename lookup across the known
+    weather dirs (trusted, server-chosen — no gate needed).
+    """
+    loaded = openstudio.osversion.VersionTranslator().loadModel(
+        openstudio.toPath(str(osm_path)))
+    if not loaded.is_initialized():
+        return None
+    wf = loaded.get().weatherFile()
+    if not wf.is_initialized():
+        return None
+    url = wf.get().path()
+    if not url.is_initialized():
+        return None
+    epw = Path(str(url.get()))
+    if epw.is_file() and is_path_allowed(epw):
+        return epw.resolve()
+    return find_epw_by_name(epw.name)
 
 
 def get_weather_info() -> dict[str, Any]:

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -268,6 +268,39 @@ def test_run_simulation_resolves_portable_weather_url():
     asyncio.run(_run())
 
 
+def test_stage_epw_skips_symlinked_companions(tmp_path):
+    """A symlinked .ddy/.stat next to the EPW must not be staged."""
+    # Regression: PR #106 review — companions were copied ungated; a tenant can
+    # write its own run dir (sandboxed measures), so x.ddy -> /etc/shadow made
+    # the root server copy the target into the tenant-readable run dir
+    from mcp_server.skills.measures.osw_weather import stage_epw_into_run
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    epw = src_dir / "leak_test.epw"
+    epw.write_text("LOCATION,fake,,,,,,,0,0,0,0\n")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("root:hunter2\n")
+    try:
+        (src_dir / "leak_test.ddy").symlink_to(secret)
+    except OSError:
+        pytest.skip("symlink creation not permitted (Windows without dev mode)")
+    stat = src_dir / "leak_test.stat"
+    stat.write_text("legit stat content\n")
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    rel = stage_epw_into_run(epw, run_dir)
+
+    assert rel == "files/leak_test.epw"
+    files_dir = run_dir / "files"
+    assert (files_dir / "leak_test.epw").is_file()
+    assert (files_dir / "leak_test.stat").read_text() == "legit stat content\n", \
+        "regular companion should still be staged"
+    assert not (files_dir / "leak_test.ddy").exists(), \
+        "symlinked companion was staged — root server leaked the link target into the run dir"
+
+
 # ---- Design day tests ----
 
 @pytest.mark.integration

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -4,11 +4,18 @@ Tests get_weather_info, change_building_location, add_design_day.
 Uses Boston EPW from ChangeBuildingLocation measure tests (has .stat + .ddy).
 """
 import asyncio
+import shutil
 import uuid
 from pathlib import Path
 
 import pytest
-from conftest import integration_enabled, server_params, setup_example, unwrap
+from conftest import (
+    integration_enabled,
+    poll_until_done,
+    server_params,
+    setup_example,
+    unwrap,
+)
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
@@ -22,6 +29,29 @@ EPW_PATH = (
     "/opt/comstock-measures/ChangeBuildingLocation"
     "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
 )
+EPW_NAME = "USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+
+# INPUT_ROOT as the server resolves it (issue #104 repro needs an EPW there)
+INPUTS_DIR = Path("/inputs")
+
+
+def _stage_inputs_epw() -> str:
+    """Ensure the Boston EPW (+ .ddy/.stat) exists under /inputs; return its path.
+
+    CI containers have no /inputs mount, so create it and copy from the
+    comstock measure tests dir. Skip only if /inputs is a read-only mount
+    that doesn't already hold the EPW.
+    """
+    src = Path(EPW_PATH)
+    dst = INPUTS_DIR / src.name
+    if not dst.is_file():
+        try:
+            INPUTS_DIR.mkdir(parents=True, exist_ok=True)
+            for companion in (src, src.with_suffix(".ddy"), src.with_suffix(".stat")):
+                shutil.copy2(str(companion), str(INPUTS_DIR / companion.name))
+        except OSError:
+            pytest.skip("/inputs not writable and Boston EPW not present there")
+    return str(dst)
 
 
 # ---- Unit tests for climate zone estimation (no Docker needed) ----
@@ -117,6 +147,124 @@ def test_get_weather_info_after_set():
                     f"Boston latitude should be ~42.4, got {wf['latitude']}"
                 assert -72.0 < wf["longitude"] < -70.0, \
                     f"Boston longitude should be ~-71, got {wf['longitude']}"
+    asyncio.run(_run())
+
+
+# ---- Issue #104: /inputs EPW staging + portable weather url ----
+
+
+@pytest.mark.integration
+def test_change_building_location_inputs_epw():
+    """EPW under /inputs must be staged into the run dir, not passed raw."""
+    # Regression: issue #104 — raw /inputs path reached the sandboxed measure
+    # subprocess, which Landlock denies (EACCES); EPW+companions must be staged
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+    epw = _stage_inputs_epw()
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique())
+                res = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": epw,
+                }))
+                assert res["ok"] is True, (
+                    f"change_building_location failed: {res.get('error')} "
+                    f"{res.get('log_tail', '')[-500:]}"
+                )
+
+                # EPW + .ddy + .stat staged into the run's files/ dir
+                files_dir = Path(res["run_dir"]) / "files"
+                assert (files_dir / EPW_NAME).is_file(), "staged EPW missing from run files/"
+                assert (files_dir / Path(EPW_NAME).with_suffix(".ddy").name).is_file(), \
+                    "companion .ddy not staged — ChangeBuildingLocation needs it for design days"
+                assert (files_dir / Path(EPW_NAME).with_suffix(".stat").name).is_file(), \
+                    "companion .stat not staged — ChangeBuildingLocation needs it for climate zone"
+                # measure argument rewritten to the staged copy, not /inputs
+                assert res["arguments_applied"]["weather_file_name"] == str(files_dir / EPW_NAME)
+
+                # Measure actually read the EPW: Boston lat/lon on the model
+                wi = unwrap(await s.call_tool("get_weather_info", {}))
+                assert wi["ok"] is True
+                assert 42.0 < wi["weather_file"]["latitude"] < 43.0, \
+                    f"Boston latitude should be ~42.4, got {wi['weather_file']['latitude']}"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_change_building_location_portable_url():
+    """OS:WeatherFile url must be the bare EPW filename, not a container path."""
+    # Regression: issue #104 secondary — url stored the container-absolute path,
+    # so saved models didn't open cleanly in a host OpenStudio App install
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique())
+                res = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": EPW_PATH,
+                }))
+                assert res["ok"] is True, f"change_building_location failed: {res.get('error')}"
+                assert res["weather_url"] == EPW_NAME, \
+                    f"weather_url should be bare filename, got {res.get('weather_url')}"
+
+                # In-memory model agrees
+                wi = unwrap(await s.call_tool("get_weather_info", {}))
+                assert wi["weather_file"]["url"] == EPW_NAME
+
+                # Saved OSM stores the portable reference
+                osm_path = f"/runs/{_unique('portable_url')}.osm"
+                sv = unwrap(await s.call_tool("save_osm_model", {"osm_path": osm_path}))
+                assert sv["ok"] is True, f"save_osm_model failed: {sv.get('error')}"
+                text = Path(osm_path).read_text(encoding="utf-8")
+                start = text.index("OS:WeatherFile,")
+                block = text[start:text.index(";", start)]
+                assert f"\n  {EPW_NAME}," in block, \
+                    f"OS:WeatherFile Url should be bare filename, block was:\n{block}"
+                assert "/runs/" not in block and "/inputs/" not in block and "/opt/" not in block, \
+                    f"container-absolute path leaked into OS:WeatherFile:\n{block}"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_run_simulation_resolves_portable_weather_url():
+    """run_simulation with no epw override must resolve a bare-filename url."""
+    # Regression: issue #104 — after the portable-url rewrite, run_simulation
+    # must stage the model's EPW itself (bare name is unresolvable by the CLI
+    # alone and a /inputs path is unreadable by the sandboxed sim child)
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+    epw = _stage_inputs_epw()
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique())
+                res = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": epw,
+                }))
+                assert res["ok"] is True, f"change_building_location failed: {res.get('error')}"
+                rp = unwrap(await s.call_tool("set_run_period", {
+                    "begin_month": 7, "begin_day": 20, "end_month": 7, "end_day": 22,
+                }))
+                assert rp["ok"] is True, f"set_run_period failed: {rp.get('error')}"
+                osm_path = f"/runs/{_unique('portable_sim')}.osm"
+                sv = unwrap(await s.call_tool("save_osm_model", {"osm_path": osm_path}))
+                assert sv["ok"] is True, f"save_osm_model failed: {sv.get('error')}"
+
+                sim = unwrap(await s.call_tool("run_simulation", {"osm_path": osm_path}))
+                assert sim["ok"] is True, f"run_simulation failed: {sim.get('error')}"
+                assert sim["epw_path"] is not None and sim["epw_path"].endswith(f"files/{EPW_NAME}"), \
+                    f"model weather url not resolved+staged, epw_path={sim.get('epw_path')}"
+                status = await poll_until_done(s, sim["run_id"])
+                assert status["run"]["status"] == "success", \
+                    f"simulation with resolved weather should succeed: {status}"
     asyncio.run(_run())
 
 


### PR DESCRIPTION
Fixes #104.

## Primary: sandbox denies /inputs EPW (option 1 from the issue)
`apply_measure` now stages `.epw` args + `.ddy`/`.stat` companions into the run's `files/` dir and rewrites the measure argument to the staged copy — the confined subprocess only ever reads its own run dir, per the sandbox design intent. Gated by `is_path_allowed` before staging (symlink-resolving, matches `run_osw`/`run_simulation`). Bare filenames resolve via `find_epw_by_name`. Option 2 (`extra_ro`) declined: grants the confined measure direct read on the shared multi-tenant `/inputs`.

## Secondary: container-absolute OS:WeatherFile.Url
`change_building_location` rewrites the url to the bare EPW filename (`makeUrlRelative()`) — the portable OSM convention a host OpenStudio App resolves. Tool result now includes `weather_url`.

## Companion: run_simulation resolves the model's weather
With a portable bare-name url (or a container-absolute `/inputs` url), the CLI alone can't produce a sim-readable EPW. When no `epw_path` override is given, `run_simulation` resolves the model's url (absolute-and-allowed, else bare-name lookup across known weather dirs) and stages it via `run_osw`'s existing `files/` mechanics. Absolute urls gated by `is_path_allowed` — url is caller-controlled model content; ungated the server would stage another tenant's file into the caller's run dir.

## Tests
3 regression tests in `tests/test_weather.py` (already in CI shard 1; adds one short 3-day sim):
- `/inputs` EPW staged + companions present + measure reads it (was EACCES)
- saved OSM stores bare-filename url, no container path
- `run_simulation` with no override resolves+stages the EPW, sim succeeds

Red-green verified: all 3 fail unfixed; sim test stays red after staging alone (proves the resolver is needed). Regression sweep (`test_weather`, `test_measures`, `test_common_measures`, `test_add_output_variable`): 57 passed, 1 pre-existing env-conditional skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)