### PR TITLE
check_leg: detect usage-cap contamination (rows with no CLI metrics)

### DIFF
--- a/scripts/benchmark_check_leg.py
+++ b/scripts/benchmark_check_leg.py
@@ -1,12 +1,19 @@
 """Leg contamination detector — flags rate-limit-corrupted benchmark rows.
 
-When the CLI fails hard (e.g. HTTP 429), runner.py raises before recording
-per-test metrics, so the row inherits the PREVIOUS test's cost/tokens/tool
-list and is misclassified wrong_tool. Nothing in the row says "API error".
-Signature: tiny pytest wall-clock (duration_s) paired with a large
-carried-over CLI duration_ms. Found 1 bad leg in 48 during prod-2026-08b
-with zero false positives — run after EVERY leg; quarantine flagged legs to
-results/<sweep>/_invalid/ and re-run.
+When the CLI fails hard, runner.py raises before recording per-test
+metrics. Two observed signatures:
+
+A. Carried-over metrics (HTTP 429 mid-stream): the row inherits the
+   PREVIOUS test's cost/tokens/tool list and is misclassified wrong_tool.
+   Tiny pytest wall-clock (duration_s) paired with a large carried-over
+   CLI duration_ms. Found 1 bad leg in 48 during prod-2026-08b.
+B. No metrics at all (subscription usage cap / hard CLI rc=1): the CLI
+   returns an error message for every call, so the failed row has
+   num_turns/duration_ms/cost all None and failure_mode None. Found 9
+   bad legs in opus48-v1.2.1 (session limit), which signature A missed.
+
+Zero false positives across the 75-leg paper-v1.2.1 collection — run after
+EVERY leg; quarantine flagged legs to results/<sweep>/_invalid/ and re-run.
 
 Usage:
   python scripts/benchmark_check_leg.py results/<sweep>/<leg>.json [...]
@@ -26,10 +33,15 @@ def suspicious_rows(leg: dict) -> list[dict]:
     for row in leg.get("tests", []):
         if row.get("skipped"):
             continue
+        if row.get("passed"):
+            continue
         duration_s = row.get("duration_s") or 0
         duration_ms = row.get("duration_ms") or 0
-        if (not row.get("passed") and duration_s < 15
-                and duration_ms / 1000 > 2 * duration_s):
+        # Signature A — carried-over CLI metrics from the previous test;
+        # Signature B — CLI errored before any metrics were recorded
+        if (duration_s < 15 and duration_ms / 1000 > 2 * duration_s) or (
+                row.get("num_turns") is None
+                and row.get("duration_ms") is None):
             flagged.append(row)
     return flagged
 

--- a/tests/test_benchmark_check_leg.py
+++ b/tests/test_benchmark_check_leg.py
@@ -1,0 +1,66 @@
+"""Unit tests for scripts/benchmark_check_leg.py — contamination signatures.
+Stdlib only, no openstudio import.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from benchmark_check_leg import suspicious_rows
+
+pytestmark = pytest.mark.unit
+
+PROG = "tests/llm/test_06_progressive.py::test_progressive"
+
+
+def _row(**kw):
+    base = {"test_id": f"{PROG}[roof_insulation_L1]", "passed": False,
+            "tier": "progressive"}
+    base.update(kw)
+    return base
+
+
+def test_carried_over_metrics_signature_flagged():
+    # Regression: 429-contaminated rows inherit the previous test's CLI
+    # duration_ms while pytest wall-clock is tiny (prod-2026-08b bad leg)
+    leg = {"tests": [_row(duration_s=3.0, duration_ms=120000,
+                          num_turns=7, cost_usd=0.2)]}
+    assert len(suspicious_rows(leg)) == 1
+
+
+def test_usage_cap_rows_with_no_cli_metrics_flagged():
+    # Regression: opus48-v1.2.1 sweep hit the subscription session limit;
+    # runner raised RuntimeError before recording metrics, so rows carried
+    # failure_mode=None and NO num_turns/duration_ms/cost — check_leg
+    # passed all 9 garbage legs (exit 0) and they polluted the aggregate
+    leg = {"tests": [
+        _row(duration_s=4.7, duration_ms=None, num_turns=None,
+             cost_usd=None, output_tokens=None, failure_mode=None),
+    ]}
+    flagged = suspicious_rows(leg)
+    assert len(flagged) == 1, (
+        "hard CLI failure (rate limit / usage cap) row must be flagged"
+    )
+
+
+def test_recorded_failure_rows_not_flagged():
+    # Validates: genuine graded failures carry CLI metrics and must NOT be
+    # flagged — zero false positives across the 75-leg paper-v1.2.1 rerun
+    leg = {"tests": [
+        _row(duration_s=45.0, duration_ms=41000, num_turns=9,
+             cost_usd=0.21, output_tokens=1500,
+             failure_mode="outcome_mismatch"),
+        _row(test_id=f"{PROG}[add_hvac_L1]", passed=True, duration_s=30.0,
+             duration_ms=28000, num_turns=6, cost_usd=0.1,
+             output_tokens=900),
+    ]}
+    assert suspicious_rows(leg) == []
+
+
+def test_skipped_rows_ignored():
+    # Validates: prerequisite-skip rows have no metrics by design and are
+    # not contamination
+    leg = {"tests": [_row(skipped=True, duration_s=0.0, duration_ms=None,
+                          num_turns=None)]}
+    assert suspicious_rows(leg) == []


### PR DESCRIPTION
During an exploratory Opus 4.8 sweep the Claude subscription session limit made every CLI call fail (rc=1, ~5 s, $0). `runner.py` raises before recording per-test metrics, so the rows carry `failure_mode=None` with `num_turns`/`duration_ms`/`cost_usd` all null — a shape signature A (carried-over metrics) does not match. `check_leg` passed all 9 garbage legs.

- Adds signature B to `suspicious_rows`: failed, unskipped row with `num_turns is None and duration_ms is None`
- Red-green: `tests/test_benchmark_check_leg.py` (new, unit tier) — usage-cap test fails on the unfixed detector
- Validation: flags all 9 quarantined opus48 legs; zero false positives across the 81 clean v1.2.1 legs (paper 57 + t240 12 + codegen 6 + opus48 valid 6)
- Does not affect the frozen paper collection (host-side analysis tool only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)