### PR TITLE
Benchmark: 600s-budget merged dataset builder

### DIFF
--- a/scripts/benchmark_build_t600_dataset.py
+++ b/scripts/benchmark_build_t600_dataset.py
@@ -1,0 +1,258 @@
+"""Build the 600s-budget merged benchmark dataset (censored-row substitution).
+
+A 120s-timeout row is a CENSORED observation: the run did not finish, so
+we know it was slow, not that it was wrong. Rows that completed under the
+cap (pass or graded fail) are valid observations under any larger budget.
+This builder merges each base sweep with its 600s rerun sweep:
+
+  kept row         passed, or failed with is_timeout falsy -> copied
+                   unchanged, `exceeded_120s: false`.
+  substituted row  failed AND is_timeout -> replaced by the 600s rerun row
+                   at the same (model, arm, task, repeat), OUTCOME-BLIND:
+                   the rerun's verdict stands even if it failed grading or
+                   timed out again (`exceeded_600s: true`). Cherry-picking
+                   in either direction is p-hacking.
+  missing rerun    original timeout kept, `substitution_missing: true`,
+                   reported loudly; exit 1 unless --allow-missing.
+
+Source legs are NEVER edited (run_config signs them). Derived legs keep
+the base leg's run_config so the aggregator pools them, plus a `derived`
+block naming both source sweeps. Also emits MERGE_MANIFEST.md (every
+substitution: cell, old->new duration and verdict) and LATENCY.md
+(>120s count, share of rows, median substituted duration per model).
+
+Usage:
+  python scripts/benchmark_build_t600_dataset.py --out results/paper-v1.2.1-merged \
+    --pair results/paper-v1.2.1=results/paper-v1.2.1-t600fix \
+    --pair <worktree>/results/opus48-v1.2.1=<worktree>/results/opus48-v1.2.1-t600
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import statistics
+import sys
+from pathlib import Path
+
+
+def _task(test_id: str) -> str:
+    """'measure_replace_terminals_L1' from a progressive id, else the raw id."""
+    if "[" in test_id:
+        return test_id.rsplit("[", maxsplit=1)[-1].rstrip("]")
+    return test_id.rsplit("::", maxsplit=1)[-1]
+
+
+def _recount(leg: dict) -> None:
+    """Recompute leg-level summaries from rows (harness convention:
+    passed + failed == total_tests; pass_rate over all rows)."""
+    rows = leg["tests"]
+    n_pass = sum(1 for r in rows if r.get("passed"))
+    n_skip = sum(1 for r in rows if r.get("skipped"))
+    leg["total_tests"] = len(rows)
+    leg["passed"] = n_pass
+    leg["failed"] = len(rows) - n_pass - n_skip
+    leg["pass_rate"] = round(n_pass / len(rows) * 100, 1) if rows else 0.0
+    tiers: dict = {}
+    for r in rows:
+        if r.get("skipped"):
+            continue
+        t = tiers.setdefault(r.get("tier", "?"),
+                             {"total": 0, "passed": 0, "duration_s": 0.0})
+        t["total"] += 1
+        t["passed"] += int(bool(r.get("passed")))
+        t["duration_s"] += r.get("duration_s") or 0.0
+    for t in tiers.values():
+        t["duration_s"] = round(t["duration_s"], 1)
+        t["pass_rate"] = round(t["passed"] / t["total"] * 100, 1)
+    leg["tiers"] = tiers
+    for key, field in (("total_duration_s", "duration_s"),
+                       ("total_input_tokens", "input_tokens"),
+                       ("total_output_tokens", "output_tokens"),
+                       ("total_cache_read_tokens", "cache_read_tokens"),
+                       ("total_cost_usd", "cost_usd")):
+        total = sum(r.get(field) or 0 for r in rows if not r.get("skipped"))
+        leg[key] = round(total, 4) if isinstance(total, float) else total
+
+
+def merge_leg(base_leg: dict, rerun_leg: dict | None,
+              pair_label: str) -> tuple[dict, list[dict], list[str], list[str]]:
+    """Apply the substitution rules to one leg. Pure — no filesystem.
+
+    Returns (derived_leg, substitutions, problems, warnings). Problems are
+    data gaps (missing rerun row — nonzero exit); warnings are informational
+    (passed-but-timed-out rows kept with a latency flag; 5 exist in the
+    opus48 collection: artifact complete and graded pass, CLI killed at the
+    cap mid-summary). Each substitution dict: model/arm/repeat/task/
+    old_duration_s/new_duration_s/old/new verdicts.
+    """
+    rerun_rows = {}
+    if rerun_leg is not None:
+        for r in rerun_leg["tests"]:
+            if not r.get("skipped"):
+                rerun_rows[r["test_id"]] = r
+
+    derived = copy.deepcopy(base_leg)
+    rc = derived.get("run_config", {})
+    model, arm, rep = derived.get("model", "?"), rc.get("arm", "?"), rc.get("repeat", 0)
+    subs: list[dict] = []
+    problems: list[str] = []
+    warnings: list[str] = []
+    out_rows = []
+    for row in derived["tests"]:
+        if row.get("skipped"):
+            out_rows.append(row)
+            continue
+        cell = f"{model}/{arm}/r{rep}/{_task(row['test_id'])}"
+        if row.get("passed") or not row.get("is_timeout"):
+            if row.get("passed") and row.get("is_timeout"):
+                # Passed despite hitting the cap: artifact was complete when
+                # the CLI was killed. A valid pass at any budget — keep it,
+                # but it DID need >120s, so it carries the latency flag.
+                row["exceeded_120s"] = True
+                warnings.append(f"WARN passed-but-timeout kept: {cell}")
+            else:
+                row["exceeded_120s"] = False
+            out_rows.append(row)
+            continue
+        # failed AND is_timeout — censored; substitute outcome-blind
+        rerun = rerun_rows.get(row["test_id"])
+        if rerun is None:
+            row["exceeded_120s"] = True
+            row["substitution_missing"] = True
+            problems.append(f"MISSING rerun row: {cell} ({pair_label})")
+            out_rows.append(row)
+            continue
+        new = copy.deepcopy(rerun)
+        new["substituted_t600"] = True
+        new["original_duration_s"] = row.get("duration_s")
+        new["exceeded_120s"] = True
+        if not new.get("passed") and new.get("is_timeout"):
+            new["exceeded_600s"] = True
+        out_rows.append(new)
+        subs.append({
+            "model": model, "arm": arm, "repeat": rep,
+            "task": _task(row["test_id"]),
+            "old_duration_s": row.get("duration_s"),
+            "new_duration_s": new.get("duration_s"),
+            "old": "timeout@120s",
+            "new": ("pass" if new.get("passed")
+                    else "timeout@600s" if new.get("exceeded_600s")
+                    else new.get("failure_mode") or "fail"),
+        })
+    derived["tests"] = out_rows
+    _recount(derived)
+    derived["derived"] = {
+        "builder": "benchmark_build_t600_dataset.py",
+        "sources": pair_label,
+        "budget_s": 600,
+        "substituted": len(subs),
+    }
+    return derived, subs, problems, warnings
+
+
+def latency_stats(legs: list[dict]) -> dict:
+    """Per-model: >120s row count, share of non-skipped rows, median
+    substituted duration — the three latency metrics the paper reports."""
+    per: dict = {}
+    for leg in legs:
+        m = per.setdefault(leg.get("model", "?"),
+                           {"rows": 0, "exceeded_120s": 0, "sub_durations": []})
+        for r in leg["tests"]:
+            if r.get("skipped"):
+                continue
+            m["rows"] += 1
+            if r.get("exceeded_120s"):
+                m["exceeded_120s"] += 1
+            if r.get("substituted_t600"):
+                m["sub_durations"].append(r.get("duration_s") or 0.0)
+    for m in per.values():
+        m["share_pct"] = round(m["exceeded_120s"] / m["rows"] * 100, 1)
+        m["median_sub_duration_s"] = (
+            round(statistics.median(m["sub_durations"]), 1)
+            if m["sub_durations"] else None)
+        del m["sub_durations"]
+    return per
+
+
+def _write_reports(out: Path, legs: list[dict], subs: list[dict]) -> None:
+    lines = ["# Merge manifest — 120s timeout rows substituted by 600s reruns",
+             "", "Outcome-blind rule: every substitution recorded here kept the",
+             "rerun verdict, pass or fail. Kept rows are not listed.", "",
+             "| Model | Arm | r | Task | Old dur s | New dur s | Old | New |",
+             "|---|---|---|---|---|---|---|---|"]
+    for s in sorted(subs, key=lambda s: (s["model"], s["arm"], s["repeat"], s["task"])):
+        lines.append(f"| {s['model']} | {s['arm']} | {s['repeat']} | {s['task']} "
+                     f"| {s['old_duration_s']} | {s['new_duration_s']} "
+                     f"| {s['old']} | {s['new']} |")
+    lines += ["", f"Total substitutions: {len(subs)}"]
+    (out / "MERGE_MANIFEST.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    lines = ["# Latency — tasks needing more than 120 s (reported instead of",
+             "timeout failures; correctness is graded at the 600 s budget)", "",
+             "| Model | Rows | >120s rows | Share % | Median substituted dur s |",
+             "|---|---|---|---|---|"]
+    for model, m in sorted(latency_stats(legs).items()):
+        med = m["median_sub_duration_s"]
+        lines.append(f"| {model} | {m['rows']} | {m['exceeded_120s']} "
+                     f"| {m['share_pct']} | {med if med is not None else '—'} |")
+    (out / "LATENCY.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pair", action="append", required=True,
+                    metavar="BASE_DIR=RERUN_DIR",
+                    help="base sweep dir = its 600s rerun sweep dir (repeatable)")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--allow-missing", action="store_true",
+                    help="exit 0 even when a timeout row has no rerun row")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    all_legs, all_subs, all_problems, all_warnings = [], [], [], []
+    identities = set()
+    for pair in args.pair:
+        base_s, sep, rerun_s = pair.rpartition("=")
+        if not sep:
+            sys.exit(f"--pair must be BASE_DIR=RERUN_DIR, got: {pair}")
+        base_dir, rerun_dir = Path(base_s), Path(rerun_s)
+        label = f"{base_dir.name} + {rerun_dir.name}"
+        for f in sorted(base_dir.glob("*.json")):
+            if f.name == "sweep_meta.json":
+                continue
+            base_leg = json.loads(f.read_text(encoding="utf-8"))
+            rerun_path = rerun_dir / f.name
+            rerun_leg = (json.loads(rerun_path.read_text(encoding="utf-8"))
+                         if rerun_path.exists() else None)
+            derived, subs, problems, warnings = merge_leg(base_leg, rerun_leg,
+                                                          label)
+            if len(derived["tests"]) != len(base_leg["tests"]):
+                sys.exit(f"BUG: row count changed for {f.name}")
+            rc = derived.get("run_config", {})
+            identities.add((rc.get("git"), rc.get("image_id")))
+            (out / f.name).write_text(json.dumps(derived, indent=1),
+                                      encoding="utf-8")
+            all_legs.append(derived)
+            all_subs.extend(subs)
+            all_problems.extend(problems)
+            all_warnings.extend(warnings)
+            print(f"[leg ] {f.name}: {len(subs)} substituted"
+                  + (f", {len(problems)} problem(s)" if problems else ""))
+    if len(identities) > 1:
+        sys.exit(f"ABORT: mixed provenance across merged legs: {identities}")
+    _write_reports(out, all_legs, all_subs)
+    print(f"Merged {len(all_legs)} leg(s), {len(all_subs)} substitution(s) "
+          f"-> {out}")
+    for w in all_warnings:
+        print(w)
+    for p in all_problems:
+        print(p)
+    if all_problems and not args.allow_missing:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_benchmark_build_t600.py
+++ b/tests/test_benchmark_build_t600.py
@@ -1,0 +1,144 @@
+"""Unit tests for scripts/benchmark_build_t600_dataset.py — the censored-row
+substitution rules behind the 600s-budget merged dataset. Stdlib only.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from benchmark_build_t600_dataset import latency_stats, merge_leg
+
+pytestmark = pytest.mark.unit
+
+PROG = "tests/llm/test_06_progressive.py::test_progressive"
+
+
+def _row(task="measure_replace_terminals_L1", **kw):
+    base = {"test_id": f"{PROG}[{task}]", "passed": True, "is_timeout": False,
+            "tier": "progressive", "duration_s": 60.0, "duration_ms": 55000,
+            "num_turns": 8, "cost_usd": 0.2, "input_tokens": 10,
+            "output_tokens": 900, "cache_read_tokens": 1000}
+    base.update(kw)
+    return base
+
+
+def _leg(rows, model="claude-sonnet-4-6", arm="full", repeat=1):
+    return {"model": model, "tests": rows,
+            "run_config": {"git": "v1.2.1", "image_id": "sha256:eff",
+                           "arm": arm, "repeat": repeat,
+                           "timeout_base": 120}}
+
+
+def test_completed_rows_kept_unchanged():
+    # Validates: passes AND graded failures completed under 120s are valid
+    # observations at any larger budget — never re-run, never substituted
+    base = _leg([_row(), _row(task="roof_insulation_L2", passed=False,
+                              failure_mode="outcome_mismatch")])
+    rerun = _leg([_row(passed=False, failure_mode="wrong_tool"),
+                  _row(task="roof_insulation_L2", passed=True)])
+    derived, subs, problems, warnings = merge_leg(base, rerun, "t")
+    assert subs == [] and problems == [] and warnings == []
+    assert derived["tests"][0]["passed"] is True
+    assert derived["tests"][1]["failure_mode"] == "outcome_mismatch"
+    assert all(r["exceeded_120s"] is False for r in derived["tests"])
+    assert "substituted_t600" not in derived["tests"][0]
+
+
+def test_passed_but_timed_out_row_kept_with_latency_flag():
+    # Regression: 5 rows in the opus48-v1.2.1 collection are passed=True AND
+    # is_timeout=True (artifact complete and graded pass, CLI killed at the
+    # cap) — they must be KEPT (valid pass at any budget), latency-flagged,
+    # and reported as a warning, not a data-gap problem (exit stays 0)
+    base = _leg([_row(passed=True, is_timeout=True, duration_s=120.4)])
+    rerun = _leg([_row(passed=False, failure_mode="wrong_tool")])
+    derived, subs, problems, warnings = merge_leg(base, rerun, "t")
+    row = derived["tests"][0]
+    assert row["passed"] is True
+    assert row["exceeded_120s"] is True
+    assert "substituted_t600" not in row
+    assert subs == [] and problems == []
+    assert len(warnings) == 1 and "passed-but-timeout" in warnings[0]
+
+
+def test_timeout_row_substituted_outcome_blind():
+    # Validates: THE rule — a timed-out row takes its 600s rerun verdict even
+    # when the rerun FAILED grading; keeping the better row is p-hacking
+    base = _leg([_row(passed=False, is_timeout=True, duration_s=120.2,
+                      num_turns=0, cost_usd=0.0)])
+    rerun = _leg([_row(passed=False, is_timeout=False, duration_s=310.0,
+                       failure_mode="outcome_mismatch", cost_usd=0.5)])
+    derived, subs, problems, warnings = merge_leg(base, rerun, "t")
+    assert warnings == []
+    row = derived["tests"][0]
+    assert row["passed"] is False
+    assert row["failure_mode"] == "outcome_mismatch"
+    assert row["substituted_t600"] is True
+    assert row["exceeded_120s"] is True
+    assert row["original_duration_s"] == pytest.approx(120.2)
+    assert row["duration_s"] == pytest.approx(310.0)
+    assert "exceeded_600s" not in row
+    assert len(subs) == 1 and problems == []
+    assert subs[0]["old"] == "timeout@120s" and subs[0]["new"] == "outcome_mismatch"
+
+
+def test_rerun_timeout_at_600_stays_a_failure():
+    # Validates: a row still hitting the 600s ceiling IS a correctness
+    # failure in the merged set, flagged exceeded_600s
+    base = _leg([_row(passed=False, is_timeout=True, duration_s=120.1)])
+    rerun = _leg([_row(passed=False, is_timeout=True, duration_s=600.3)])
+    derived, subs, _, _ = merge_leg(base, rerun, "t")
+    row = derived["tests"][0]
+    assert row["passed"] is False and row["exceeded_600s"] is True
+    assert subs[0]["new"] == "timeout@600s"
+
+
+def test_missing_rerun_row_keeps_original_and_reports():
+    # Validates: a rerun gap keeps the original timeout failure and is
+    # reported loudly (builder exits nonzero without --allow-missing)
+    base = _leg([_row(passed=False, is_timeout=True, duration_s=120.0)])
+    rerun = _leg([_row(task="python_ems_control_L2", passed=True)])
+    derived, subs, problems, warnings = merge_leg(base, rerun, "t")
+    assert warnings == []
+    row = derived["tests"][0]
+    assert row["passed"] is False and row["substitution_missing"] is True
+    assert row["exceeded_120s"] is True
+    assert subs == []
+    assert len(problems) == 1 and "measure_replace_terminals_L1" in problems[0]
+
+
+def test_summary_recounted_after_substitution():
+    # Validates: leg-level pass counts/rate/cost reflect the substituted
+    # rows (harness convention passed+failed==total, rate over all rows)
+    base = _leg([_row(cost_usd=0.2),
+                 _row(task="python_ems_control_L2", passed=False,
+                      is_timeout=True, duration_s=120.0, cost_usd=0.0)])
+    rerun = _leg([_row(task="python_ems_control_L2", passed=True,
+                       duration_s=250.0, cost_usd=0.6)])
+    derived, _, _, _ = merge_leg(base, rerun, "t")
+    assert derived["passed"] == 2 and derived["failed"] == 0
+    assert derived["total_tests"] == 2
+    assert derived["pass_rate"] == pytest.approx(100.0)
+    assert derived["total_cost_usd"] == pytest.approx(0.8)
+    assert derived["tiers"]["progressive"]["passed"] == 2
+    assert derived["derived"]["substituted"] == 1
+
+
+def test_latency_stats_three_metrics():
+    # Validates: the paper's three latency metrics — >120s count, share of
+    # rows, median substituted duration — computed per model
+    base = _leg([_row(),
+                 _row(task="python_ems_control_L2", passed=False,
+                      is_timeout=True, duration_s=120.0),
+                 _row(task="python_ems_control_L3", passed=False,
+                      is_timeout=True, duration_s=120.0)])
+    rerun = _leg([_row(task="python_ems_control_L2", passed=True,
+                       duration_s=200.0),
+                  _row(task="python_ems_control_L3", passed=True,
+                       duration_s=400.0)])
+    derived, _, _, _ = merge_leg(base, rerun, "t")
+    stats = latency_stats([derived])
+    m = stats["claude-sonnet-4-6"]
+    assert m["rows"] == 3 and m["exceeded_120s"] == 2
+    assert m["share_pct"] == pytest.approx(66.7)
+    assert m["median_sub_duration_s"] == pytest.approx(300.0)


### PR DESCRIPTION
Builds the merged benchmark dataset for the 600s completion budget: 120s timeout rows are censored observations, substituted by their 600s rerun rows at the same (model, arm, task, repeat).

- **Outcome-blind rule**: the rerun verdict stands regardless of outcome (graded fail or 600s timeout stays a failure) — cherry-picking either direction would be p-hacking.
- Completed rows (pass or graded fail) are never re-run; `exceeded_120s: false`.
- Passed-but-timed-out rows (artifact complete, CLI killed at cap; 5 exist in the opus48 collection) are kept with the latency flag, reported as warnings.
- Missing rerun row keeps the original timeout failure, exits 1 (`--allow-missing` to override).
- Source legs never edited; derived legs keep base `run_config` (aggregator pools with no overrides) plus a `derived` block naming both source sweeps.
- Emits `MERGE_MANIFEST.md` (every substitution, old→new duration and verdict) and `LATENCY.md` (>120s count, share %, median substituted duration per model).

7 unit tests (`-m unit`, stdlib only, no CI shard edit needed). Validated end-to-end on the opus48 pair: 15 legs, 17 substitutions, check_leg clean, aggregate runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)