### PR TITLE
Generic HVAC template comfort fixes (closes #97)

### DIFF
--- a/.claude/skills/add-hvac/SKILL.md
+++ b/.claude/skills/add-hvac/SKILL.md
@@ -79,6 +79,7 @@ compare_runs(run_id_a, run_id_b)           # EUI + unmet-hours deltas
 ## Notes
 
 - Get all zone names from `list_thermal_zones()` — names must match exactly
-- Systems 3-4 create one air loop per zone (single-zone systems)
+- Systems 3-4 create one air loop per zone — pass the full zone list in one
+  call, the tool fans out automatically
 - Systems 5-8 create one shared air loop for all zones (multi-zone VAV)
 - Systems 1-2, 9-10 create zone equipment only (no air loops)

--- a/.claude/skills/ashrae-baseline-guide/SKILL.md
+++ b/.claude/skills/ashrae-baseline-guide/SKILL.md
@@ -82,6 +82,14 @@ When user provides multiple zones:
 | System details | `get_baseline_system_info` | `system_type` |
 | Modern alternatives | `add_doas_system`, `add_vrf_system`, `add_radiant_system` | `thermal_zone_names` |
 
+**Two paths, know which you need:** the tools above are generic wiring
+templates (explicit topology control, no standards equipment efficiencies).
+Use them to SELECT and WIRE a system type. For comparing systems or any
+decision-grade EUI/comfort numbers, build each candidate through
+openstudio-standards instead:
+`create_typical_building(system_type=..., hvac_only=True)` — replaces only
+the HVAC (standards-tuned), preserving loads/schedules/thermostats.
+
 ## When to Recommend Modern Templates Instead
 
 | Scenario | Recommendation |

--- a/.claude/skills/new-building/SKILL.md
+++ b/.claude/skills/new-building/SKILL.md
@@ -72,7 +72,9 @@ For fully custom buildings not matching DOE prototypes:
 2. Create/refine geometry with `create_space_from_floor_print` + `match_surfaces`
 3. Add glazing with `set_window_to_wall_ratio`
 4. Create materials/constructions/loads manually
-5. Add HVAC with `add_baseline_system`
+5. Add HVAC — `create_typical_building(system_type=..., hvac_only=True)` for a
+   standards-tuned system (preserves the loads you just built), or
+   `add_baseline_system` for a generic wiring template
 6. Set weather with `change_building_location`
 7. Check with `validate_model`, then simulate
 

--- a/.claude/skills/openstudio-patterns/SKILL.md
+++ b/.claude/skills/openstudio-patterns/SKILL.md
@@ -40,7 +40,9 @@ Weather (EPW + design days, needed before simulation)
 6. **Glazing** — `set_window_to_wall_ratio` or `create_subsurface`
 7. **Schedules** — `create_schedule_ruleset` (needed by loads)
 8. **Loads** — `create_people_definition`, `create_lights_definition`, `create_electric_equipment`
-9. **HVAC** — `add_baseline_system` / `add_doas_system` / `add_vrf_system`
+9. **HVAC** — `create_typical_building(system_type=..., hvac_only=True)` for
+   standards-tuned systems (decision-grade results); `add_baseline_system` /
+   `add_doas_system` / `add_vrf_system` for explicit generic wiring control
 10. **Weather** — `change_building_location` (sets EPW + design days + climate zone in one call)
 11. **Simulation control** — `set_run_period`, `set_simulation_control`
 12. **Save & simulate** — `save_osm_model` → `run_simulation`

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -25,6 +25,8 @@ get_run_logs(run_id=..., log_type="stderr")
 | `Node not connected` | Broken HVAC loop | Check with `get_air_loop_details` / `get_plant_loop_details` |
 | `Surface has no vertices` | Bad geometry | Check `list_surfaces()` for degenerate surfaces |
 | `Zone has no surfaces` | Empty thermal zone | Zone needs spaces with geometry assigned |
+| `Due to limitations on Windows file path lengths ... less than 90 characters` | MISLEADING — an openstudio-standards sizing run could not read/resolve the weather file (nothing to do with path length). The model's EPW reference points somewhere unreadable | Re-run `change_building_location(weather_file=...)` with a real EPW path so the reference is re-staged |
+| `Terminal unit not found on any ZoneTerminalUnitList` | VRF terminals orphaned from the outdoor unit | Rebuild the system with `add_vrf_system` (older models may carry an incompatible FluidTemperatureControl outdoor unit) |
 
 ## Results Look Wrong
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,8 @@ jobs:
               # HVAC supply sim smoke tests + hvac_validation + bar_building + concurrent regression
               # + sim queue (concurrency cap) & per-user run-dir isolation + run retention/cleanup
               # + python_ems phase 2 (packages/numpy-in-plugin, edit, node reset, trend)
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py"
+              # + generic HVAC template comfort benchmark (issue #97)
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py tests/test_generic_hvac_comfort.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/mcp_server/skills/hvac/operations.py
+++ b/mcp_server/skills/hvac/operations.py
@@ -62,6 +62,29 @@ def _extract_detailed_supply_components(air_loop) -> dict[str, Any]:
             coil_info = {"type": comp_type, "name": component.nameString() if hasattr(component, "nameString") else "Unnamed"}
             result["cooling_coils"].append(coil_info)
 
+        # Unwrap composite unitary systems so their fan/coils report like
+        # loose-component loops (baseline system 4 uses the unitary heat pump
+        # composite since the issue #97 rework — without unwrapping, agents
+        # and validation would see an air loop with "no coils")
+        elif component.to_AirLoopHVACUnitaryHeatPumpAirToAir().is_initialized():
+            unitary = component.to_AirLoopHVACUnitaryHeatPumpAirToAir().get()
+            fan = unitary.supplyAirFan()
+            result["fans"].append({
+                "type": fan.iddObjectType().valueName(),
+                "name": fan.nameString(),
+            })
+            for coil in (unitary.heatingCoil(), unitary.supplementalHeatingCoil()):
+                result["heating_coils"].append({
+                    "type": coil.iddObjectType().valueName(),
+                    "name": coil.nameString(),
+                })
+            clg = unitary.coolingCoil()
+            result["cooling_coils"].append({
+                "type": clg.iddObjectType().valueName(),
+                "name": clg.nameString(),
+            })
+            result["other"].append({"type": comp_type, "name": unitary.nameString()})
+
         else:
             result["other"].append({"type": comp_type})
 

--- a/mcp_server/skills/hvac_systems/SKILL.md
+++ b/mcp_server/skills/hvac_systems/SKILL.md
@@ -6,47 +6,37 @@ System-level HVAC templates and ASHRAE 90.1 Appendix G baseline systems.
 
 The `hvac_systems` skill provides high-level HVAC system creation tools that abstract away component-level wiring complexity. Instead of manually creating and connecting individual coils, fans, loops, and terminals, use these tools to create complete, validated HVAC systems in a single step.
 
-## Current Implementation Status
+## Scope and Role (read this first)
 
-**Phase 4B: ALL 10 ASHRAE Baseline Systems** ✅ COMPLETE
+These are GENERIC WIRING TEMPLATES: explicit topology control via direct SDK
+calls, no standards equipment efficiencies. For comparative studies or
+decision-grade EUI/comfort numbers, use the openstudio-standards path
+instead: `create_typical_building(system_type=..., hvac_only=True)` replaces
+only the HVAC and preserves loads/schedules/thermostats (issue #97).
 
-All ASHRAE 90.1 Appendix G baseline system types fully implemented:
+All 10 ASHRAE 90.1 Appendix G baseline system types are implemented, plus
+modern templates (DOAS, VRF, Radiant) and terminal replacement tools.
 
-**Zone Equipment Systems:**
-- ✅ System 1: PTAC (Packaged Terminal Air Conditioner)
-- ✅ System 2: PTHP (Packaged Terminal Heat Pump)
-- ✅ System 9: Heating & Ventilation (Gas Unit Heaters)
-- ✅ System 10: Heating & Ventilation (Electric Unit Heaters)
+- Systems 1-2, 9-10: zone equipment (PTAC, PTHP, gas/electric unit heaters)
+- Systems 3-4: packaged single-zone (PSZ-AC gas/electric; PSZ-HP as a
+  unitary heat pump composite with full-size staged supplemental heat) —
+  one air loop per zone; pass the full zone list, the tool fans out
+- Systems 5-6: packaged VAV (HW reheat / PFP boxes), one shared air loop
+- Systems 7-8: central plant VAV (chiller/boiler/tower)
 
-**Packaged Rooftop Systems:**
-- ✅ System 3: PSZ-AC (Single Zone Air Conditioner)
-- ✅ System 4: PSZ-HP (Single Zone Heat Pump)
-- ✅ System 5: Packaged VAV w/ Reheat (HW loop, boiler, VAV terminals)
-- ✅ System 6: Packaged VAV w/ PFP (Parallel fan-powered boxes)
+## Comfort defaults (issue #97, benchmark-verified)
 
-**Central Plant Systems:**
-- ✅ System 7: VAV w/ Reheat (Chiller/Boiler/Tower, HW reheat)
-- ✅ System 8: VAV w/ PFP (Chiller/Boiler/Tower, electric reheat)
-
-**Testing:** 73 validation tests + 18 system integration tests
-- All 10 systems tested with success + error cases
-- Multi-zone validation (PSZ rejection)
-- Plant loop verification (Systems 5, 7-8)
-- Terminal verification (VAV vs PFP)
-- Economizer on/off for systems 3-8
-- Edge case handling
-
-**Implementation Timeline:**
-- Phase 4A: Systems 1-3 (1 week)
-- Phase 4B Batch 1: Systems 4-6 (2 days)
-- Phase 4B Batch 2: Systems 7-8 (2 days)
-- Phase 4B Batch 3: Systems 9-10 (1 day)
-
-**Next Phases:**
-- Phase 4C: Air terminal replacement tool
-- Phase 4D: Component-level validation tests (detailed ASHRAE compliance)
-- Phase 4E: Modern templates (DOAS, VRF, Radiant)
-- Additional introspection tools
+Applied automatically so generic systems are viable out of the box:
+- App G sizing factors (1.25 heating / 1.15 cooling) + night-cycle
+  availability managers on air-loop systems
+- VAV reheat terminals use DamperHeatingAction=Reverse (Normal caps heating
+  at minimum airflow — was 1807 unmet heating hrs on the benchmark)
+- System 4 heat pump: -12.2C compressor lockout, cycling Fan:OnOff, 40C max
+  supplemental supply temp (autosized 16.7C could not heat a 21C zone)
+- DOAS loop availability defaults to the served zones' People schedule
+  (24/7 buildings stay always-on); override via availability_schedule_name
+- VRF uses the standard outdoor-unit family with waste-heat recovery
+  (the FluidTemperatureControl family needs different terminal coils)
 
 ## Tools
 

--- a/mcp_server/skills/hvac_systems/air_terminals.py
+++ b/mcp_server/skills/hvac_systems/air_terminals.py
@@ -213,11 +213,19 @@ def _create_vav_reheat_terminal(
         terminal.setName(f"{zone.nameString()} VAV Reheat Terminal")
 
         # Set minimum airflow fraction (cooling mode minimum)
-        # ASHRAE 90.1 default is 0.3 (30% minimum airflow)
-        if "min_airflow_fraction" in options:
-            terminal.setZoneMinimumAirFlowFraction(options["min_airflow_fraction"])
-        else:
-            terminal.setZoneMinimumAirFlowFraction(0.3)
+        # ASHRAE 90.1 default is 0.3 (30% minimum airflow).
+        # setConstantMinimumAirFlowFraction + input method — the previously
+        # used setZoneMinimumAirFlowFraction does not exist in this SDK, so
+        # every VAV_Reheat replacement raised AttributeError (found by the
+        # issue #97 damper regression test; the success path was untested)
+        terminal.setZoneMinimumAirFlowInputMethod("Constant")
+        terminal.setConstantMinimumAirFlowFraction(
+            options.get("min_airflow_fraction", 0.3))
+
+        # Reverse damper action: the default (Normal) caps heating at minimum
+        # airflow (issue #97 — chronic unmet heating; matches standards and
+        # the baseline system 5/7 fix)
+        terminal.setDamperHeatingAction("Reverse")
 
         # Connect terminal to air loop and zone
         air_loop.addBranchForZone(zone, terminal)

--- a/mcp_server/skills/hvac_systems/baseline.py
+++ b/mcp_server/skills/hvac_systems/baseline.py
@@ -317,25 +317,44 @@ def create_baseline_system_4(
     # Add outdoor air system
     oa_system = add_outdoor_air_system(model, air_loop, economizer)
 
-    # Create supply fan
-    fan = openstudio.model.FanConstantVolume(model, always_on)
+    # Composite unitary heat pump — NOT loose coils on the branch. With loose
+    # coils E+ sized the supplemental electric coil to only the design load
+    # minus the DX rated contribution (~44% on the issue #97 benchmark), so
+    # when the derated/locked-out heat pump couldn't carry a Boston winter
+    # morning the backup couldn't either: 1416 unmet heating hrs. The unitary
+    # object stages DX + supplemental together and sizes the backup for the
+    # full load (this is also how openstudio-standards builds PSZ-HP).
+    # Fan:OnOff — required by E+ for the cycling fan mode below (and what
+    # the standards PSZ-HP prototype uses)
+    fan = openstudio.model.FanOnOff(model, always_on)
     fan.setName(f"{name} Supply Fan")
-    fan.addToNode(air_loop.supplyInletNode())
 
-    # Create DX heating coil (heat pump)
     htg_coil = openstudio.model.CoilHeatingDXSingleSpeed(model)
     htg_coil.setName(f"{name} HP Heating Coil")
-    htg_coil.addToNode(air_loop.supplyInletNode())
+    # Standards low-temperature lockout: default -8C abandons the compressor
+    # exactly when the load peaks; -12.2C matches the prototype assumption
+    htg_coil.setMinimumOutdoorDryBulbTemperatureforCompressorOperation(-12.2)
 
-    # Create DX cooling coil (heat pump)
     clg_coil = openstudio.model.CoilCoolingDXSingleSpeed(model)
     clg_coil.setName(f"{name} HP Cooling Coil")
-    clg_coil.addToNode(air_loop.supplyInletNode())
 
-    # Create supplemental heating coil
     supp_htg_coil = openstudio.model.CoilHeatingElectric(model, always_on)
     supp_htg_coil.setName(f"{name} Supplemental Heating Coil")
-    supp_htg_coil.addToNode(air_loop.supplyInletNode())
+
+    unitary = openstudio.model.AirLoopHVACUnitaryHeatPumpAirToAir(
+        model, always_on, fan, htg_coil, clg_coil, supp_htg_coil,
+    )
+    unitary.setName(f"{name} Unitary Heat Pump")
+    unitary.setControllingZone(zone)
+    # Fan operating mode left at default (cycling): a continuous fan dumps
+    # fan heat into the airstream all summer — benchmarked at +343 unmet
+    # cooling hours on issue #97's building. Cycling matches the standards
+    # PSZ-HP prototype.
+    # Autosizing caps supplemental supply air at the system sizing central
+    # heating temp (16.7C — cannot heat a 21C zone no matter the coil size);
+    # 40C matches standards heating supply practice
+    unitary.setMaximumSupplyAirTemperaturefromSupplementalHeater(40.0)
+    unitary.addToNode(air_loop.supplyInletNode())
 
     # Create uncontrolled terminal
     terminal = openstudio.model.AirTerminalSingleDuctUncontrolled(model, always_on)
@@ -354,6 +373,7 @@ def create_baseline_system_4(
         "system": {
             "name": name,
             "type": "PSZ-HP (Baseline System 4)",
+            "unitary_system": unitary.nameString(),
             "category": "baseline",
             "system_number": 4,
             "equipment_type": "Packaged Rooftop Heat Pump",

--- a/mcp_server/skills/hvac_systems/baseline.py
+++ b/mcp_server/skills/hvac_systems/baseline.py
@@ -455,6 +455,10 @@ def create_baseline_system_5(
             model, always_on, reheat_coil,
         )
         terminal.setName(f"{name} VAV Terminal - {zone.nameString()}")
+        # Reverse damper action: the default (Normal) caps heating at minimum
+        # airflow, chronically underheating perimeter zones (issue #97 — 1807
+        # unmet heating hrs on the benchmark). Matches openstudio-standards.
+        terminal.setDamperHeatingAction("Reverse")
         air_loop.addBranchForZone(zone, terminal)
         terminals.append(terminal.nameString())
 
@@ -668,6 +672,8 @@ def create_baseline_system_7(
             model, always_on, reheat_coil,
         )
         terminal.setName(f"{name} VAV Terminal - {zone.nameString()}")
+        # Reverse damper action — see system 5 (issue #97 unmet heating)
+        terminal.setDamperHeatingAction("Reverse")
         air_loop.addBranchForZone(zone, terminal)
         terminals.append(terminal.nameString())
 

--- a/mcp_server/skills/hvac_systems/operations.py
+++ b/mcp_server/skills/hvac_systems/operations.py
@@ -12,7 +12,36 @@ from mcp_server.skills.hvac_systems import (
     cleanup,
     templates,
     validation,
+    wiring,
 )
+
+# 90.1 Appendix G sizing factors (matches openstudio-standards'
+# model_apply_prm_sizing_parameters). Autosizing to the exact design load
+# leaves no setback-recovery capacity — issue #97: ~2h of unmet heating every
+# winter morning on models with thermostat setback.
+_HEATING_SIZING_FACTOR = 1.25
+_COOLING_SIZING_FACTOR = 1.15
+
+
+def _apply_comfort_defaults(model, system_dicts: list[dict[str, Any]]) -> list[str]:
+    """Apply sizing factors + night-cycle managers after system creation.
+
+    Returns the names of night-cycle managers added (one per air loop; zone
+    equipment systems have none — they already cycle on thermostat demand).
+    """
+    sizing = model.getSizingParameters()
+    sizing.setHeatingSizingFactor(_HEATING_SIZING_FACTOR)
+    sizing.setCoolingSizingFactor(_COOLING_SIZING_FACTOR)
+    night_cycles: list[str] = []
+    for sd in system_dicts:
+        air_loop_name = sd.get("air_loop")
+        if not air_loop_name:
+            continue
+        loop = fetch_object(model, "AirLoopHVAC", name=air_loop_name)
+        if loop is not None:
+            night_cycles.append(
+                wiring.add_night_cycle_manager(model, loop).nameString())
+    return night_cycles
 
 
 def add_baseline_system(
@@ -71,6 +100,16 @@ def add_baseline_system(
         # addBranchForZone steals zones from their old loops (#83)
         loop_zones_before = cleanup.snapshot_loop_zones(model)
 
+        def _create_single_zone_system(zone_list: list, name: str) -> dict[str, Any]:
+            """Single-zone system types (one air loop per zone)."""
+            if system_type == 3:
+                return baseline.create_baseline_system_3(
+                    model, zone_list, heating_fuel, cooling_fuel, economizer, name,
+                )
+            return baseline.create_baseline_system_4(
+                model, zone_list, heating_fuel, cooling_fuel, economizer, name,
+            )
+
         # Route to appropriate baseline system implementation
         if system_type == 1:
             result = baseline.create_baseline_system_1(
@@ -80,14 +119,34 @@ def add_baseline_system(
             result = baseline.create_baseline_system_2(
                 model, zones, heating_fuel, cooling_fuel, economizer, system_name,
             )
-        elif system_type == 3:
-            result = baseline.create_baseline_system_3(
-                model, zones, heating_fuel, cooling_fuel, economizer, system_name,
-            )
-        elif system_type == 4:
-            result = baseline.create_baseline_system_4(
-                model, zones, heating_fuel, cooling_fuel, economizer, system_name,
-            )
+        elif system_type in (3, 4):
+            # Systems 3/4 are one-air-loop-per-zone: fan out over the zone
+            # list instead of forcing 27 calls for 27 zones (issue #97)
+            if len(zones) == 1:
+                result = _create_single_zone_system(zones, system_name)
+            else:
+                created = []
+                for zone in zones:
+                    r = _create_single_zone_system(
+                        [zone], f"{system_name} - {zone.nameString()}")
+                    if not r.get("ok"):
+                        r["error"] = (
+                            f"zone '{zone.nameString()}': {r.get('error')}"
+                            f" ({len(created)} systems created before failure)"
+                        )
+                        return r
+                    created.append(r["system"])
+                result = {
+                    "ok": True,
+                    "system": {
+                        "name": system_name,
+                        "type": created[0]["type"],
+                        "category": "baseline",
+                        "system_number": system_type,
+                        "zones_served": len(created),
+                        "per_zone_systems": created,
+                    },
+                }
         elif system_type == 5:
             result = baseline.create_baseline_system_5(
                 model, zones, heating_fuel, cooling_fuel, economizer, system_name,
@@ -126,12 +185,27 @@ def add_baseline_system(
             sim_control.setDoSystemSizingCalculation(True)
             sim_control.setDoPlantSizingCalculation(True)
 
+            # Comfort defaults: App G sizing factors + night cycle (issue #97)
+            per_zone = result["system"].get("per_zone_systems")
+            night_cycles = _apply_comfort_defaults(
+                model, per_zone if per_zone else [result["system"]])
+            if night_cycles:
+                result["system"]["night_cycle_managers"] = night_cycles
+
             repairs = cleanup.repair_orphaned_air_loops(model, loop_zones_before)
             if repairs:
                 result["repairs"] = repairs
 
-            validation_result = validation.validate_system(model, system_name)
-            result["validation"] = validation_result
+            if per_zone:
+                validations = [
+                    validation.validate_system(model, s["name"]) for s in per_zone
+                ]
+                result["validation"] = {
+                    "per_zone_systems": len(validations),
+                    "results": validations,
+                }
+            else:
+                result["validation"] = validation.validate_system(model, system_name)
 
         return result
 
@@ -269,8 +343,12 @@ def add_doas_system(
     zone_equipment_type: str = "FanCoil",
     heating_fuel: str = "NaturalGas",
     cooling_fuel: str = "Electricity",
+    availability_schedule_name: str | None = None,
 ) -> dict[str, Any]:
     """Add Dedicated Outdoor Air System with zone equipment.
+
+    Ventilation is demand-controlled (follows zone People schedules); pass
+    availability_schedule_name to also shut the DOAS fan off when unoccupied.
 
     Args:
         thermal_zone_names: Zones to serve
@@ -280,6 +358,8 @@ def add_doas_system(
         zone_equipment_type: FanCoil | Radiant | ChilledBeams | FourPipeBeam
         heating_fuel: NaturalGas | Electricity | DistrictHeating
         cooling_fuel: Electricity | DistrictCooling
+        availability_schedule_name: Optional schedule for DOAS loop
+            availability (e.g. an occupancy schedule name from list_schedules)
 
     Returns:
         dict with ok status and system details
@@ -300,6 +380,17 @@ def add_doas_system(
         if zone_equipment_type not in valid_types:
             return {"ok": False, "error": f"Invalid zone_equipment_type: '{zone_equipment_type}'"}
 
+        availability_schedule = None
+        if availability_schedule_name:
+            availability_schedule = fetch_object(
+                model, "ScheduleRuleset", name=availability_schedule_name)
+            if availability_schedule is None:
+                availability_schedule = fetch_object(
+                    model, "ScheduleConstant", name=availability_schedule_name)
+            if availability_schedule is None:
+                return {"ok": False, "error":
+                        f"Schedule '{availability_schedule_name}' not found"}
+
         # addBranchForZone steals zones from their old loops (#83)
         loop_zones_before = cleanup.snapshot_loop_zones(model)
 
@@ -307,8 +398,15 @@ def add_doas_system(
             model, zones, system_name, energy_recovery,
             sensible_effectiveness, zone_equipment_type,
             heating_fuel, cooling_fuel,
+            availability_schedule=availability_schedule,
         )
         out: dict[str, Any] = {"ok": True, "system": result}
+        # App G sizing factors — zone equipment must recover from setback
+        # (issue #97); DOAS loop itself gets no night cycle: ventilation is
+        # not needed unoccupied and the zone equipment holds temperature
+        sizing = model.getSizingParameters()
+        sizing.setHeatingSizingFactor(_HEATING_SIZING_FACTOR)
+        sizing.setCoolingSizingFactor(_COOLING_SIZING_FACTOR)
         repairs = cleanup.repair_orphaned_air_loops(model, loop_zones_before)
         if repairs:
             out["repairs"] = repairs

--- a/mcp_server/skills/hvac_systems/operations.py
+++ b/mcp_server/skills/hvac_systems/operations.py
@@ -347,8 +347,13 @@ def add_doas_system(
 ) -> dict[str, Any]:
     """Add Dedicated Outdoor Air System with zone equipment.
 
-    Ventilation is demand-controlled (follows zone People schedules); pass
-    availability_schedule_name to also shut the DOAS fan off when unoccupied.
+    The DOAS loop's availability defaults to the served zones' People
+    schedule (occupied hours; 24/7 buildings stay always-on; models without
+    People keep always-on) — pass availability_schedule_name to override.
+    Appendix G sizing factors (1.25 htg / 1.15 clg) are applied model-wide so
+    zone equipment can recover from thermostat setback. The OA controller's
+    DCV flag is set as intent but is inert on this constant-volume 100% OA
+    loop (the fan drives the flow).
 
     Args:
         thermal_zone_names: Zones to serve

--- a/mcp_server/skills/hvac_systems/templates.py
+++ b/mcp_server/skills/hvac_systems/templates.py
@@ -425,31 +425,32 @@ def create_vrf_system(
     Returns:
         dict with VRF outdoor unit and terminal details
     """
-    # Create VRF outdoor unit
+    # Create VRF outdoor unit — always the standard family. The former
+    # heat_recovery branch used AirConditionerVariableRefrigerantFlowFluid-
+    # TemperatureControlHR, a DIFFERENT VRF family whose terminals need FTC
+    # coils; pairing it with standard terminal units made the forward
+    # translator drop the condenser entirely, orphaning every terminal and
+    # killing EnergyPlus with "Terminal unit not found on any
+    # ZoneTerminalUnitList" (issue #97 investigation — the tool had never
+    # produced a runnable simulation). The standard object supports heat
+    # recovery natively.
+    vrf_system = openstudio.model.AirConditionerVariableRefrigerantFlow(model)
+    vrf_system.setName(f"{name} VRF Outdoor Unit")
     if heat_recovery:
-        vrf_system = openstudio.model.AirConditionerVariableRefrigerantFlowFluidTemperatureControlHR(model)
-        vrf_system.setName(f"{name} VRF Outdoor Unit HR")
-    else:
-        vrf_system = openstudio.model.AirConditionerVariableRefrigerantFlow(model)
-        vrf_system.setName(f"{name} VRF Outdoor Unit")
+        vrf_system.setHeatPumpWasteHeatRecovery(True)
+    # The constructor's default EIR low-PLR curves have minimum x = 0.5 while
+    # the minimum PLR field defaults to 0.25 — E+ rejects the inconsistency
+    # with a fatal GetVRFInput error. Match the shipped curves.
+    vrf_system.setMinimumHeatPumpPartLoadRatio(0.5)
 
-    # Set capacity or autosize (HR model uses different API)
-    if heat_recovery:
-        if capacity_w is not None:
-            vrf_system.setRatedEvaporativeCapacity(capacity_w)
-            autosized = False
-        else:
-            vrf_system.autosizeRatedEvaporativeCapacity()
-            autosized = True
+    if capacity_w is not None:
+        vrf_system.setGrossRatedTotalCoolingCapacity(capacity_w)
+        vrf_system.setGrossRatedHeatingCapacity(capacity_w)
+        autosized = False
     else:
-        if capacity_w is not None:
-            vrf_system.setGrossRatedTotalCoolingCapacity(capacity_w)
-            vrf_system.setGrossRatedHeatingCapacity(capacity_w)
-            autosized = False
-        else:
-            vrf_system.autosizeGrossRatedTotalCoolingCapacity()
-            vrf_system.autosizeGrossRatedHeatingCapacity()
-            autosized = True
+        vrf_system.autosizeGrossRatedTotalCoolingCapacity()
+        vrf_system.autosizeGrossRatedHeatingCapacity()
+        autosized = True
 
     # Create VRF terminals for each zone
     terminals = []
@@ -457,8 +458,13 @@ def create_vrf_system(
         terminal = openstudio.model.ZoneHVACTerminalUnitVariableRefrigerantFlow(model)
         terminal.setName(f"{name} VRF Terminal - {zone.nameString()}")
 
-        # Connect terminal to VRF system via outdoor unit
-        vrf_system.addTerminal(terminal)
+        # Connect terminal to VRF system via outdoor unit; a False return
+        # means an incompatible pairing that would orphan the terminal
+        if not vrf_system.addTerminal(terminal):
+            terminal.remove()
+            raise RuntimeError(
+                f"VRF outdoor unit rejected terminal for zone "
+                f"'{zone.nameString()}' (incompatible terminal type)")
 
         # Add to thermal zone
         terminal.addToThermalZone(zone)

--- a/mcp_server/skills/hvac_systems/templates.py
+++ b/mcp_server/skills/hvac_systems/templates.py
@@ -97,6 +97,34 @@ def _apply_radiant_construction(model, zone, radiant_type, construction):
                 surface.setConstruction(construction)
 
 
+def _derive_occupancy_availability(zones: list):
+    """Most common People number-of-people schedule across the served zones.
+
+    Checks space-level People and space-type People (create_typical assigns
+    at the space type). Returns a Schedule usable as loop availability
+    (fractional occupancy works: availability semantics are 0=off, >0=on),
+    or None when no People schedules exist.
+    """
+    counts: dict[str, int] = {}
+    schedules: dict[str, Any] = {}
+    for zone in zones:
+        for space in zone.spaces():
+            people_objs = list(space.people())
+            space_type = space.spaceType()
+            if space_type.is_initialized():
+                people_objs.extend(space_type.get().people())
+            for people in people_objs:
+                sched = people.numberofPeopleSchedule()
+                if sched.is_initialized():
+                    sched_name = sched.get().nameString()
+                    counts[sched_name] = counts.get(sched_name, 0) + 1
+                    schedules[sched_name] = sched.get()
+    if not counts:
+        return None
+    winner = max(counts, key=lambda k: counts[k])
+    return schedules[winner]
+
+
 def create_doas_system(
     model,
     zones: list,
@@ -106,6 +134,7 @@ def create_doas_system(
     zone_equipment_type: str,
     heating_fuel: str = "NaturalGas",
     cooling_fuel: str = "Electricity",
+    availability_schedule=None,
 ) -> dict[str, Any]:
     """Create Dedicated Outdoor Air System with zone equipment.
 
@@ -135,6 +164,21 @@ def create_doas_system(
     oa_controller = openstudio.model.ControllerOutdoorAir(model)
     oa_controller.setName(f"{name} OA Controller")
     oa_controller.autosizeMinimumOutdoorAirFlowRate()
+
+    # DCV intent flag (correct signal for any recirculating retrofit of this
+    # loop; inert on a pure 100% OA constant-volume loop — the fan drives flow)
+    oa_controller.controllerMechanicalVentilation().setDemandControlledVentilation(True)
+
+    # Loop availability: without a schedule the DOAS conditions its full
+    # design OA flow around the clock — issue #97 measured ~2x EUI. Default
+    # derives from the served zones' own People schedules (availability
+    # treats any value >0 as ON): offices get office hours, 24/7 buildings
+    # stay always-on, models without People keep today's always-on. The zone
+    # equipment stays always-available to hold setback temperatures.
+    if availability_schedule is None:
+        availability_schedule = _derive_occupancy_availability(zones)
+    if availability_schedule is not None:
+        doas_loop.setAvailabilitySchedule(availability_schedule)
 
     oa_system = openstudio.model.AirLoopHVACOutdoorAirSystem(model, oa_controller)
     oa_system.setName(f"{name} OA System")
@@ -286,6 +330,9 @@ def create_doas_system(
                 # also ingests full zone OA: double ventilation, and the
                 # OA-laden coil inlet air distorts E+ coil sizing (#82).
                 fc.setMaximumOutdoorAirFlowRate(0.0)
+                # Cycle the fan with load (default ConstantFanVariableFlow
+                # runs it 24/7 — issue #97 EUI penalty; standards default)
+                fc.setCapacityControlMethod("CyclingFan")
                 # Tell zone sizing the DOAS pre-treats ventilation air so
                 # fan-coil loads/flows exclude it (openstudio-standards
                 # model_add_doas settings).
@@ -346,6 +393,9 @@ def create_doas_system(
         "cooling_fuel": cooling_fuel,
         "num_zones": len(zones),
         "zone_equipment": zone_equipment_list,
+        "availability_schedule": (
+            availability_schedule.nameString() if availability_schedule else None
+        ),
     }
 
 

--- a/mcp_server/skills/hvac_systems/templates.py
+++ b/mcp_server/skills/hvac_systems/templates.py
@@ -98,12 +98,13 @@ def _apply_radiant_construction(model, zone, radiant_type, construction):
 
 
 def _derive_occupancy_availability(zones: list):
-    """Most common People number-of-people schedule across the served zones.
-
-    Checks space-level People and space-type People (create_typical assigns
-    at the space type). Returns a Schedule usable as loop availability
-    (fractional occupancy works: availability semantics are 0=off, >0=on),
-    or None when no People schedules exist.
+    """The People schedule appearing most often among the served zones'
+    People OBJECTS (space-level and space-type-level — create_typical assigns
+    at the space type). Zones holding more People objects weight the vote;
+    the goal is a representative occupied-hours pattern, not per-zone
+    fairness. Returns a Schedule usable as loop availability (fractional
+    occupancy works: availability semantics are 0=off, >0=on), or None when
+    no People schedules exist.
     """
     counts: dict[str, int] = {}
     schedules: dict[str, Any] = {}

--- a/mcp_server/skills/hvac_systems/tools.py
+++ b/mcp_server/skills/hvac_systems/tools.py
@@ -126,8 +126,9 @@ def register(mcp: FastMCP) -> None:
     ) -> str:
         """Add dedicated outdoor air system (DOAS) with zone equipment.
         Ventilation-only air loop with optional ERV, paired with fan coil, radiant,
-        or chilled beam zone conditioning. Plant loops auto-wired. Ventilation is
-        demand-controlled (follows zone People schedules).
+        or chilled beam zone conditioning. Plant loops auto-wired. The DOAS loop
+        runs on the served zones' occupancy (People) schedule by default —
+        override with availability_schedule_name.
 
         Generic wiring template — for comparative studies or decision-grade
         EUI/comfort numbers use create_typical_building(system_type="DOAS with

--- a/mcp_server/skills/hvac_systems/tools.py
+++ b/mcp_server/skills/hvac_systems/tools.py
@@ -29,6 +29,13 @@ def register(mcp: FastMCP) -> None:
         ASHRAE 90.1 Appendix G baseline systems 1-10: PTAC, PTHP, PSZ-AC,
         PSZ-HP, packaged VAV reheat, PFP boxes, VAV reheat/PFP, unit heater,
         DOAS, VRF, radiant. Call list_baseline_systems() for all options.
+        Systems 3-4 are one air loop per zone — pass the full zone list and
+        the tool fans out automatically.
+
+        Generic wiring template (App G sizing factors + night cycle included,
+        but no standards equipment efficiencies). For comparative studies or
+        decision-grade EUI/comfort numbers use
+        create_typical_building(system_type=..., hvac_only=True) instead.
 
         Args:
             system_type: ASHRAE baseline system type (1-10). Call list_baseline_systems() to see options.
@@ -115,10 +122,16 @@ def register(mcp: FastMCP) -> None:
         zone_equipment_type: str = "FanCoil",
         heating_fuel: str = "NaturalGas",
         cooling_fuel: str = "Electricity",
+        availability_schedule_name: str | None = None,
     ) -> str:
         """Add dedicated outdoor air system (DOAS) with zone equipment.
         Ventilation-only air loop with optional ERV, paired with fan coil, radiant,
-        or chilled beam zone conditioning. Plant loops auto-wired.
+        or chilled beam zone conditioning. Plant loops auto-wired. Ventilation is
+        demand-controlled (follows zone People schedules).
+
+        Generic wiring template — for comparative studies or decision-grade
+        EUI/comfort numbers use create_typical_building(system_type="DOAS with
+        fan coil chiller with boiler", hvac_only=True) instead.
 
         Args:
             thermal_zone_names: List of thermal zone names to serve
@@ -127,6 +140,8 @@ def register(mcp: FastMCP) -> None:
             zone_equipment_type: FanCoil | Radiant | ChilledBeams | FourPipeBeam
             heating_fuel: NaturalGas | Electricity | DistrictHeating
             cooling_fuel: Electricity | DistrictCooling
+            availability_schedule_name: Optional schedule name — shuts the DOAS
+                fan off when unoccupied (zone equipment still holds setback)
         """
         result = operations.add_doas_system(
             thermal_zone_names=parse_str_list(thermal_zone_names),
@@ -136,6 +151,7 @@ def register(mcp: FastMCP) -> None:
             zone_equipment_type=zone_equipment_type,
             heating_fuel=heating_fuel,
             cooling_fuel=cooling_fuel,
+            availability_schedule_name=availability_schedule_name,
         )
         return json.dumps(result, indent=2)
 
@@ -149,6 +165,10 @@ def register(mcp: FastMCP) -> None:
         """Add variable refrigerant flow (VRF) multi-zone heat pump system.
         Creates single outdoor unit with individual zone terminals. Heat recovery enables
         simultaneous heating/cooling across zones.
+
+        Generic wiring template — for comparative studies or decision-grade
+        EUI/comfort numbers use create_typical_building(system_type="DOAS with
+        VRF", hvac_only=True) instead.
 
         Args:
             thermal_zone_names: List of thermal zone names to serve (max ~20 per outdoor unit)

--- a/mcp_server/skills/hvac_systems/wiring.py
+++ b/mcp_server/skills/hvac_systems/wiring.py
@@ -34,6 +34,32 @@ def add_outdoor_air_system(
     return oa_system
 
 
+def add_night_cycle_manager(
+    model,
+    air_loop,
+) -> openstudio.model.AvailabilityManagerNightCycle:
+    """Add a night-cycle availability manager to an air loop.
+
+    Cycles the system on when any zone drifts past its thermostat setpoints
+    outside the fan schedule. Without it, a system that is scheduled off (or
+    holding setback) cannot recover the zones by occupancy — issue #97's
+    mass unmet-heating hours every winter morning. CycleOnAny matches the
+    openstudio-standards default.
+
+    Args:
+        model: OpenStudio model
+        air_loop: AirLoopHVAC object
+
+    Returns:
+        AvailabilityManagerNightCycle
+    """
+    night_cycle = openstudio.model.AvailabilityManagerNightCycle(model)
+    night_cycle.setName(f"{air_loop.nameString()} Night Cycle")
+    night_cycle.setControlType("CycleOnAny")
+    air_loop.addAvailabilityManager(night_cycle)
+    return night_cycle
+
+
 def create_setpoint_manager_single_zone_reheat(
     model,
     zone,

--- a/mcp_server/skills/prompts_resources/tools.py
+++ b/mcp_server/skills/prompts_resources/tools.py
@@ -24,26 +24,38 @@ def register(mcp):
     @mcp.prompt(
         name="baseline_comparison",
         description=(
-            "Compare two ASHRAE 90.1 baseline HVAC systems on the same "
-            "building geometry. Returns a step-by-step tool sequence."
+            "Compare two HVAC systems on the same building with "
+            "standards-tuned equipment (decision-grade results). Returns a "
+            "step-by-step tool sequence."
         ),
     )
     def baseline_comparison_prompt(
-        system_a: str = "03",
-        system_b: str = "07",
+        system_a: str = "PSZ-AC with gas coil",
+        system_b: str = "VAV chiller with gas boiler reheat",
         climate_city: str = "Chicago",
     ) -> str:
+        # hvac_only swaps preserve loads/schedules between candidates, and the
+        # standards path applies real equipment efficiencies and controls —
+        # generic add_baseline_system templates are for wiring, not comparisons
+        # (issue #97: they produced misleading EUI/comfort numbers)
         return (
-            f"Compare ASHRAE baseline System {system_a} vs System {system_b} "
-            f"for a 10-zone office in {climate_city}.\n\n"
+            f"Compare HVAC system '{system_a}' vs '{system_b}' "
+            f"for an office in {climate_city}, with decision-grade results.\n\n"
             "Steps:\n"
             f'1. create_new_building(building_type="SmallOffice", '
-            f'weather_file="/inputs/{climate_city}.epw")\n'
-            f'2. add_baseline_system(system_type="{system_a}")\n'
-            "3. save_osm_model() and run_simulation()\n"
-            "4. extract_summary_metrics() — note EUI and unmet hours\n"
-            f'5. Repeat steps 1-4 with system_type="{system_b}"\n'
-            "6. Compare EUI, heating/cooling energy, and unmet hours"
+            f'weather_file="/inputs/{climate_city}.epw")  # builds typical model\n'
+            f'2. create_typical_building(system_type="{system_a}", '
+            'hvac_only=True)  # standards-tuned swap, loads untouched\n'
+            '3. save_osm_model() and run_simulation()\n'
+            "4. get_run_status() until complete\n"
+            f'5. create_typical_building(system_type="{system_b}", '
+            'hvac_only=True)  # swap to candidate B on the SAME model\n'
+            "6. save_osm_model() and run_simulation()\n"
+            "7. compare_runs(run_id_a, run_id_b) — EUI, end uses, unmet hours\n\n"
+            "Note: system_type takes openstudio-standards names — call "
+            "create_typical_building's docs or list them via the tool schema. "
+            "Do NOT use add_baseline_system for comparisons; it is a generic "
+            "wiring template without standards efficiencies."
         )
 
     @mcp.prompt(

--- a/tests/test_generic_hvac_comfort.py
+++ b/tests/test_generic_hvac_comfort.py
@@ -1,0 +1,134 @@
+"""Comfort viability of generic HVAC templates (issue #97).
+
+Replicates the issue's failure mode on a 10k ft2 SmallOffice bar (Boston 5A,
+90.1-2019 typical loads + setback thermostats): strip HVAC, add the generic
+system, simulate, check comfort/energy.
+
+Dev benchmark (2026-07-28), unfixed -> fixed:
+  system 5 (PVAV reheat): 1807.2 -> 222.2 unmet heating hrs
+    (root cause: VAV terminal DamperHeatingAction=Normal caps heating at
+    minimum airflow; standards uses Reverse. Standards PVAV on this same
+    building: 343.7)
+  DOAS FanCoil: 164.3 -> 125.1 kBtu/ft2 EUI, 51.0 -> 49.5 unmet htg hrs
+    (root cause: no availability schedule, conditioning design OA 24/7; now
+    defaults to the served zones' People schedule — OfficeSmall BLDG_OCC_SCH
+    on this benchmark)
+"""
+import asyncio
+import json
+import time
+import uuid
+
+import pytest
+from conftest import integration_enabled, server_params, unwrap
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+EPW = ("/opt/comstock-measures/ChangeBuildingLocation"
+       "/tests/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
+
+
+def _unique(prefix: str = "pytest_comfort97") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+# Thresholds sit midway between the fixed dev-benchmark values and the pre-fix
+# failures, so normal E+/standards version drift passes but a regression to
+# the old behavior cannot.
+SYS5_UNMET_HEATING_MAX = 700    # fixed: 222.2, broken: 1807.2
+DOAS_EUI_MAX = 145.0            # fixed: 125.1, broken: 164.3
+DOAS_UNMET_HEATING_MAX = 100    # fixed: 49.5 (sanity bound)
+
+
+async def _strip_hvac(s):
+    for tool, key in (("list_air_loops", "air_loops"),
+                      ("list_plant_loops", "plant_loops"),
+                      ("list_zone_hvac_equipment", "equipment")):
+        listing = unwrap(await s.call_tool(tool, {}))
+        for item in listing.get(key, []):
+            r = unwrap(await s.call_tool("delete_object", {"object_name": item["name"]}))
+            assert r["ok"] is True, f"delete {item['name']} failed: {r.get('error')}"
+
+
+async def _sim_metrics(s, name):
+    sv = unwrap(await s.call_tool("save_osm_model", {"osm_path": f"/runs/{name}.osm"}))
+    assert sv["ok"] is True, sv
+    sim = unwrap(await s.call_tool("run_simulation", {"osm_path": f"/runs/{name}.osm"}))
+    assert sim["ok"] is True, f"run_simulation failed: {sim.get('error')}"
+    t0 = time.time()
+    while True:
+        st = unwrap(await s.call_tool("get_run_status", {"run_id": sim["run_id"]}))
+        state = (st.get("run", {}).get("status") or "?").lower()
+        if state in ("success", "failed", "error", "cancelled"):
+            break
+        assert time.time() - t0 < 1200, "simulation timed out"
+        await asyncio.sleep(3)
+    assert state == "success", f"simulation failed: {st}"
+    m = unwrap(await s.call_tool("extract_summary_metrics", {"run_id": sim["run_id"]}))
+    assert m["ok"] is True, m
+    return m["metrics"]
+
+
+@pytest.mark.integration
+def test_generic_templates_comfort_viability():
+    """Generic system 5 and DOAS produce livable comfort/energy out of the box."""
+    # Regression: issue #97 — system 5 accumulated 1807 occupied unmet heating
+    # hours (damper action Normal) and DOAS burned 164 kBtu/ft2 (24/7 design-
+    # flow OA conditioning) on this exact benchmark before the fixes
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                bar = unwrap(await s.call_tool("create_bar_building", {
+                    "building_type": "SmallOffice", "climate_zone": "5A"}))
+                assert bar["ok"] is True, bar.get("error")
+                wr = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": EPW}))
+                assert wr["ok"] is True, wr.get("error")
+                typ = unwrap(await s.call_tool("create_typical_building", {
+                    "template": "90.1-2019", "climate_zone": "ASHRAE 169-2013-5A"}))
+                assert typ["ok"] is True, typ.get("error")
+                zones = unwrap(await s.call_tool("list_thermal_zones", {"max_results": 0}))
+                zone_names = [z["name"] for z in zones["thermal_zones"]]
+
+                # --- System 5 (PVAV reheat) ---
+                await _strip_hvac(s)
+                r5 = unwrap(await s.call_tool("add_baseline_system", {
+                    "system_type": 5, "thermal_zone_names": zone_names}))
+                assert r5["ok"] is True, r5.get("error")
+                assert r5["system"]["night_cycle_managers"], \
+                    "system 5 air loop should get a night-cycle manager"
+                m5 = await _sim_metrics(s, _unique("sys5"))
+                assert m5["unmet_hours_heating"] < SYS5_UNMET_HEATING_MAX, (
+                    f"system 5 unmet heating {m5['unmet_hours_heating']} hrs — "
+                    f"regressed toward the pre-fix 1807 (damper action?)"
+                )
+
+                # --- DOAS (FanCoil) ---
+                await _strip_hvac(s)
+                rd = unwrap(await s.call_tool("add_doas_system", {
+                    "thermal_zone_names": zone_names,
+                    "zone_equipment_type": "FanCoil"}))
+                assert rd["ok"] is True, rd.get("error")
+                assert rd["system"]["availability_schedule"] is not None, (
+                    "DOAS on an occupied model must default to an occupancy-"
+                    "derived availability schedule"
+                )
+                md = await _sim_metrics(s, _unique("doas"))
+                assert md["eui_kBtu_ft2"] < DOAS_EUI_MAX, (
+                    f"DOAS EUI {md['eui_kBtu_ft2']:.1f} kBtu/ft2 — regressed "
+                    f"toward the pre-fix 164 (24/7 OA conditioning?)"
+                )
+                assert md["unmet_hours_heating"] < DOAS_UNMET_HEATING_MAX, (
+                    f"DOAS unmet heating {md['unmet_hours_heating']} hrs"
+                )
+                print("benchmark:", json.dumps({
+                    "sys5": {k: m5.get(k) for k in
+                             ("unmet_hours_heating", "eui_kBtu_ft2")},
+                    "doas": {k: md.get(k) for k in
+                             ("unmet_hours_heating", "eui_kBtu_ft2")},
+                }))
+    asyncio.run(_run())

--- a/tests/test_generic_hvac_comfort.py
+++ b/tests/test_generic_hvac_comfort.py
@@ -38,6 +38,10 @@ def _unique(prefix: str = "pytest_comfort97") -> str:
 SYS5_UNMET_HEATING_MAX = 700    # fixed: 222.2, broken: 1807.2
 DOAS_EUI_MAX = 145.0            # fixed: 125.1, broken: 164.3
 DOAS_UNMET_HEATING_MAX = 100    # fixed: 49.5 (sanity bound)
+SYS4_UNMET_HEATING_MAX = 600    # fixed: 199.8, broken: 1416.5 (loose coils)
+SYS4_UNMET_COOLING_MAX = 100    # fixed: 0.0 (continuous-fan variant hit 366)
+VRF_UNMET_HEATING_MAX = 900     # fixed: 518.2, broken: E+ fatal (never ran)
+VRF_UNMET_COOLING_MAX = 100     # fixed: 0.0
 
 
 async def _strip_hvac(s):
@@ -130,5 +134,71 @@ def test_generic_templates_comfort_viability():
                              ("unmet_hours_heating", "eui_kBtu_ft2")},
                     "doas": {k: md.get(k) for k in
                              ("unmet_hours_heating", "eui_kBtu_ft2")},
+                }))
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_heat_pump_and_vrf_viability():
+    """Generic system 4 (PSZ-HP) and VRF simulate and hold comfort."""
+    # Regression: issue #97 follow-up — sys 4's loose coils sized the backup
+    # electric coil to ~44% of design load and autosizing capped supplemental
+    # supply air at 16.7C (1416 unmet htg hrs); VRF paired an FTC-HR outdoor
+    # unit with standard terminals and shipped self-inconsistent PLR defaults,
+    # so it had NEVER completed a simulation (E+ fatal)
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                bar = unwrap(await s.call_tool("create_bar_building", {
+                    "building_type": "SmallOffice", "climate_zone": "5A"}))
+                assert bar["ok"] is True, bar.get("error")
+                wr = unwrap(await s.call_tool("change_building_location", {
+                    "weather_file": EPW}))
+                assert wr["ok"] is True, wr.get("error")
+                typ = unwrap(await s.call_tool("create_typical_building", {
+                    "template": "90.1-2019", "climate_zone": "ASHRAE 169-2013-5A"}))
+                assert typ["ok"] is True, typ.get("error")
+                zones = unwrap(await s.call_tool("list_thermal_zones", {"max_results": 0}))
+                zone_names = [z["name"] for z in zones["thermal_zones"]]
+
+                # --- System 4 (PSZ-HP, unitary composite, fan-out) ---
+                await _strip_hvac(s)
+                r4 = unwrap(await s.call_tool("add_baseline_system", {
+                    "system_type": 4, "thermal_zone_names": zone_names}))
+                assert r4["ok"] is True, r4.get("error")
+                assert r4["system"]["zones_served"] == len(zone_names)
+                m4 = await _sim_metrics(s, _unique("sys4"))
+                assert m4["unmet_hours_heating"] < SYS4_UNMET_HEATING_MAX, (
+                    f"system 4 unmet heating {m4['unmet_hours_heating']} hrs — "
+                    f"regressed toward the pre-fix 1416 (backup sizing/supply cap?)"
+                )
+                assert m4["unmet_hours_cooling"] < SYS4_UNMET_COOLING_MAX, (
+                    f"system 4 unmet cooling {m4['unmet_hours_cooling']} hrs — "
+                    f"continuous-fan heat regression?"
+                )
+
+                # --- VRF (was: EnergyPlus fatal, never simulated) ---
+                await _strip_hvac(s)
+                rv = unwrap(await s.call_tool("add_vrf_system", {
+                    "thermal_zone_names": zone_names}))
+                assert rv["ok"] is True, rv.get("error")
+                mv = await _sim_metrics(s, _unique("vrf"))
+                assert mv["unmet_hours_heating"] < VRF_UNMET_HEATING_MAX, (
+                    f"VRF unmet heating {mv['unmet_hours_heating']} hrs"
+                )
+                assert mv["unmet_hours_cooling"] < VRF_UNMET_COOLING_MAX, (
+                    f"VRF unmet cooling {mv['unmet_hours_cooling']} hrs"
+                )
+                print("benchmark:", json.dumps({
+                    "sys4": {k: m4.get(k) for k in
+                             ("unmet_hours_heating", "unmet_hours_cooling",
+                              "eui_kBtu_ft2")},
+                    "vrf": {k: mv.get(k) for k in
+                            ("unmet_hours_heating", "unmet_hours_cooling",
+                             "eui_kBtu_ft2")},
                 }))
     asyncio.run(_run())

--- a/tests/test_hvac_systems.py
+++ b/tests/test_hvac_systems.py
@@ -382,9 +382,10 @@ def test_add_baseline_system_4_psz_hp():
     asyncio.run(_run())
 
 
-def test_system_4_multi_zone_rejection():
-    """Test System 4 rejects multiple zones."""
-    # Validates: PSZ systems (single-zone) reject multi-zone input with clear error
+def test_system_4_multi_zone_fanout():
+    """System 4 with a zone list fans out to one PSZ-HP per zone."""
+    # Regression: issue #97 — systems 1-4 rejected multi-zone input, forcing
+    # 27 calls for 27 zones; now one call creates one air loop per zone
     name = "test_sys4_multi_zone"
 
     async def _run():
@@ -410,15 +411,25 @@ def test_system_4_multi_zone_rejection():
                 # Ensure we have at least 2 zones
                 assert len(zone_names) >= 2
 
-                # Try to add PSZ-HP with 2 zones (should fail)
                 system_resp = await session.call_tool("add_baseline_system", {
                     "system_type": 4,
                     "thermal_zone_names": zone_names[:2],
                 })
                 system_data = unwrap(system_resp)
 
-                assert system_data["ok"] is False
-                assert "requires exactly 1 zone" in system_data["error"]
+                assert system_data["ok"] is True, f"fan-out failed: {system_data.get('error')}"
+                sys_info = system_data["system"]
+                assert sys_info["zones_served"] == 2
+                assert len(sys_info["per_zone_systems"]) == 2, \
+                    "expected one PSZ-HP per zone from a single call"
+                # One air loop per zone actually exists in the model
+                loops = unwrap(await session.call_tool("list_air_loops", {}))
+                loop_names = [al["name"] for al in loops["air_loops"]]
+                for per_zone in sys_info["per_zone_systems"]:
+                    assert per_zone["air_loop"] in loop_names, \
+                        f"per-zone air loop {per_zone['air_loop']} missing from model"
+                # Night cycle on each fanned-out loop
+                assert len(sys_info["night_cycle_managers"]) == 2
 
     asyncio.run(_run())
 

--- a/tests/test_hvac_validation.py
+++ b/tests/test_hvac_validation.py
@@ -256,14 +256,14 @@ class TestSystem4:
                     )
                     result.update(main)
 
-                    # Single-zone-only test: create second zone, try 2 zones
+                    # Multi-zone fan-out: create second zone, add with 2 zones
                     await s.call_tool("create_thermal_zone", {"name": "Zone 2"})
-                    err_resp = unwrap(await s.call_tool("add_baseline_system", {
+                    fanout_resp = unwrap(await s.call_tool("add_baseline_system", {
                         "system_type": 4,
                         "thermal_zone_names": [zone_name, "Zone 2"],
                         "system_name": "PSZ HP 2",
                     }))
-                    result["multi_zone_error"] = err_resp
+                    result["multi_zone_fanout"] = fanout_resp
 
         asyncio.run(_go())
         return result
@@ -301,10 +301,13 @@ class TestSystem4:
         # Validates: System 4 uses heat pump DX cooling
         assert data["system"]["system"]["cooling"] == "Heat Pump"
 
-    def test_single_zone_only(self, data):
-        # Validates: System 4 rejects multi-zone requests (single-zone only)
-        assert data["multi_zone_error"]["ok"] is False
-        assert "exactly 1 zone" in data["multi_zone_error"]["error"].lower()
+    def test_multi_zone_fanout(self, data):
+        # Regression: issue #97 — System 4 rejected multi-zone requests
+        # (27 calls for 27 zones); now fans out to one PSZ-HP per zone
+        fanout = data["multi_zone_fanout"]
+        assert fanout["ok"] is True, f"fan-out failed: {fanout.get('error')}"
+        assert fanout["system"]["zones_served"] == 2
+        assert len(fanout["system"]["per_zone_systems"]) == 2
 
 
 @pytest.mark.integration

--- a/tests/test_replace_air_terminals.py
+++ b/tests/test_replace_air_terminals.py
@@ -1,5 +1,6 @@
 """Integration tests for replace_air_terminals."""
 import asyncio
+from pathlib import Path
 
 import pytest
 from conftest import integration_enabled, server_params, unwrap
@@ -615,4 +616,56 @@ def test_replace_four_pipe_beam_no_loops():
                 assert replace_data["ok"] is False
                 assert "chilled water" in replace_data["error"].lower() or "hot water" in replace_data["error"].lower()
 
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_vav_reheat_replacement_sets_reverse_damper():
+    """Replacement VAV reheat terminals get DamperHeatingAction=Reverse."""
+    # Regression: issue #97 follow-up — _create_vav_reheat_terminal left the
+    # damper action at Normal (heating capped at minimum airflow), quietly
+    # reintroducing the underheating bug fixed in baseline systems 5/7
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                name = "test_replace_vav_damper"
+                create_resp = unwrap(await session.call_tool(
+                    "create_example_osm", {"name": name}))
+                assert create_resp["ok"] is True, create_resp
+                load_resp = unwrap(await session.call_tool(
+                    "load_osm_model", {"osm_path": create_resp["osm_path"]}))
+                assert load_resp["ok"] is True, load_resp
+                zones_resp = unwrap(await session.call_tool(
+                    "list_thermal_zones", {"max_results": 0}))
+                zone_names = [z["name"] for z in zones_resp["thermal_zones"]]
+
+                sys_resp = unwrap(await session.call_tool("add_baseline_system", {
+                    "system_type": 7, "thermal_zone_names": zone_names,
+                    "system_name": "VAV Damper Test",
+                }))
+                assert sys_resp["ok"] is True, sys_resp.get("error")
+
+                replace_resp = unwrap(await session.call_tool("replace_air_terminals", {
+                    "air_loop_name": "VAV Damper Test",
+                    "terminal_type": "VAV_Reheat",
+                }))
+                assert replace_resp["ok"] is True, replace_resp.get("error")
+
+                osm_path = f"/runs/{name}_damper.osm"
+                save_resp = unwrap(await session.call_tool(
+                    "save_osm_model", {"osm_path": osm_path}))
+                assert save_resp["ok"] is True, save_resp
+                text = Path(osm_path).read_text(encoding="utf-8")
+                blocks = text.split("OS:AirTerminal:SingleDuct:VAV:Reheat,")[1:]
+                assert blocks, "no VAV reheat terminals found after replacement"
+                for block in blocks:
+                    body = block.split(";")[0]
+                    assert "Reverse" in body, (
+                        "replacement VAV reheat terminal left DamperHeatingAction "
+                        f"at Normal:\n{body[:600]}"
+                    )
     asyncio.run(_run())


### PR DESCRIPTION
Follow-up to #108 — fixes the generic tools themselves. With #108 (decision-grade sweeps) this closes #97.

## Benchmark-driven, honestly reported
All changes verified on a repro of the issue's failure mode (10k ft² SmallOffice bar, Boston 5A, 90.1-2019 typical loads + setback thermostats; strip HVAC → add generic system → annual sim). Notably, the first-pass hypotheses — App G sizing factors, night-cycle managers, DCV — moved the benchmark **zero** (bit-identical results): typical-built models already carry the sizing factors, night cycle is dormant with always-on fans, and DCV can't reduce flow on a constant-volume 100%-OA loop. The benchmark loop exposed the real levers:

- **System 5/7 unmet heating, 1807 → 222 hrs** (standards PVAV on the same building: 344): VAV reheat terminals defaulted to `DamperHeatingAction=Normal`, capping heating at minimum airflow. Now `Reverse`, matching openstudio-standards.
- **DOAS EUI, 164 → 125 kBtu/ft²**: no availability schedule meant conditioning design OA 24/7. The loop now defaults to the served zones' own People schedule (availability semantics: >0 = on) — offices get office hours, 24/7 buildings stay always-on, models without People keep today's behavior. `availability_schedule_name` overrides. Fan coils set `CyclingFan` explicitly (the FT already translated `FanOnOff` as cycling — cosmetic alignment).

The inert-on-this-benchmark changes are kept as defense-in-depth, labeled as such: sizing factors + night cycle matter on models *not* built via `create_typical_building`; DCV is the correct intent flag for any recirculating retrofit.

## Ergonomics + routing (issue items 1 & 3)
- Systems 3/4 fan out over a zone list (one air loop per zone, one call instead of 27); per-zone results + validation aggregated. Two tests asserting the old rejection rewritten to assert the fan-out contract.
- Tool descriptions on `add_baseline_system`/`add_doas_system`/`add_vrf_system` now state "generic wiring template" and route comparative studies to `create_typical_building(system_type=..., hvac_only=True)`.

## Behavior change note
Default-on (approved): existing models rebuilt with these tools will show different (more correct) results — systems 5/7 heat properly, DOAS runs occupied hours.

## Tests
- New `tests/test_generic_hvac_comfort.py` (CI shard 5): replicates the benchmark, thresholds midway between fixed and broken values (700 hrs / 145 kBtu/ft²) so version drift passes but regression to old behavior cannot.
- Structural asserts: night-cycle managers present, DOAS availability schedule derived, fan-out shape.
- Sweep green: 135 passed across test_generic_hvac_comfort, test_hvac_systems, test_doas_system, test_hvac, test_hvac_supply_sim, test_hvac_validation, test_replace_zone_terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)