### PR TITLE
Wizard hardening for #115: scope reset, dedupe, atomic batch, generation guard, simple-path validation

### DIFF
--- a/mcp_server/model_manager.py
+++ b/mcp_server/model_manager.py
@@ -38,6 +38,11 @@ class _SessionState:
     model: openstudio.model.Model | None = None
     path: Path | None = None
     last_access: float = 0.0  # time.monotonic() of last touch
+    # Bumped every time `model` is replaced. Session-scoped skill state (see
+    # `extra`) records this at capture time to detect that the model it
+    # references was swapped out — id(model) can't be trusted for that
+    # because CPython reuses freed addresses.
+    generation: int = 0
     # Generic scratch space for skills that need session-scoped state beyond
     # the model itself (e.g. a multi-turn wizard). Keyed by skill name so
     # unrelated skills can't collide. Shares this session's TTL/LRU eviction,
@@ -97,6 +102,7 @@ def load_model(osm_path: Path, version_translate: bool = True) -> openstudio.mod
         st = _sessions.setdefault(key, _SessionState())
         st.model = model
         st.path = Path(osm_path)
+        st.generation += 1
         _touch(st)
     return model
 
@@ -151,6 +157,18 @@ def get_model_if_loaded() -> openstudio.model.Model | None:
             return None
         _touch(st)
         return st.model
+
+
+def model_generation() -> int:
+    """Monotonic per-session counter, bumped on every load_model.
+
+    Session-scoped skill state (see get_session_extra) records this at
+    capture time and compares later to detect that the model it references
+    was replaced. Returns 0 if the session has never loaded a model.
+    """
+    with _lock:
+        st = _sessions.get(session_key())
+        return st.generation if st else 0
 
 
 def get_session_extra() -> dict[str, Any]:

--- a/mcp_server/skills/space_type_assignment/operations.py
+++ b/mcp_server/skills/space_type_assignment/operations.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import openstudio
 
-from mcp_server.model_manager import get_model
+from mcp_server.model_manager import get_model, model_generation
 from mcp_server.osm_helpers import fetch_object, is_conditioned_zone, parse_str_list
 from mcp_server.skills.model_management.operations import save_osm_model
 from mcp_server.skills.space_type_assignment import wizard_state
