### PR TITLE
validate_osw/run_osw honor OSW file_paths like the CLI (fixes #99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,8 @@ jobs:
             4)
               # vrf, radiant, query skills, creation, air terminals, results extraction
               # + gbxml_import (Revit gbXML -> OSM via gbxml-to-openstudio measures)
-              FILES="tests/test_vrf_system.py tests/test_radiant_system.py tests/test_loads.py tests/test_spaces.py tests/test_space_types.py tests/test_schedules.py tests/test_constructions.py tests/test_create_space.py tests/test_create_thermal_zone.py tests/test_add_air_loop.py tests/test_create_schedule_ruleset.py tests/test_add_output_variable.py tests/test_add_output_meter.py tests/test_load_save_model.py tests/test_versions.py tests/test_create_example_osm.py tests/test_inspect_osm_summary.py tests/test_copy_file.py tests/test_replace_air_terminals.py tests/test_results_extraction.py tests/test_swig_memleak_cleanup.py tests/test_skill_tools_integration.py tests/test_stdio_smoke.py tests/test_response_sizes.py tests/test_response_guard.py tests/test_gbxml_import.py"
+              # + validate_osw/run_osw file_paths resolution (issue #99)
+              FILES="tests/test_vrf_system.py tests/test_radiant_system.py tests/test_loads.py tests/test_spaces.py tests/test_space_types.py tests/test_schedules.py tests/test_constructions.py tests/test_create_space.py tests/test_create_thermal_zone.py tests/test_add_air_loop.py tests/test_create_schedule_ruleset.py tests/test_add_output_variable.py tests/test_add_output_meter.py tests/test_load_save_model.py tests/test_versions.py tests/test_create_example_osm.py tests/test_inspect_osm_summary.py tests/test_copy_file.py tests/test_replace_air_terminals.py tests/test_results_extraction.py tests/test_swig_memleak_cleanup.py tests/test_skill_tools_integration.py tests/test_stdio_smoke.py tests/test_response_sizes.py tests/test_response_guard.py tests/test_gbxml_import.py tests/test_validate_osw.py"
               EXTRA_ENV=""
               ;;
             5)

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -192,13 +192,70 @@ def _dump_json(path: Path, obj: dict[str, Any]) -> None:
     path.write_text(json.dumps(obj, indent=2, sort_keys=False) + "\n", encoding="utf-8")
 
 
-def validate_osw(osw_path: str, epw_path: str | None = None) -> dict[str, Any]:
+# Search dirs WorkflowJSON::findFile consults when the OSW declares no
+# file_paths (relative to the OSW dir). Explicit file_paths are searched too —
+# union rather than replacement, so the validator never rejects a workflow the
+# CLI would run (issue #99: false rejection is the bug being fixed here).
+_OSW_DEFAULT_FILE_DIRS = ("files", "weather", ".")
+
+
+def _resolve_osw_file(name: str, base: Path, osw: dict,
+                      *, gated: bool = True) -> tuple[Path | None, Path | None]:
+    """Resolve an OSW file reference the way the CLI's WorkflowJSON::findFile
+    does: absolute as-is, else the WHOLE relative reference appended to the OSW
+    dir, each file_paths entry (relative entries resolved against the OSW dir),
+    and the default search dirs.
+
+    When `gated`, candidates outside the caller's allowed roots are skipped:
+    file_paths is caller-controlled OSW content and a hit is later staged into
+    the run dir by the root server (run_osw) — ungated that is an arbitrary
+    host-file read primitive (same class as issue #104's companion staging).
+    Internal callers (run_simulation's private temp stage) pass gated=False.
+
+    Returns (hit, denied_hit) — denied_hit is the first candidate that exists
+    but failed the gate, kept for a precise error message.
+    """
+    n = Path(name)
+    if n.is_absolute():
+        candidates = [n]
+    else:
+        dirs = [base]
+        for fp in (*(osw.get("file_paths") or []), *_OSW_DEFAULT_FILE_DIRS):
+            fpp = Path(fp)
+            dirs.append(fpp if fpp.is_absolute() else base / fpp)
+        candidates = [d / name for d in dirs]
+    denied: Path | None = None
+    for c in candidates:
+        if not c.exists():
+            continue
+        if gated and not is_path_allowed(c):
+            if denied is None:
+                denied = c.resolve()
+            continue
+        return c.resolve(), None
+    return None, denied
+
+
+def _osw_ref_issue(kind: str, name: str, denied: Path | None, osw: dict) -> str:
+    """Error text for an unresolvable OSW file reference."""
+    if denied is not None:
+        return (f"{kind} '{name}' resolves to {denied}, which is outside the "
+                "caller's allowed roots")
+    searched = list(osw.get("file_paths") or [])
+    return f"{kind} '{name}' not found (searched OSW dir + file_paths {searched})"
+
+
+def validate_osw(osw_path: str, epw_path: str | None = None,
+                 *, _gated: bool = True) -> dict[str, Any]:
     """
     Best-effort validation:
       - JSON parses
       - file exists
-      - seed_file (if relative) resolves
-      - weather_file (if relative) resolves
+      - seed_file resolves (OSW dir + file_paths search, like the CLI)
+      - weather_file resolves (same search)
+
+    `_gated=False` is the trusted internal path (run_simulation's server-built
+    temp OSW lives outside the caller's roots); not exposed via the MCP tool.
     """
     p = Path(osw_path)
     if not p.exists():
