### PR TITLE
gbXML import: bump subprocess timeout 300s->600s (flaky Austin test on develop)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,8 @@ jobs:
           # Shard timings measured via `pytest --durations=0` on 2026-08-07 after the
           # gbXML climate-zone/roof-repair work landed (see runs/shard_timing_full.log
           # for the raw per-test breakdown). Two tests inside test_gbxml_import.py
-          # (test_..._stat_file_on_austin_fixture ~233s, test_..._wmo_lookup... ~213s)
+          # (test_..._stat_file_on_austin_fixture ~233s local / ~300s on runners,
+          # test_..._wmo_lookup... ~213s)
           # alone rivaled the runtime of an entire shard, so they're pulled out by
           # node ID into shards 2/3 below rather than moving the whole file, which
           # would just relocate the imbalance. All 5 shards land within ~50s of each

--- a/mcp_server/skills/gbxml_import/operations.py
+++ b/mcp_server/skills/gbxml_import/operations.py
@@ -214,7 +214,10 @@ def import_gbxml_op(
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
                 env=run_env,
-                timeout=300,  # 5 minute timeout
+                # gbxml_import_advanced is CPU-bound surface matching; the Austin
+                # fixture alone takes ~300s on 2-core CI runners (~160s locally),
+                # so 300 flaked at the boundary — 600 gives 2x headroom.
+                timeout=600,
                 check=False,
             )
 
@@ -307,7 +310,7 @@ def import_gbxml_op(
         return result
 
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "gbXML import timed out (5 min)"}
+        return {"ok": False, "error": "gbXML import timed out (10 min)"}
     except Exception as e:
         return {"ok": False, "error": f"Failed to import gbXML: {e}"}
 


### PR DESCRIPTION
## Why

Develop CI went red after #117 merged (run 31222121002): `test_import_gbxml_resolves_climate_zone_from_stat_file_on_austin_fixture` failed with `gbXML import timed out (5 min)` at 300,076 ms. The prior PR-branch run passed the same test at 299,954 ms — 46 ms under the cap. The test sits exactly at the timeout boundary on runners.

## Root cause (verified by local repro at 7f884d6)

Reproduced in Docker against the exact merge commit: import completes in ~160s locally, and `out.osw` step timings show **`gbxml_import_advanced` accounts for 150s of the 159s workflow** — CPU-bound surface matching (user time ≈ real time, no I/O or network stall) in the upstream pinned gbxml-to-openstudio measure on the 70-space Austin fixture. On ~1.85x-slower 2-core GH runners that lands right at 300s, so the old cap is a coin flip.

## Change

- `timeout=300` → `timeout=600` in `gbxml_import/operations.py` (+ error message 5 min → 10 min). 2x headroom over observed runner runtime; a cap, so zero cost on success.
- ci.yml shard-timing comment: note the Austin test is ~300s on runners (the ~233s figure was local).

No new test: the existing Austin integration test is the regression guard — it is the test that flaked; asserting the constant's value would be tautological.

🤖 Generated with [Claude Code](https://claude.com/claude-code)