### PR TITLE
hvac_only standards-tuned HVAC swap for fair system sweeps (addresses #97)

### DIFF
--- a/.claude/skills/add-hvac/SKILL.md
+++ b/.claude/skills/add-hvac/SKILL.md
@@ -59,6 +59,23 @@ search_wiring_patterns("DOAS")                     # get working Ruby wiring cod
 search_api("CoilCoolingFourPipeBeam")              # verify SDK method names
 ```
 
+## Comparing Systems / Decision-Grade Results
+
+The generic templates above (add_baseline_system, add_doas_system, add_vrf_system)
+are wiring templates — no standards efficiency tuning or availability-manager
+coordination. For comparative studies or decision-grade EUI/comfort numbers, use
+the standards-tuned path instead:
+
+```
+# Replace ONLY the HVAC on an already-configured model — loads, constructions,
+# schedules, thermostats preserved. One call per candidate system:
+create_typical_building(system_type="PVAV with gas boiler reheat",
+    template="90.1-2019", climate_zone="ASHRAE 169-2013-5A", hvac_only=True)
+save_osm_model(...); run_simulation(...)   # then next candidate
+
+compare_runs(run_id_a, run_id_b)           # EUI + unmet-hours deltas
+```
+
 ## Notes
 
 - Get all zone names from `list_thermal_zones()` — names must match exactly

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -61,6 +61,31 @@ list_files()                              # find available weather files
 change_building_location(weather_file="/inputs/Chicago.epw")
 ```
 
+## Fair HVAC System Sweep (decision-grade comparison)
+
+Compare candidate systems on the SAME configured model — standards-tuned
+equipment/controls each time, loads and schedules never touched:
+
+```
+# One-time setup: geometry + weather + typical build + any load customizations
+create_bar_building(...); change_building_location(...)
+create_typical_building(template="90.1-2019", climate_zone="ASHRAE 169-2013-5A")
+# ... apply load reductions, setbacks, etc. ...
+
+# Per candidate: swap ONLY the HVAC, simulate, compare
+create_typical_building(system_type="PVAV with gas boiler reheat",
+    template="90.1-2019", climate_zone="ASHRAE 169-2013-5A", hvac_only=True)
+save_osm_model(osm_path="/runs/sweep_pvav.osm"); run_simulation(...)
+
+create_typical_building(system_type="PSZ-HP", ..., hvac_only=True)
+save_osm_model(osm_path="/runs/sweep_pszhp.osm"); run_simulation(...)
+
+compare_runs(run_id_a, run_id_b)          # EUI + unmet-hours deltas
+```
+
+Do NOT use add_baseline_system/add_doas_system for comparative studies — they
+are generic wiring templates without standards tuning (see add-hvac skill).
+
 ## Tune Component Properties
 
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,8 @@ jobs:
             4)
               # vrf, radiant, query skills, creation, air terminals, results extraction
               # + gbxml_import (Revit gbXML -> OSM via gbxml-to-openstudio measures)
-              FILES="tests/test_vrf_system.py tests/test_radiant_system.py tests/test_loads.py tests/test_spaces.py tests/test_space_types.py tests/test_schedules.py tests/test_constructions.py tests/test_create_space.py tests/test_create_thermal_zone.py tests/test_add_air_loop.py tests/test_create_schedule_ruleset.py tests/test_add_output_variable.py tests/test_add_output_meter.py tests/test_load_save_model.py tests/test_versions.py tests/test_create_example_osm.py tests/test_inspect_osm_summary.py tests/test_copy_file.py tests/test_replace_air_terminals.py tests/test_results_extraction.py tests/test_swig_memleak_cleanup.py tests/test_skill_tools_integration.py tests/test_stdio_smoke.py tests/test_response_sizes.py tests/test_response_guard.py tests/test_gbxml_import.py"
+              # + hvac_only standards swap parity benchmark (issue #97)
+              FILES="tests/test_vrf_system.py tests/test_radiant_system.py tests/test_loads.py tests/test_spaces.py tests/test_space_types.py tests/test_schedules.py tests/test_constructions.py tests/test_create_space.py tests/test_create_thermal_zone.py tests/test_add_air_loop.py tests/test_create_schedule_ruleset.py tests/test_add_output_variable.py tests/test_add_output_meter.py tests/test_load_save_model.py tests/test_versions.py tests/test_create_example_osm.py tests/test_inspect_osm_summary.py tests/test_copy_file.py tests/test_replace_air_terminals.py tests/test_results_extraction.py tests/test_swig_memleak_cleanup.py tests/test_skill_tools_integration.py tests/test_stdio_smoke.py tests/test_response_sizes.py tests/test_response_guard.py tests/test_gbxml_import.py tests/test_hvac_only_swap.py"
               EXTRA_ENV=""
               ;;
             5)