@@ -225,14 +282,14 @@ def validate_osw(osw_path: str, epw_path: str | None = None) -> dict[str, Any]:
             return {"ok": False, "error": f"EPW not found: {epw_path}"}
 
     if seed:
-        seed_path = (base / seed).resolve()
-        if not seed_path.exists():
-            issues.append(f"seed_file not found at {seed} (resolved: {seed_path})")
+        seed_hit, seed_denied = _resolve_osw_file(seed, base, osw, gated=_gated)
+        if seed_hit is None:
+            issues.append(_osw_ref_issue("seed_file", seed, seed_denied, osw))
 
     if weather:
-        weather_path = (base / weather).resolve()
-        if not weather_path.exists():
-            msg = f"weather_file not found at {weather} (resolved: {weather_path})"
+        weather_hit, weather_denied = _resolve_osw_file(weather, base, osw, gated=_gated)
+        if weather_hit is None:
+            msg = _osw_ref_issue("weather_file", weather, weather_denied, osw)
             if epw_override is None:
                 issues.append(msg)
             else:
@@ -462,7 +519,7 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None,
         return {"ok": False, "error": sym_err}
 
     # Fail fast on invalid OSW (before staging any run dir)
-    v = validate_osw(str(src_osw), epw_path=epw_path)
+    v = validate_osw(str(src_osw), epw_path=epw_path, _gated=not _internal)
     if not v.get("ok", False):
         return {
             "ok": False,
@@ -507,6 +564,36 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None,
             if seed_rel != Path(seed_rel).name:
                 osw["seed_file"] = Path(seed_rel).name
                 _dump_json(staged_osw, osw)
+        else:
+            # Not next to the OSW: resolve via the OSW file_paths search like
+            # the CLI does (issue #99), then stage into the run dir — the
+            # sandboxed CLI child can only read its own run dir, so leaving
+            # the external reference in place would fail under Landlock
+            # (issue #104 class). Absolute rewrite sidesteps search-path
+            # semantics in the staged workflow.
+            found, _denied = _resolve_osw_file(seed_rel, src_dir, osw,
+                                               gated=not _internal)
+            if found is not None:
+                seed_dst = run_dir / found.name
+                if not seed_dst.exists():
+                    shutil.copy2(found, seed_dst)
+                osw["seed_file"] = str(seed_dst)
+                _dump_json(staged_osw, osw)
+
+    # Same treatment for a weather_file resolved via file_paths (only when no
+    # EPW override — the override staging below wins and rewrites weather_file)
+    weather_rel = osw.get("weather_file")
+    if weather_rel and not epw_src and not (src_dir / weather_rel).resolve().exists():
+        found, _denied = _resolve_osw_file(weather_rel, src_dir, osw,
+                                           gated=not _internal)
+        if found is not None:
+            files_dir = run_dir / "files"
+            files_dir.mkdir(parents=True, exist_ok=True)
+            weather_dst = files_dir / found.name
+            if not weather_dst.exists():
+                shutil.copy2(found, weather_dst)
+            osw["weather_file"] = str(weather_dst)
+            _dump_json(staged_osw, osw)
 
     # If an EPW is provided, stage it into files/ and rewrite weather_file to match
     staged_epw: Path | None = None

--- a/mcp_server/skills/simulation/operations.py
+++ b/mcp_server/skills/simulation/operations.py
@@ -199,6 +199,17 @@ def _dump_json(path: Path, obj: dict[str, Any]) -> None:
 _OSW_DEFAULT_FILE_DIRS = ("files", "weather", ".")
 
 
+def _osw_file_paths(osw: dict) -> list:
+    """The OSW's file_paths as a list.
+
+    Caller-supplied JSON may put any type here — an int/bool would crash the
+    starred unpack, and a string would be iterated char-by-char into junk
+    search dirs. Non-lists are treated as absent.
+    """
+    fps = osw.get("file_paths")
+    return fps if isinstance(fps, list) else []
+
+
 def _resolve_osw_file(name: str, base: Path, osw: dict,
                       *, gated: bool = True) -> tuple[Path | None, Path | None]:
     """Resolve an OSW file reference the way the CLI's WorkflowJSON::findFile
@@ -220,8 +231,8 @@ def _resolve_osw_file(name: str, base: Path, osw: dict,
         candidates = [n]
     else:
         dirs = [base]
-        for fp in (*(osw.get("file_paths") or []), *_OSW_DEFAULT_FILE_DIRS):
-            fpp = Path(fp)
+        for fp in (*_osw_file_paths(osw), *_OSW_DEFAULT_FILE_DIRS):
+            fpp = Path(str(fp))  # entries may be non-strings in caller JSON
             dirs.append(fpp if fpp.is_absolute() else base / fpp)
         candidates = [d / name for d in dirs]
     denied: Path | None = None
@@ -241,7 +252,7 @@ def _osw_ref_issue(kind: str, name: str, denied: Path | None, osw: dict) -> str:
     if denied is not None:
         return (f"{kind} '{name}' resolves to {denied}, which is outside the "
                 "caller's allowed roots")
-    searched = list(osw.get("file_paths") or [])
+    searched = _osw_file_paths(osw)
     return f"{kind} '{name}' not found (searched OSW dir + file_paths {searched})"
 
 
@@ -271,6 +282,14 @@ def validate_osw(osw_path: str, epw_path: str | None = None,
     weather = osw.get("weather_file")
 
     issues: list[str] = []
+
+    # Caller-supplied JSON: non-string refs would crash Path() below
+    if seed is not None and not isinstance(seed, str):
+        issues.append(f"seed_file must be a string, got {type(seed).__name__}")
+        seed = None
+    if weather is not None and not isinstance(weather, str):
+        issues.append(f"weather_file must be a string, got {type(weather).__name__}")
+        weather = None
 
     # If an EPW override is provided, it must exist. When present, the OSW's
     # `weather_file` reference becomes optional (we may still report it as an
@@ -580,12 +599,24 @@ def run_osw(osw_path: str, epw_path: str | None = None, name: str | None = None,
                 osw["seed_file"] = str(seed_dst)
                 _dump_json(staged_osw, osw)
 
-    # Same treatment for a weather_file resolved via file_paths (only when no
-    # EPW override — the override staging below wins and rewrites weather_file)
+    # Stage a weather_file the sandboxed child couldn't read in place: refs
+    # resolving OUTSIDE the OSW dir (absolute path or ../ escape — _copy_tree
+    # mirrors only the OSW dir itself) plus refs that only resolve via the
+    # file_paths search. Staged copy gets an absolute rewrite. (PR #107
+    # review: the absolute-ref case validated but was never staged.) Skipped
+    # when an EPW override is present — the override staging below wins.
     weather_rel = osw.get("weather_file")
-    if weather_rel and not epw_src and not (src_dir / weather_rel).resolve().exists():
-        found, _denied = _resolve_osw_file(weather_rel, src_dir, osw,
-                                           gated=not _internal)
+    if weather_rel and isinstance(weather_rel, str) and not epw_src:
+        found: Path | None = None
+        w_direct = (src_dir / weather_rel).resolve()
+        if w_direct.exists():
+            inside_src = w_direct == src_dir or \
+                str(w_direct).startswith(str(src_dir) + os.sep)
+            if not inside_src and (_internal or is_path_allowed(w_direct)):
+                found = w_direct
+        else:
+            found, _denied = _resolve_osw_file(weather_rel, src_dir, osw,
+                                               gated=not _internal)
         if found is not None:
             files_dir = run_dir / "files"
             files_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_validate_osw.py
+++ b/tests/test_validate_osw.py
@@ -1,0 +1,276 @@
+"""validate_osw / run_osw honoring OSW file_paths (issue #99).
+
+Unit tests drive validate_osw directly (no OpenStudio import needed);
+integration tests prove run_osw stages file_paths-resolved seed/weather
+into the run dir so the sandboxed CLI child can read them.
+"""
+import asyncio
+import json
+import shutil
+import uuid
+from pathlib import Path
+
+import pytest
+from conftest import (
+    integration_enabled,
+    poll_until_done,
+    server_params,
+    unwrap,
+)
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+
+def _unique(prefix: str = "pytest_osw99") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+# EPW with companion .stat + .ddy (same source as test_weather.py)
+EPW_PATH = (
+    "/opt/comstock-measures/ChangeBuildingLocation"
+    "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+)
+EPW_NAME = "USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+
+
+# ---- Unit tests: validate_osw resolution semantics ----
+
+
+@pytest.fixture
+def allowed_root(tmp_path, monkeypatch):
+    """Scope is_path_allowed's run root to a temp dir (unit-tier config mock)."""
+    import mcp_server.config as config
+    root = tmp_path / "runs"
+    root.mkdir()
+    monkeypatch.setattr(config, "RUN_ROOT", root)
+    return root
+
+
+@pytest.mark.unit
+def test_validate_osw_honors_absolute_file_paths(allowed_root):
+    # Regression: issue #99 — validator resolved seed/weather only against the
+    # OSW dir, rejecting workflows the CLI runs via file_paths search
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    assets = allowed_root / "assets"
+    assets.mkdir()
+    (assets / "seed.osm").touch()
+    (assets / "weather.epw").touch()
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "seed.osm",
+        "weather_file": "weather.epw",
+        "file_paths": [str(assets)],
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is True, f"CLI-runnable OSW rejected: {result['issues']}"
+    assert result["issues"] == []
+
+
+@pytest.mark.unit
+def test_validate_osw_honors_relative_file_paths(allowed_root):
+    # Regression: issue #99 — relative file_paths entries resolve against the
+    # OSW dir (WorkflowJSON::findFile semantics), not the server cwd
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    assets = allowed_root / "assets"
+    assets.mkdir()
+    (assets / "seed.osm").touch()
+    (assets / "weather.epw").touch()
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "seed.osm",
+        "weather_file": "weather.epw",
+        "file_paths": ["../assets"],
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is True, f"relative file_paths entry ignored: {result['issues']}"
+
+
+@pytest.mark.unit
+def test_validate_osw_resolves_subdir_reference_via_file_paths(allowed_root):
+    # Validates: findFile appends the WHOLE relative reference to each search
+    # dir (models/seed.osm), not just the basename
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    assets = allowed_root / "assets"
+    (assets / "models").mkdir(parents=True)
+    (assets / "models" / "seed.osm").touch()
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "models/seed.osm",
+        "file_paths": [str(assets)],
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is True, f"subdir reference not searched via file_paths: {result['issues']}"
+
+
+@pytest.mark.unit
+def test_validate_osw_missing_file_reports_search_dirs(allowed_root):
+    # Validates: a genuinely-missing seed still fails, and the message names the
+    # file_paths search list instead of one misleading resolved path
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "nope.osm",
+        "file_paths": ["/does/not/exist"],
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is False
+    joined = " ".join(result["issues"])
+    assert "nope.osm" in joined
+    assert "/does/not/exist" in joined, \
+        f"error should name the searched file_paths, got: {joined}"
+
+
+@pytest.mark.unit
+def test_validate_osw_denied_file_paths_hit_flagged(allowed_root, tmp_path):
+    # Validates: a file_paths entry outside the caller's allowed roots is not
+    # silently used — file_paths is caller-controlled OSW content and hits get
+    # staged by the root server (same read-primitive class as issue #104)
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "seed.osm").touch()
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "seed.osm",
+        "file_paths": [str(outside)],
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is False
+    joined = " ".join(result["issues"])
+    assert "outside" in joined and "allowed" in joined, \
+        f"denied file_paths hit should be flagged explicitly, got: {joined}"
+
+
+@pytest.mark.unit
+def test_validate_osw_relative_escape_seed_denied(allowed_root, tmp_path):
+    # Validates: a seed_file escaping the OSW dir via ../ to a path outside
+    # allowed roots is rejected — previously it validated (exists-check only)
+    # and run_osw staged it root-privileged into the caller-readable run dir
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.osm").touch()
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "../../outside/secret.osm",
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is False
+    joined = " ".join(result["issues"])
+    assert "allowed" in joined, \
+        f"escaping seed_file should be denied, got: {joined}"
+
+
+# ---- Integration tests: run_osw stages file_paths-resolved files ----
+
+
+@pytest.mark.integration
+def test_run_osw_stages_file_paths_seed_and_weather():
+    """OSW with seed+EPW on an external file_paths dir runs to success."""
+    # Regression: issue #99 — run_osw refused CLI-runnable OSWs; and even past
+    # validation the sandboxed CLI child can't read external dirs, so the
+    # resolved files must be staged into the run dir (issue #104 pattern)
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                # Assets dir under the caller's run root, separate from OSW dir
+                assets = Path(f"/runs/{_unique('osw99_assets')}")
+                assets.mkdir(parents=True)
+                cr = unwrap(await s.call_tool("create_example_osm", {"name": _unique()}))
+                assert cr["ok"] is True, cr
+                lr = unwrap(await s.call_tool("load_osm_model", {"osm_path": cr["osm_path"]}))
+                assert lr["ok"] is True, lr
+                wr = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": EPW_PATH,
+                }))
+                assert wr["ok"] is True, f"change_building_location failed: {wr.get('error')}"
+                rp = unwrap(await s.call_tool("set_run_period", {
+                    "begin_month": 7, "begin_day": 20, "end_month": 7, "end_day": 22,
+                }))
+                assert rp["ok"] is True, rp
+                sv = unwrap(await s.call_tool("save_osm_model", {
+                    "osm_path": str(assets / "seed_model.osm"),
+                }))
+                assert sv["ok"] is True, sv
+                shutil.copy2(EPW_PATH, str(assets / EPW_NAME))
+
+                wf_dir = Path(f"/runs/{_unique('osw99_wf')}")
+                wf_dir.mkdir(parents=True)
+                osw_path = wf_dir / "workflow.osw"
+                osw_path.write_text(json.dumps({
+                    "seed_file": "seed_model.osm",
+                    "weather_file": EPW_NAME,
+                    "file_paths": [str(assets)],
+                    "steps": [],
+                }))
+
+                res = unwrap(await s.call_tool("run_osw", {"osw_path": str(osw_path)}))
+                assert res["ok"] is True, \
+                    f"run_osw rejected CLI-runnable OSW: {res.get('error')} {res.get('issues')}"
+
+                run_dir = Path(res["run_dir"])
+                assert (run_dir / "seed_model.osm").is_file(), \
+                    "file_paths-resolved seed not staged into run dir"
+                assert (run_dir / "files" / EPW_NAME).is_file(), \
+                    "file_paths-resolved weather not staged into run files/"
+
+                status = await poll_until_done(s, res["run_id"])
+                assert status["run"]["status"] == "success", \
+                    f"staged file_paths workflow should simulate: {status}"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_run_osw_denied_file_paths_clean_error():
+    """file_paths pointing outside allowed roots fails with a clear message."""
+    # Validates: caller-controlled file_paths can't make the root server stage
+    # host files (/etc) into the caller-readable run dir; error names the issue
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                wf_dir = Path(f"/runs/{_unique('osw99_denied')}")
+                wf_dir.mkdir(parents=True)
+                osw_path = wf_dir / "workflow.osw"
+                osw_path.write_text(json.dumps({
+                    "seed_file": "passwd",
+                    "file_paths": ["/etc"],
+                    "steps": [],
+                }))
+                res = unwrap(await s.call_tool("run_osw", {"osw_path": str(osw_path)}))
+                assert res["ok"] is False
+                joined = " ".join(res.get("issues") or [])
+                assert "allowed" in joined, \
+                    f"denied file_paths hit should be flagged, got: {res}"
+    asyncio.run(_run())