@@ -109,6 +109,35 @@ def _get_or_create_space_type(model, template: str, building_type: str, space_ty
     return st, False
 
 
+def _validate_combo(model, template: str, building_type: str, space_type: str) -> dict[str, Any] | None:
+    """Validate a standards triple against the SDK's suggested lists.
+
+    Returns an ok=False error dict with did_you_mean suggestions, or None if valid.
+    """
+    templates = _all_templates(model)
+    if template not in templates:
+        return {
+            "ok": False,
+            "error": f"'{template}' is not a known standards_template",
+            "did_you_mean": difflib.get_close_matches(template, templates, n=5),
+        }
+    building_types = _building_types_for_template(model, template)
+    if building_type not in building_types:
+        return {
+            "ok": False,
+            "error": f"'{building_type}' is not a valid standards_building_type for {template}",
+            "did_you_mean": difflib.get_close_matches(building_type, building_types, n=5),
+        }
+    space_types = _space_types_for(model, template, building_type)
+    if space_type not in space_types:
+        return {
+            "ok": False,
+            "error": f"'{space_type}' is not a valid standards_space_type for ({template}, {building_type})",
+            "did_you_mean": difflib.get_close_matches(space_type, space_types, n=5),
+        }
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Path A — simple, one shot
 # ---------------------------------------------------------------------------
@@ -124,6 +153,10 @@ def assign_space_type_simple(
         spaces = _list_conditioned_spaces(model)
         if not spaces:
             return {"ok": False, "error": "No conditioned (heated and cooled) zones found in the model."}
+
+        invalid = _validate_combo(model, standards_template, standards_building_type, standards_space_type)
+        if invalid:
+            return invalid
 
         space_type, reused = _get_or_create_space_type(
             model, standards_template, standards_building_type, standards_space_type,
@@ -147,11 +180,11 @@ def assign_space_type_simple(
 # Path B — wizard
 # ---------------------------------------------------------------------------
 
-def _require_wizard(model) -> tuple[WizardState | None, dict[str, Any] | None]:
+def _require_wizard() -> tuple[WizardState | None, dict[str, Any] | None]:
     state = wizard_state.get()
     if state is None:
         return None, {"ok": False, "error": "No space type wizard active. Call start_space_type_wizard first."}
-    if state.model_id != id(model):
+    if state.model_generation != model_generation():
         return None, {
             "ok": False,
             "error": "Model changed since the wizard started (reloaded/replaced). Call start_space_type_wizard again.",
@@ -191,7 +224,7 @@ def start_space_type_wizard() -> dict[str, Any]:
             idx: PendingRow(**_extract_conditioned_space_row(space))
             for idx, space in enumerate(sorted(spaces, key=lambda s: s.nameString()))
         }
-        wizard_state.set_state(WizardState(model_id=id(model), pending=pending))
+        wizard_state.set_state(WizardState(model_generation=model_generation(), pending=pending))
         return {
             "ok": True,
             "conditioned_space_count": len(pending),
@@ -207,7 +240,7 @@ def choose_space_type_templates(templates: list[str] | str) -> dict[str, Any]:
     """Narrow the wizard to one or more standards templates."""
     try:
         model = get_model()
-        state, err = _require_wizard(model)
+        state, err = _require_wizard()
         if err:
             return err
 
@@ -224,6 +257,11 @@ def choose_space_type_templates(templates: list[str] | str) -> dict[str, Any]:
                 "available_templates": available,
             }
 
+        # Changing templates invalidates the narrower choices made under the
+        # old ones — force choose_space_type_building_types to be re-run.
+        if set(names) != set(state.templates):
+            state.building_types = []
+            state.valid_combos = set()
         state.templates = names
         building_types: set[str] = set()
         for template in names:
@@ -248,7 +286,7 @@ def choose_space_type_building_types(
     """Narrow the wizard to one or more building types, then show the space table."""
     try:
         model = get_model()
-        state, err = _require_wizard(model)
+        state, err = _require_wizard()
         if err:
             return err
         if not state.templates:
@@ -292,8 +330,8 @@ def choose_space_type_building_types(
 def get_space_type_wizard_status(page: int = 1, page_size: int = 40) -> dict[str, Any]:
     """Status + a paginated page of the remaining (unassigned) space table."""
     try:
-        model = get_model()
-        state, err = _require_wizard(model)
+        get_model()  # raise if no model loaded; keeps the session touched
+        state, err = _require_wizard()
         if err:
             return err
         return {
@@ -318,7 +356,7 @@ def assign_space_type_batch(
     """Assign one (template, building_type, space_type) combo to a batch of space indices."""
     try:
         model = get_model()
-        state, err = _require_wizard(model)
+        state, err = _require_wizard()
         if err:
             return err
         if not state.valid_combos:
@@ -343,7 +381,7 @@ def assign_space_type_batch(
 
         raw_indices = parse_str_list(space_indices) if isinstance(space_indices, str) else list(space_indices)
         try:
-            indices = [int(i) for i in raw_indices]
+            indices = list(dict.fromkeys(int(i) for i in raw_indices))  # dedupe, keep order
         except (TypeError, ValueError):
             return {"ok": False, "error": "space_indices must be a list of integers."}
         if not indices:
@@ -355,14 +393,24 @@ def assign_space_type_batch(
             if idx not in state.pending:
                 return {"ok": False, "error": f"Space index {idx} is not a pending space index."}
 
-        space_type, reused = _get_or_create_space_type(
-            model, standards_template, standards_building_type, standards_space_type,
-        )
+        # Resolve every space before mutating anything, so a stale handle
+        # fails the whole batch instead of leaving it half-applied.
+        resolved = []
         for idx in indices:
             row = state.pending[idx]
             space = fetch_object(model, "Space", handle=row.handle)
             if space is None:
-                return {"ok": False, "error": f"Space '{row.name}' (index {idx}) no longer exists in the model."}
+                return {
+                    "ok": False,
+                    "error": f"Space '{row.name}' (index {idx}) no longer exists in the model; "
+                             "no assignments were made.",
+                }
+            resolved.append((idx, space))
+
+        space_type, reused = _get_or_create_space_type(
+            model, standards_template, standards_building_type, standards_space_type,
+        )
+        for idx, space in resolved:
             space.setSpaceType(space_type)
             del state.pending[idx]
             state.assigned[idx] = space_type.nameString()
@@ -383,8 +431,8 @@ def assign_space_type_batch(
 def finish_space_type_wizard(force: bool = False) -> dict[str, Any]:
     """Save the model and end the wizard, once every conditioned space is assigned."""
     try:
-        model = get_model()
-        state, err = _require_wizard(model)
+        get_model()  # raise if no model loaded; save_osm_model re-fetches it
+        state, err = _require_wizard()
         if err:
             return err
         if state.pending and not force:

--- a/mcp_server/skills/space_type_assignment/wizard_state.py
+++ b/mcp_server/skills/space_type_assignment/wizard_state.py
@@ -28,7 +28,10 @@ class PendingRow:
 
 @dataclass
 class WizardState:
-    model_id: int
+    # model_manager.model_generation() at wizard start — any reload bumps the
+    # session's counter, invalidating this wizard (its handles/indices are
+    # snapshots of the old model).
+    model_generation: int
     pending: dict[int, PendingRow] = field(default_factory=dict)
     assigned: dict[int, str] = field(default_factory=dict)
     templates: list[str] = field(default_factory=list)

--- a/tests/test_space_type_assignment.py
+++ b/tests/test_space_type_assignment.py
@@ -150,10 +150,12 @@ def test_simple_path_dedupes_existing_combo():
                 await session.initialize()
                 await create_baseline_and_load(session, name)
 
+                # "Core_Retail" is a real (90.1-2016, Retail) combo per the SDK's
+                # suggested lists — assign_space_type_simple now validates these.
                 args = {
                     "standards_template": "90.1-2016",
                     "standards_building_type": "Retail",
-                    "standards_space_type": "WholeBuilding - Retail",
+                    "standards_space_type": "Core_Retail",
                 }
                 first = unwrap(await session.call_tool("assign_space_type_simple", args))
                 assert first["ok"] is True, first
@@ -434,5 +436,220 @@ def test_wizard_cancel_clears_state_not_model():
                 ))
                 assert details["ok"] is True, details
                 assert len(details["space_type"]["spaces"]) == 1, details
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_rechoose_templates_resets_downstream_scope():
+    # Regression: choose_space_type_templates kept building_types/valid_combos
+    # from the previous template choice, so after re-choosing templates,
+    # assign_space_type_batch accepted combos from a template no longer in scope.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    name = _unique_name()
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await create_baseline_and_load(session, name)
+
+                start = unwrap(await session.call_tool("start_space_type_wizard", {}))
+                assert start["ok"] is True, start
+                other = [t for t in start["available_templates"] if t != "90.1-2019"]
+                assert other, f"need a second template to re-choose: {start['available_templates']}"
+
+                assert unwrap(await session.call_tool(
+                    "choose_space_type_templates", {"templates": ["90.1-2019"]},
+                ))["ok"] is True
+                assert unwrap(await session.call_tool(
+                    "choose_space_type_building_types", {"building_types": ["Office"]},
+                ))["ok"] is True
+
+                # Change mind: narrow to a different template. Old combos must die.
+                rechoose = unwrap(await session.call_tool(
+                    "choose_space_type_templates", {"templates": [other[0]]},
+                ))
+                assert rechoose["ok"] is True, rechoose
+
+                stale = unwrap(await session.call_tool("assign_space_type_batch", {
+                    "standards_template": "90.1-2019",
+                    "standards_building_type": "Office",
+                    "standards_space_type": "OpenOffice",
+                    "space_indices": [0],
+                }))
+                assert stale["ok"] is False, (
+                    f"batch accepted a combo from the no-longer-chosen template: {stale}"
+                )
+                assert "choose_space_type_building_types" in stale["error"], stale
+
+                status = unwrap(await session.call_tool("get_space_type_wizard_status", {}))
+                assert status["ok"] is True, status
+                assert status["remaining_count"] == 10, (
+                    f"stale-combo batch mutated the model/state: {status}"
+                )
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_batch_duplicate_indices_deduped():
+    # Regression: duplicate space_indices ([0, 0, 1]) passed pre-validation
+    # (checks read unmutated state), then KeyError'd mid-mutation on the second
+    # 0 — cryptic "Failed to assign space type batch: 0" AFTER idx 0 was
+    # already assigned, so the error lied about what happened.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    name = _unique_name()
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await create_baseline_and_load(session, name)
+
+                assert unwrap(await session.call_tool("start_space_type_wizard", {}))["ok"] is True
+                assert unwrap(await session.call_tool(
+                    "choose_space_type_templates", {"templates": ["90.1-2019"]},
+                ))["ok"] is True
+                assert unwrap(await session.call_tool(
+                    "choose_space_type_building_types", {"building_types": ["Office"]},
+                ))["ok"] is True
+
+                batch = unwrap(await session.call_tool("assign_space_type_batch", {
+                    "standards_template": "90.1-2019",
+                    "standards_building_type": "Office",
+                    "standards_space_type": "OpenOffice",
+                    "space_indices": [0, 0, 1],
+                }))
+                assert batch["ok"] is True, f"duplicate indices must dedupe, not crash: {batch}"
+                assert batch["assigned_this_batch"] == 2, batch
+                assert batch["remaining_count"] == 8, batch
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_batch_missing_space_is_atomic():
+    # Regression: when a space was deleted after wizard start, assign_space_type_batch
+    # assigned earlier indices before erroring on the missing one — the error
+    # implied nothing happened but idx 0 was already assigned (partial mutation).
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    name = _unique_name()
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await create_baseline_and_load(session, name)
+
+                assert unwrap(await session.call_tool("start_space_type_wizard", {}))["ok"] is True
+                assert unwrap(await session.call_tool(
+                    "choose_space_type_templates", {"templates": ["90.1-2019"]},
+                ))["ok"] is True
+                assert unwrap(await session.call_tool(
+                    "choose_space_type_building_types", {"building_types": ["Office"]},
+                ))["ok"] is True
+
+                # Wizard idx order == spaces sorted by name; delete the space at idx 1.
+                spaces = unwrap(await session.call_tool("list_spaces", {"max_results": 0}))
+                assert spaces["ok"] is True, spaces
+                idx1_name = sorted(s["name"] for s in spaces["spaces"])[1]
+                deleted = unwrap(await session.call_tool(
+                    "delete_object", {"object_name": idx1_name, "object_type": "Space"},
+                ))
+                assert deleted["ok"] is True, deleted
+
+                batch = unwrap(await session.call_tool("assign_space_type_batch", {
+                    "standards_template": "90.1-2019",
+                    "standards_building_type": "Office",
+                    "standards_space_type": "OpenOffice",
+                    "space_indices": [0, 1],
+                }))
+                assert batch["ok"] is False, batch
+                assert "no longer exists" in batch["error"], batch
+
+                # Atomicity: the failed batch must not have assigned idx 0.
+                status = unwrap(await session.call_tool("get_space_type_wizard_status", {"page_size": 100}))
+                assert status["ok"] is True, status
+                assert status["remaining_count"] == 10, (
+                    f"failed batch partially mutated wizard state: {status}"
+                )
+                assert 0 in _parse_table(status["table_rows"]), status
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_simple_path_rejects_invalid_combo():
+    # Regression: assign_space_type_simple accepted arbitrary strings, silently
+    # creating a bogus standards combo — the exact failure mode the wizard's
+    # did_you_mean exists to prevent, on the path most exposed to freehand input.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    name = _unique_name()
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await create_baseline_and_load(session, name)
+
+                bad = unwrap(await session.call_tool("assign_space_type_simple", {
+                    "standards_template": "90.1-2019",
+                    "standards_building_type": "Office",
+                    "standards_space_type": "OpenOfice",  # typo
+                }))
+                assert bad["ok"] is False, f"typo'd space type silently accepted: {bad}"
+                assert "OpenOffice" in bad["did_you_mean"], bad
+
+                # No bogus SpaceType may have been created by the failed call.
+                listed = unwrap(await session.call_tool(
+                    "list_model_objects", {"object_type": "SpaceType", "max_results": 0},
+                ))
+                names = [o["name"] for o in listed["objects"]]
+                assert not any("OpenOfice" in n for n in names), names
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_reload_model_invalidates_wizard():
+    # Validates: a wizard started on one model refuses to act after the session
+    # loads another model — pending handles/indices describe the old model.
+    # (Guards the model-staleness contract; see also the generation-counter fix
+    # replacing the id(model) comparison, whose failure mode — CPython address
+    # reuse — is not deterministically reproducible in a test.)
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
+
+    name = _unique_name()
+
+    async def _run():
+        async with stdio_client(server_params()) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await create_baseline_and_load(session, name)
+
+                assert unwrap(await session.call_tool("start_space_type_wizard", {}))["ok"] is True
+
+                save = unwrap(await session.call_tool("save_osm_model", {}))
+                assert save["ok"] is True, save
+                reload_result = unwrap(await session.call_tool(
+                    "load_osm_model", {"osm_path": save["osm_path"]},
+                ))
+                assert reload_result["ok"] is True, reload_result
+
+                status = unwrap(await session.call_tool("get_space_type_wizard_status", {}))
+                assert status["ok"] is False, (
+                    f"wizard survived a model reload; its handles/indices are stale: {status}"
+                )
+                assert "start_space_type_wizard" in status["error"], status
 
     asyncio.run(_run())


### PR DESCRIPTION
Fixes for four bugs found reviewing #115, each proven red-green (test fails on unfixed code, passes after fix).

## Bugs + red evidence

| Bug | Red failure on unfixed code |
|-----|------------------------------|
| Re-choosing templates left stale `valid_combos` — batch accepted combos from a no-longer-chosen template | `ok: True, remaining: 9` for a `90.1-2019` combo after re-choosing another template |
| Duplicate `space_indices` passed pre-validation then KeyError'd mid-mutation | `[0,0,1]` → `"Failed to assign space type batch: 0"` after idx 0 already assigned |
| Missing space (deleted after wizard start) errored mid-batch after mutating earlier indices | failed batch left `assigned_count: 1, remaining: 9` |
| `assign_space_type_simple` accepted arbitrary strings | typo `"OpenOfice"` silently created a bogus SpaceType and assigned all 10 spaces |

## Fixes

- `choose_space_type_templates` resets `building_types`/`valid_combos` when the template set changes
- `assign_space_type_batch` dedupes indices (order-preserving) and resolves every handle before mutating — atomic; SpaceType creation moved after resolution so failed batches don't create one
- `assign_space_type_simple` validates the triple against the SDK suggested lists with `did_you_mean`, reusing the wizard's scratch-SpaceType helpers
- `id(model)` staleness guard → monotonic `_SessionState.generation` bumped in `load_model`, exposed as `model_manager.model_generation()`. The id-reuse failure mode (CPython address reuse after GC) is not deterministically testable; covered instead by a `test_reload_model_invalidates_wizard` invariant test
- Fixture fix: `test_simple_path_dedupes_existing_combo` used `("90.1-2016", "Retail", "WholeBuilding - Retail")`, which is not a real combo per `suggestedStandardsSpaceTypes()` (valid: `Core_Retail`, `Front_Retail`, `Point_of_Sale`, ...) — the unvalidated simple path was silently accepting it. Now `Core_Retail`; test intent (dedupe) unchanged.

## Testing

`pytest tests/test_space_type_assignment.py tests/test_session_isolation.py` in Docker: 16 passed. Eviction + registration suites green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)