--- a/mcp_server/skills/common_measures/wrappers.py
+++ b/mcp_server/skills/common_measures/wrappers.py
@@ -320,34 +320,13 @@ def change_building_location_op(
         weather_file: Absolute path to .epw file (must have .stat + .ddy alongside)
         climate_zone: ASHRAE climate zone or "Lookup From Stat File" for auto-detect
     """
-    result = _run("ChangeBuildingLocation", {
+    # Portable weather url (bare filename) is applied generally by
+    # apply_measure's post-reload step — the result carries `weather_url`
+    # when the reference is portable (see weather.make_weather_url_portable).
+    return _run("ChangeBuildingLocation", {
         "weather_file_name": weather_file,
         "climate_zone": climate_zone,
     })
-    if result.get("ok"):
-        _make_weather_url_portable(result)
-    return result
-
-
-def _make_weather_url_portable(result: dict[str, Any]) -> None:
-    """Rewrite the model's OS:WeatherFile url to the bare EPW filename.
-
-    The measure records the staged run-dir path, which resolves only inside
-    this container (issue #104, secondary). The bare filename is the portable
-    OSM convention: a host OpenStudio App resolves it via the model's
-    companion files/ dir, and run_simulation re-resolves it against known
-    weather dirs at sim time.
-    """
-    from mcp_server.model_manager import get_model
-    try:
-        model = get_model()
-        wf = model.weatherFile()
-        if wf.is_initialized() and wf.get().makeUrlRelative():
-            url = wf.get().url()
-            if url.is_initialized():
-                result["weather_url"] = str(url.get())
-    except Exception as e:  # measure succeeded — don't fail the tool on cleanup
-        result["weather_url_error"] = str(e)
 
 
 # ===================================================================

--- a/mcp_server/skills/comstock/operations.py
+++ b/mcp_server/skills/comstock/operations.py
@@ -190,8 +190,9 @@ def create_typical_building(
         remove_objects: Remove existing objects of the types being added
         hvac_only: Replace ONLY the HVAC system (standards-tuned), preserving
             loads, constructions, schedules, and thermostats — for fair system
-            comparisons on an already-configured model. Overrides the add_*
-            toggles and remove_objects.
+            comparisons on an already-configured model. Overrides every add_*
+            toggle AND forces remove_objects=True (the existing HVAC is
+            removed before the new system is added).
     """
     measures_dir = Path(os.environ.get("COMSTOCK_MEASURES_DIR", "/opt/comstock-measures"))
     measure_path = measures_dir / "create_typical_building_from_model"

--- a/mcp_server/skills/comstock/operations.py
+++ b/mcp_server/skills/comstock/operations.py
@@ -111,7 +111,29 @@ _TYPICAL_ARG_MAP = {
     "add_swh": "add_swh",
     "add_exterior_lights": "add_exterior_lights",
     "add_thermostat": "add_thermostat",
+    "add_elevators": "add_elevators",
+    "add_internal_mass": "add_internal_mass",
+    "add_exhaust": "add_exhaust",
+    "add_refrigeration": "add_refrigeration",
     "remove_objects": "remove_objects",
+}
+
+# The measure's remove_objects is per-section ("Only removes objects of type
+# that are selected to be added"), so pinning every section off except HVAC
+# yields a standards-tuned HVAC swap that leaves loads, constructions,
+# schedules, and thermostats untouched (issue #97 — fair system sweeps).
+_HVAC_ONLY_PINS = {
+    "add_constructions": False,
+    "add_space_type_loads": False,
+    "add_swh": False,
+    "add_exterior_lights": False,
+    "add_thermostat": False,
+    "add_elevators": False,
+    "add_internal_mass": False,
+    "add_exhaust": False,
+    "add_refrigeration": False,
+    "add_hvac": True,
+    "remove_objects": True,
 }
 
 
@@ -129,7 +151,12 @@ def create_typical_building(
     add_swh: bool = True,
     add_exterior_lights: bool = True,
     add_thermostat: bool = True,
+    add_elevators: bool = True,
+    add_internal_mass: bool = True,
+    add_exhaust: bool = True,
+    add_refrigeration: bool = True,
     remove_objects: bool = True,
+    hvac_only: bool = False,
 ) -> dict[str, Any]:
     """Create a typical building from the loaded model using ComStock measure.
 
@@ -156,7 +183,15 @@ def create_typical_building(
         add_swh: Add service water heating
         add_exterior_lights: Add exterior lighting
         add_thermostat: Add thermostat schedules
-        remove_objects: Remove existing objects before adding new ones
+        add_elevators: Add elevators
+        add_internal_mass: Add internal mass
+        add_exhaust: Add exhaust fans
+        add_refrigeration: Add refrigeration
+        remove_objects: Remove existing objects of the types being added
+        hvac_only: Replace ONLY the HVAC system (standards-tuned), preserving
+            loads, constructions, schedules, and thermostats — for fair system
+            comparisons on an already-configured model. Overrides the add_*
+            toggles and remove_objects.
     """
     measures_dir = Path(os.environ.get("COMSTOCK_MEASURES_DIR", "/opt/comstock-measures"))
     measure_path = measures_dir / "create_typical_building_from_model"
@@ -211,8 +246,14 @@ def create_typical_building(
         "add_swh": add_swh,
         "add_exterior_lights": add_exterior_lights,
         "add_thermostat": add_thermostat,
+        "add_elevators": add_elevators,
+        "add_internal_mass": add_internal_mass,
+        "add_exhaust": add_exhaust,
+        "add_refrigeration": add_refrigeration,
         "remove_objects": remove_objects,
     }
+    if hvac_only:
+        local_vars.update(_HVAC_ONLY_PINS)
     arguments = {}
     for py_name, measure_name in _TYPICAL_ARG_MAP.items():
         val = local_vars[py_name]
@@ -233,6 +274,8 @@ def create_typical_building(
         result["template"] = template
         result["system_type"] = system_type
         result["climate_zone"] = climate_zone
+        if hvac_only:
+            result["hvac_only"] = True
 
     return result
 

--- a/mcp_server/skills/comstock/tools.py
+++ b/mcp_server/skills/comstock/tools.py
@@ -136,7 +136,8 @@ def register(mcp):
             add_exhaust: Add exhaust fans
             add_refrigeration: Add refrigeration
             remove_objects: Remove existing objects of the types being added
-            hvac_only: Replace ONLY the HVAC system; overrides add_* toggles
+            hvac_only: Replace ONLY the HVAC system; overrides every add_*
+                toggle AND forces remove_objects=True (existing HVAC removed)
 
         """
         return create_typical_building(

--- a/mcp_server/skills/comstock/tools.py
+++ b/mcp_server/skills/comstock/tools.py
@@ -97,13 +97,23 @@ def register(mcp):
         add_swh: bool = True,
         add_exterior_lights: bool = True,
         add_thermostat: bool = True,
+        add_elevators: bool = True,
+        add_internal_mass: bool = True,
+        add_exhaust: bool = True,
+        add_refrigeration: bool = True,
         remove_objects: bool = True,
+        hvac_only: bool = False,
     ):
         """Apply 90.1 template: constructions, loads, HVAC, SWH to model with geometry.
 
         Adds constructions, loads, HVAC, schedules, and service water heating
         to a model that already has geometry and space types assigned.
         Wraps the ComStock create_typical_building_from_model measure.
+
+        For fair HVAC system comparisons on an already-configured model, use
+        hvac_only=True with an explicit system_type — replaces just the HVAC
+        (standards-tuned equipment, efficiencies, and controls) and preserves
+        loads, constructions, schedules, and thermostats.
 
         Args:
             template: ASHRAE standard — "90.1-2019", "90.1-2016", "90.1-2013", etc.
@@ -121,7 +131,12 @@ def register(mcp):
             add_swh: Add service water heating
             add_exterior_lights: Add exterior lighting
             add_thermostat: Add thermostat schedules
-            remove_objects: Remove existing HVAC/loads before adding new ones
+            add_elevators: Add elevators
+            add_internal_mass: Add internal mass
+            add_exhaust: Add exhaust fans
+            add_refrigeration: Add refrigeration
+            remove_objects: Remove existing objects of the types being added
+            hvac_only: Replace ONLY the HVAC system; overrides add_* toggles
 
         """
         return create_typical_building(
@@ -138,7 +153,12 @@ def register(mcp):
             add_swh=add_swh,
             add_exterior_lights=add_exterior_lights,
             add_thermostat=add_thermostat,
+            add_elevators=add_elevators,
+            add_internal_mass=add_internal_mass,
+            add_exhaust=add_exhaust,
+            add_refrigeration=add_refrigeration,
             remove_objects=remove_objects,
+            hvac_only=hvac_only,
         )
 
     @mcp.tool(tags={"core"}, name="create_new_building")

--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -684,6 +684,22 @@ def list_measure_arguments(measure_dir: str) -> dict[str, Any]:
         return {"ok": False, "error": f"Failed to list measure arguments: {e}"}
 
 
+def _attach_portable_weather_url(result: dict[str, Any]) -> None:
+    """Post-reload step: record a portable weather url on the result.
+
+    Never raises: the measure already succeeded and the model reloaded — a
+    failure in this cleanup (OpenStudio API RuntimeError) must not flip the
+    tool result to ok=False (PR #108 review). Failures are surfaced as
+    `weather_url_error` instead.
+    """
+    try:
+        portable = make_weather_url_portable(get_model())
+        if portable is not None:
+            result["weather_url"] = portable
+    except Exception as e:
+        result["weather_url_error"] = str(e)
+
+
 def apply_measure(
     measure_dir: str,
     arguments: dict[str, Any] | None = None,
@@ -922,9 +938,7 @@ def apply_measure(
         # future confined run can't read (issue #104 class). Custom EPWs with
         # unfindable basenames keep the absolute url — tier 1 staging above
         # handles those per-run instead.
-        portable = make_weather_url_portable(get_model())
-        if portable is not None:
-            result["weather_url"] = portable
+        _attach_portable_weather_url(result)
 
         if runner_messages:
             result["runner_messages"] = runner_messages

--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -37,7 +37,7 @@ from mcp_server.config import (
 from mcp_server.model_manager import get_model, load_model
 from mcp_server.skills.measures.osw_weather import resolve_osw_weather, stage_epw_into_run
 from mcp_server.skills.measures.runner_messages import parse_runner_messages
-from mcp_server.skills.weather.operations import find_epw_by_name
+from mcp_server.skills.weather.operations import find_epw_by_name, make_weather_url_portable
 from mcp_server.util import create_run_dir, reject_escaping_symlinks, resolve_run_dir
 
 
@@ -915,6 +915,16 @@ def apply_measure(
                     "model weather reference was unresolvable; removed for the "
                     "measures_only run and restored afterward"
                 )
+
+        # Make the weather reference portable when recoverable: the runner
+        # writes the staged absolute EPW path (this run's files/) into the
+        # output model, which points later tools at a container path that a
+        # future confined run can't read (issue #104 class). Custom EPWs with
+        # unfindable basenames keep the absolute url — tier 1 staging above
+        # handles those per-run instead.
+        portable = make_weather_url_portable(get_model())
+        if portable is not None:
+            result["weather_url"] = portable
 
         if runner_messages:
             result["runner_messages"] = runner_messages

--- a/mcp_server/skills/measures/osw_weather.py
+++ b/mcp_server/skills/measures/osw_weather.py
@@ -20,6 +20,7 @@ from typing import Any
 
 import openstudio
 
+from mcp_server.config import is_path_allowed
 from mcp_server.skills.weather.operations import find_epw_by_name
 
 
@@ -41,11 +42,15 @@ def resolve_osw_weather(model: Any, run_dir: Path, temp_osm: Path) -> dict[str, 
     epw = Path(str(url.get()))
 
     # Tier 1: url already resolves (absolute path still valid on this
-    # machine). resolve() so a url relative to the server cwd doesn't
-    # produce a relative file_paths entry — the runner executes with
-    # cwd=run_dir and would resolve it against the wrong base
-    if epw.is_file():
-        out["file_paths"].append(str(epw.resolve().parent))
+    # machine). Stage it into the run dir instead of granting the parent via
+    # file_paths: the confined subprocess reads only its own run dir, so an
+    # absolute url into another run's files/ or /inputs is unreadable there
+    # even though the server resolves it (issue #104 class; surfaced again in
+    # issue #97 as a bogus "Windows path length" error from the standards
+    # sizing-run rescue). Gated: the url is caller-controlled model content —
+    # never point the root server's copy at a path outside allowed roots.
+    if epw.is_file() and is_path_allowed(epw):
+        out["weather_file"] = stage_epw_into_run(epw.resolve(), run_dir)
         return out
 
     # Tier 2: bare/stale name — look in known weather dirs, stage like run_osw

--- a/mcp_server/skills/weather/operations.py
+++ b/mcp_server/skills/weather/operations.py
@@ -188,6 +188,38 @@ def find_epw_by_name(basename: str) -> Path | None:
     return None
 
 
+def make_weather_url_portable(model: Any) -> str | None:
+    """Rewrite the model's OS:WeatherFile url to the bare EPW filename.
+
+    Bare filename is the portable OSM convention (issue #104 secondary): a
+    host OpenStudio App resolves it via the model's companion files/ dir and
+    the server re-resolves it via find_epw_by_name. Only rewrites when the
+    basename IS findable in the known weather dirs — relativizing a custom
+    EPW that lives only in a run dir would strand the reference (nothing
+    could resolve it afterwards), so those keep their absolute url.
+
+    Returns the bare url when the reference is portable (rewritten now or
+    already bare), else None (unchanged).
+    """
+    wf = model.weatherFile()
+    if not wf.is_initialized():
+        return None
+    url = wf.get().path()
+    if not url.is_initialized():
+        return None
+    raw = str(url.get())
+    p = Path(raw)
+    if p.name == raw:
+        return raw  # already bare
+    if find_epw_by_name(p.name) is None:
+        return None
+    if wf.get().makeUrlRelative():
+        rewritten = wf.get().url()
+        if rewritten.is_initialized():
+            return str(rewritten.get())
+    return None
+
+
 def resolve_model_weather_epw(osm_path: Path) -> Path | None:
     """Resolve a saved OSM's OS:WeatherFile url to a readable EPW, or None.
 

--- a/tests/test_hvac_only_swap.py
+++ b/tests/test_hvac_only_swap.py
@@ -1,0 +1,148 @@
+"""hvac_only HVAC swap on create_typical_building (issue #97).
+
+Proves the standards-tuned HVAC-only replacement path: swapping systems on an
+already-configured model must preserve loads and produce results equivalent to
+building the model fresh with that system_type (the sanctioned full path).
+
+Dev benchmark (2026-07-28, 10k ft2 SmallOffice bar, Boston 5A, 90.1-2019,
+PVAV with gas boiler reheat): full build vs Inferred+swap were identical to
+0.007% site energy (746.74 vs 746.79 GJ) with unmet heating 343.67 in both.
+"""
+import asyncio
+import time
+import uuid
+
+import pytest
+from conftest import integration_enabled, server_params, unwrap
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+EPW = ("/opt/comstock-measures/ChangeBuildingLocation"
+       "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
+SYSTEM = "PVAV with gas boiler reheat"
+TEMPLATE = "90.1-2019"
+CZ = "ASHRAE 169-2013-5A"
+
+
+def _unique(prefix: str = "pytest_hvaconly") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+async def _build_bar(s):
+    bar = unwrap(await s.call_tool("create_bar_building", {
+        "building_type": "SmallOffice", "climate_zone": "5A"}))
+    assert bar["ok"] is True, f"create_bar failed: {bar.get('error')}"
+    wr = unwrap(await s.call_tool("change_building_location", {"weather_file": EPW}))
+    assert wr["ok"] is True, f"change_building_location failed: {wr.get('error')}"
+
+
+async def _lights_snapshot(s):
+    objs = unwrap(await s.call_tool("list_model_objects", {
+        "object_type": "Lights", "max_results": 0}))
+    assert objs["ok"] is True, objs
+    snapshot = {}
+    for o in objs["objects"]:
+        det = unwrap(await s.call_tool("get_load_details", {"load_name": o["name"]}))
+        assert det["ok"] is True, det
+        snapshot[o["name"]] = det
+    return snapshot
+
+
+async def _sim_metrics(s, name):
+    sv = unwrap(await s.call_tool("save_osm_model", {"osm_path": f"/runs/{name}.osm"}))
+    assert sv["ok"] is True, sv
+    sim = unwrap(await s.call_tool("run_simulation", {"osm_path": f"/runs/{name}.osm"}))
+    assert sim["ok"] is True, f"run_simulation failed: {sim.get('error')}"
+    t0 = time.time()
+    while True:
+        st = unwrap(await s.call_tool("get_run_status", {"run_id": sim["run_id"]}))
+        state = (st.get("run", {}).get("status") or "?").lower()
+        if state in ("success", "failed", "error", "cancelled"):
+            break
+        assert time.time() - t0 < 1200, "simulation timed out"
+        await asyncio.sleep(3)
+    assert state == "success", f"simulation failed: {st}"
+    m = unwrap(await s.call_tool("extract_summary_metrics", {"run_id": sim["run_id"]}))
+    assert m["ok"] is True, m
+    return m["metrics"]
+
+
+@pytest.mark.integration
+def test_hvac_only_swap_matches_full_build():
+    """Inferred build + hvac_only swap == full build with explicit system_type."""
+    # Regression: issue #97 — HVAC system sweeps needed a load-preserving,
+    # standards-tuned swap; generic add_* templates gave non-decision-grade
+    # results (718-953 unmet hrs) and full re-typical wiped custom loads.
+    # Parity with the full build proves the swap path loses nothing.
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        # Arm A (control): full typical straight to the target system
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _build_bar(s)
+                typ = unwrap(await s.call_tool("create_typical_building", {
+                    "template": TEMPLATE, "climate_zone": CZ,
+                    "system_type": SYSTEM}))
+                assert typ["ok"] is True, f"full build failed: {typ.get('error')}"
+                control_metrics = await _sim_metrics(s, _unique("ctl"))
+
+        # Arm B: full typical (Inferred) then hvac_only swap to the target
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _build_bar(s)
+                typ = unwrap(await s.call_tool("create_typical_building", {
+                    "template": TEMPLATE, "climate_zone": CZ}))
+                assert typ["ok"] is True, f"inferred build failed: {typ.get('error')}"
+                lights_before = await _lights_snapshot(s)
+                summary_before = unwrap(await s.call_tool("get_model_summary", {}))["summary"]
+
+                swap = unwrap(await s.call_tool("create_typical_building", {
+                    "template": TEMPLATE, "climate_zone": CZ,
+                    "system_type": SYSTEM, "hvac_only": True}))
+                assert swap["ok"] is True, f"hvac_only swap failed: {swap.get('error')}"
+                assert swap["hvac_only"] is True
+
+                # Loads, constructions, geometry untouched — exact values
+                lights_after = await _lights_snapshot(s)
+                assert lights_after == lights_before, (
+                    "hvac_only swap must not touch lighting loads:\n"
+                    f"before={lights_before}\nafter={lights_after}"
+                )
+                summary_after = unwrap(await s.call_tool("get_model_summary", {}))["summary"]
+                for key in ("people", "lights", "electric_equipment", "constructions",
+                            "materials", "spaces", "thermal_zones", "surfaces"):
+                    assert summary_after[key] == summary_before[key], (
+                        f"hvac_only swap changed {key}: "
+                        f"{summary_before[key]} -> {summary_after[key]}"
+                    )
+
+                # HVAC actually replaced: 9 PSZ-AC loops -> 1 multizone PVAV
+                loops = unwrap(await s.call_tool("list_air_loops", {}))
+                names = [al["name"] for al in loops["air_loops"]]
+                assert len(names) == 1 and "PVAV" in names[0], (
+                    f"expected single multizone PVAV loop after swap, got {names}"
+                )
+
+                swap_metrics = await _sim_metrics(s, _unique("swap"))
+
+        # Parity: the swap path must be equivalent to the sanctioned full build
+        assert swap_metrics["eui_MJ_m2"] == pytest.approx(
+            control_metrics["eui_MJ_m2"], rel=0.02), (
+            f"EUI diverged: control {control_metrics['eui_MJ_m2']:.1f} vs "
+            f"swap {swap_metrics['eui_MJ_m2']:.1f} MJ/m2"
+        )
+        assert swap_metrics["unmet_hours_heating"] == pytest.approx(
+            control_metrics["unmet_hours_heating"], abs=25), (
+            f"unmet heating diverged: control {control_metrics['unmet_hours_heating']} "
+            f"vs swap {swap_metrics['unmet_hours_heating']}"
+        )
+        assert swap_metrics["unmet_hours_cooling"] == pytest.approx(
+            control_metrics["unmet_hours_cooling"], abs=25), (
+            f"unmet cooling diverged: control {control_metrics['unmet_hours_cooling']} "
+            f"vs swap {swap_metrics['unmet_hours_cooling']}"
+        )
+    asyncio.run(_run())

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -318,6 +318,25 @@ def test_apply_measure_custom_epw_stays_absolute_and_rerunnable():
     asyncio.run(_run())
 
 
+def test_portable_url_failure_never_fails_measure(monkeypatch):
+    """A raise in the portable-url post-step must not flip ok to False."""
+    # Regression: PR #108 review — apply_measure's outer except would catch a
+    # RuntimeError from the portable-url cleanup and report the whole
+    # (successful, reloaded) measure run as failed
+    from mcp_server.skills.measures import operations as ops
+
+    def _boom(model):
+        raise RuntimeError("weatherFile exploded")
+
+    monkeypatch.setattr(ops, "make_weather_url_portable", _boom)
+    monkeypatch.setattr(ops, "get_model", object)
+    result = {"ok": True}
+    ops._attach_portable_weather_url(result)
+    assert result["ok"] is True
+    assert result["weather_url_error"] == "weatherFile exploded"
+    assert "weather_url" not in result
+
+
 @pytest.mark.integration
 def test_apply_measure_verify_model_changed():
     """Verify model state changed after measure application."""

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -234,6 +234,91 @@ def test_apply_measure_weather_setting_measure_not_clobbered():
 
 
 @pytest.mark.integration
+def test_apply_measure_staged_url_portable_and_rerunnable():
+    """After a weather-setting measure, url is portable and measures re-run."""
+    # Regression: issue #97 investigation — the runner writes the staged
+    # absolute EPW path into the output model; the next apply_measure passed
+    # that other-run-dir path via OSW file_paths unstaged, and the confined
+    # subprocess EACCESed (surfaced as a bogus "Windows path length" error
+    # from the standards sizing-run rescue)
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique())
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": "/opt/common-measures/ChangeBuildingLocation",
+                    "arguments": {
+                        "weather_file_name":
+                            "/opt/comstock-measures/ChangeBuildingLocation"
+                            "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw",
+                    },
+                }))
+                assert res["ok"] is True, f"CBL failed: {res.get('error')}"
+                weather = unwrap(await s.call_tool("get_weather_info", {}))
+                assert weather["weather_file"]["url"] == \
+                    "USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw", (
+                    "known EPW should be relativized to the portable bare name, "
+                    f"got {weather['weather_file']['url']}"
+                )
+                # Re-running any measure on this model must work
+                res2 = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": MEASURE_DIR,
+                    "arguments": {"building_name": "Rerun OK"},
+                }))
+                assert res2["ok"] is True, \
+                    f"second measure failed after weather set: {res2.get('error')}"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_apply_measure_custom_epw_stays_absolute_and_rerunnable():
+    """Custom EPW (basename in no search dir) keeps absolute url; re-runs work."""
+    # Regression: issue #97 investigation — resolve_osw_weather tier 1 passed
+    # an absolute own-run url via file_paths without staging (sandbox denies
+    # other run dirs); and relativizing an unfindable basename would strand
+    # the model's weather reference entirely
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique())
+                import shutil
+                custom = f"MyCustom_{uuid.uuid4().hex[:8]}"
+                wdir = Path(f"/runs/{_unique('custom_epw')}")
+                wdir.mkdir(parents=True)
+                src = Path("/opt/comstock-measures/ChangeBuildingLocation"
+                           "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3")
+                for ext in (".epw", ".ddy", ".stat"):
+                    shutil.copy2(f"{src}{ext}", str(wdir / f"{custom}{ext}"))
+
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": "/opt/common-measures/ChangeBuildingLocation",
+                    "arguments": {"weather_file_name": str(wdir / f"{custom}.epw")},
+                }))
+                assert res["ok"] is True, f"CBL failed: {res.get('error')}"
+                weather = unwrap(await s.call_tool("get_weather_info", {}))
+                url = weather["weather_file"]["url"]
+                assert url.endswith(f"files/{custom}.epw") and url.startswith("/"), (
+                    "unfindable custom EPW must keep a resolvable absolute url, "
+                    f"got {url}"
+                )
+                res2 = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": MEASURE_DIR,
+                    "arguments": {"building_name": "Custom EPW Rerun"},
+                }))
+                assert res2["ok"] is True, \
+                    f"second measure failed with custom EPW url: {res2.get('error')}"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
 def test_apply_measure_verify_model_changed():
     """Verify model state changed after measure application."""
     # Validates: apply_measure mutates in-memory model (building name changes)