--- a/tests/test_validate_osw.py
+++ b/tests/test_validate_osw.py
@@ -162,6 +162,27 @@ def test_validate_osw_denied_file_paths_hit_flagged(allowed_root, tmp_path):
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("bad_file_paths", [5, True, {"a": 1}, "not-a-list"])
+def test_validate_osw_malformed_file_paths_no_crash(allowed_root, bad_file_paths):
+    # Regression: PR #107 review — non-list file_paths (caller-supplied OSW
+    # JSON) crashed _resolve_osw_file with TypeError instead of returning
+    # ok: False; a JSON string would be iterated char-by-char as junk dirs
+    from mcp_server.skills.simulation.operations import validate_osw
+
+    wf_dir = allowed_root / "wf"
+    wf_dir.mkdir()
+    osw = wf_dir / "workflow.osw"
+    osw.write_text(json.dumps({
+        "seed_file": "nope.osm",
+        "file_paths": bad_file_paths,
+        "steps": [],
+    }))
+    result = validate_osw(str(osw))
+    assert result["ok"] is False
+    assert "nope.osm" in " ".join(result["issues"])
+
+
+@pytest.mark.unit
 def test_validate_osw_relative_escape_seed_denied(allowed_root, tmp_path):
     # Validates: a seed_file escaping the OSW dir via ../ to a path outside
     # allowed roots is rejected — previously it validated (exists-check only)
@@ -245,6 +266,60 @@ def test_run_osw_stages_file_paths_seed_and_weather():
                 status = await poll_until_done(s, res["run_id"])
                 assert status["run"]["status"] == "success", \
                     f"staged file_paths workflow should simulate: {status}"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_run_osw_stages_absolute_weather_file():
+    """OSW weather_file given as an absolute external path runs to success."""
+    # Regression: PR #107 review — an absolute weather_file validated but was
+    # never staged (staging only covered file_paths-search hits), so the
+    # Landlocked CLI child couldn't read it and the sim failed at runtime
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                assets = Path(f"/runs/{_unique('osw99_abs')}")
+                assets.mkdir(parents=True)
+                cr = unwrap(await s.call_tool("create_example_osm", {"name": _unique()}))
+                assert cr["ok"] is True, cr
+                lr = unwrap(await s.call_tool("load_osm_model", {"osm_path": cr["osm_path"]}))
+                assert lr["ok"] is True, lr
+                wr = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": EPW_PATH,
+                }))
+                assert wr["ok"] is True, wr.get("error")
+                rp = unwrap(await s.call_tool("set_run_period", {
+                    "begin_month": 7, "begin_day": 20, "end_month": 7, "end_day": 22,
+                }))
+                assert rp["ok"] is True, rp
+                sv = unwrap(await s.call_tool("save_osm_model", {
+                    "osm_path": str(assets / "seed_model.osm"),
+                }))
+                assert sv["ok"] is True, sv
+                shutil.copy2(EPW_PATH, str(assets / EPW_NAME))
+
+                wf_dir = Path(f"/runs/{_unique('osw99_abs_wf')}")
+                wf_dir.mkdir(parents=True)
+                osw_path = wf_dir / "workflow.osw"
+                osw_path.write_text(json.dumps({
+                    "seed_file": str(assets / "seed_model.osm"),
+                    "weather_file": str(assets / EPW_NAME),
+                    "steps": [],
+                }))
+
+                res = unwrap(await s.call_tool("run_osw", {"osw_path": str(osw_path)}))
+                assert res["ok"] is True, \
+                    f"run_osw rejected absolute-ref OSW: {res.get('error')} {res.get('issues')}"
+                run_dir = Path(res["run_dir"])
+                assert (run_dir / "files" / EPW_NAME).is_file(), \
+                    "absolute weather_file not staged into run files/"
+                status = await poll_until_done(s, res["run_id"])
+                assert status["run"]["status"] == "success", \
+                    f"absolute weather_file workflow should simulate: {status}"
     asyncio.run(_run())
 
 