### PR DESCRIPTION
Addresses #97 — the decision-grade system-comparison path, using existing tools only (no new tool).

## hvac_only on create_typical_building
The bundled measure's `remove_objects` is per-section ("Only removes objects of type that are selected to be added"), so pinning every section off except HVAC yields a standards-tuned HVAC swap that preserves loads, constructions, schedules, and thermostats. `hvac_only=True` does that pinning; the four previously-unexposed toggles (`add_elevators`, `add_internal_mass`, `add_exhaust`, `add_refrigeration`) are now exposed so the pin set is complete. This also resolves the issue's item 4 (`replace_hvac_only`) without touching `remove_objects` semantics.

**Parity proof** (dev benchmark, 10k ft² SmallOffice bar, Boston 5A, 90.1-2019, PVAV gas boiler reheat): full build with explicit `system_type` vs Inferred build + `hvac_only` swap — site energy 746.74 vs 746.79 GJ (0.007%), unmet heating 343.67 in both, loads value-identical. The CI benchmark asserts exactly this parity plus load preservation, so it self-calibrates instead of hardcoding absolute EUI bands.

## Prerequisite fix found en route (first commit)
The swap initially failed with a bogus "Windows file path length" error — actually the standards sizing-run `rescue` masking an EACCES: the workflow runner writes the staged absolute EPW path into the output model, and the next measure run passed that other-run-dir path via OSW `file_paths` **unstaged**, which Landlock denies (issue #104 class, third variant). Fixes:
- `resolve_osw_weather` tier 1 now stages the EPW into the run's `files/` (gated by `is_path_allowed`) instead of appending an external parent to `file_paths`
- portable bare-filename url rewrite generalized from the CBL wrapper to **all** measures via `apply_measure` post-reload — and made conditional on `find_epw_by_name` recoverability, fixing a flaw in #106's unconditional rewrite that would strand custom EPWs (basename in no search dir); those keep a resolvable absolute url
- 2 red-green regression tests (`test_measures.py`)

## Docs / routing
Fair-sweep recipe in the tool-workflows and add-hvac skills; comparative studies explicitly routed away from the generic wiring templates.

## Remaining #97 items (follow-up PR)
Generic-tool comfort fixes (night-cycle availability managers, occupied-hours DOAS), tool-description warnings on `add_baseline_system`/`add_doas_system`, and zone-list fan-out for systems 1-4.

## Tests
- `tests/test_hvac_only_swap.py` parity benchmark (76s), CI shard 4 (lightest)
- 2 regression tests in `tests/test_measures.py`, red-green verified
- Sweeps green: measures+weather (30), comstock+bar (15); unit + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)