### PR DESCRIPTION
Fixes #99.

## Resolution semantics
New `_resolve_osw_file` mirrors the CLI's `WorkflowJSON::findFile`: absolute as-is, else the **whole relative reference** appended to the OSW dir, each `file_paths` entry (relative entries resolved against the OSW dir), and the default search dirs (`files`, `weather`, `.`). Two deliberate deviations from the issue's sketch:
- whole relative reference (`models/seed.osm`), not basename — matches `findFile`
- defaults are searched as a **union** with explicit `file_paths` — laxer than the CLI in edge cases, but the bug being fixed is false *rejection*; staging closes any runtime gap

`validate_osw` no longer rejects CLI-runnable workflows, and its errors name the searched roots (or the denied hit) instead of one misleading resolved path.

## Staging (the half the issue didn't cover)
Validation alone is insufficient under the sandbox: the Landlocked CLI child reads only its own run dir, so a seed/EPW on an external `file_paths` dir would validate and then fail at runtime with the exact #104 failure (the issue's "CLI accepts it" evidence came from an unsandboxed `docker exec`). `run_osw` now stages file_paths-resolved seed (run dir root) and weather (`files/`) with absolute rewrites in the staged OSW.

## Security
`file_paths` is caller-controlled OSW content and hits are staged root-privileged, so the resolver gates every candidate via `is_path_allowed` (denied hits produce an explicit "outside the caller's allowed roots" issue). This incidentally closes a **pre-existing** hole: `seed_file: \"../../../etc/passwd\"` previously validated (exists-check only) and was staged into the caller-readable run dir. `run_simulation`'s internal temp OSW passes `_gated=False` (inputs pre-validated, temp dir outside caller roots).

Not addressed (follow-up candidates): steps' `measure_dir_name` vs `measure_paths` is still unvalidated and external `measure_paths` are not staged; the public `validate_osw` tool still accepts arbitrary `osw_path` for its existence checks.

## Tests
8 in new `tests/test_validate_osw.py`, added to CI shard 4 (lightest at 7m15s):
- 5 unit, red-green verified (absolute/relative/subdir file_paths, search-dirs message, denied-hit flagged)
- 1 unit hardening lock-in (`../`-escape seed denied)
- 2 integration: e2e `run_osw` with seed+EPW on an external `file_paths` dir runs to **success** under the sandbox (proves staging, not just validation); denied `file_paths` (`/etc`) fails with a clear message

Regression sweep green: 87 passed (SEB4 EUI workflow, sim queue, stdio smoke, weather incl. #104 tests, path safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)