### PR TITLE
Feat test gbxml

### DIFF
--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -86,7 +86,8 @@ left once merge and weld have closed what they can.
   looks healthy there. `repair_and_validate_gbxml_geometry()` re-synchronizes automatically on
   every call, so running it after each repair (as instructed above) is what keeps the model
   simulable. Check `paired_vertex_mismatches_skipped` — those are pairs it would not guess at (a
-  side carrying windows/doors, or a mirrored polygon that collapses), and they still block
+  side carrying windows/doors, a mirrored polygon that collapses, or a mirror that would have left
+  a space with more unpaired edges than it had, which is rolled back), and they still block
   simulation. `paired_area_mismatches` is informational: E+ accepts those.
 - `repair_and_validate_gbxml_geometry()` mutates the model (via `match_surfaces()` and the pair
   sync) before reporting — if you need to inspect pre-match state, save a copy of the model first.

--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -14,9 +14,10 @@ description: Translate a Revit-exported gbXML file into an OpenStudio model, the
    `climate_zone_resolved` is `false`, call `change_building_location` explicitly before any
    ASHRAE 90.1 baseline work.
 2. `repair_and_validate_gbxml_geometry()` — always run next. Fixes shared walls left as
-   "Outdoors" internally, then reports `overlapping_surfaces_count` and
-   `non_enclosed_spaces_count` for what it can't fix on its own.
-3. If both counts are `0`, done. Otherwise diagnose and repair — see below.
+   "Outdoors" internally and re-synchronizes desynchronized interior surface pairs, then reports
+   `overlapping_surfaces_count`, `non_enclosed_spaces_count`, and
+   `paired_vertex_mismatches_skipped_count` for what it can't fix on its own.
+3. If all three counts are `0`, done. Otherwise diagnose and repair — see below.
 
 ## Fixing non-enclosed spaces
 
@@ -67,7 +68,27 @@ left once merge and weld have closed what they can.
   (matching type, boundary condition, and construction, neither carrying a window or door).
   Anything else is reported as skipped — resolve those by hand rather than expecting the
   tool to pick a winner.
-- `repair_and_validate_gbxml_geometry()` mutates the model (via `match_surfaces()`) before
-  reporting — if you need to inspect pre-match state, save a copy of the model first.
+- **Check `ground_contact_missing_count`.** gbXML exports under-declare ground contact and the
+  translator reproduces the omission — the repo's own basement fixture ends up with 1 Ground
+  surface out of 292. A buried slab or basement wall left `Outdoors` takes fictitious solar gain
+  and wind convection. `repair_and_validate_gbxml_geometry()` reports it (z = 0 is grade) but
+  never fixes it. Fix in one batched call:
+  `set_surface_boundary_conditions(surface_names=[<the reported names>],
+  outside_boundary_condition="Ground")` — it sets `NoSun`/`NoWind` automatically. **Review the
+  list first**: a slab over a crawlspace or open parking is not ground contact, and a wall only
+  partly below grade gets its above-grade portion buried too. `partially_below_grade` holds walls
+  crossing grade with less than half buried — reported, not proposed for a batch fix. `ok` is
+  unaffected by any of this, so it will not stop you; check the count yourself.
+- **The repair tools above can desynchronize interior surface pairs**, since each rewrites one
+  side of a pair in isolation. Two sides with different vertex counts make EnergyPlus abort at
+  `GetSurfaceData` before simulating — nothing else in this server catches it, `validate_model`
+  included, and `match_surfaces()` counts surfaces rather than consistent pairs so a broken pair
+  looks healthy there. `repair_and_validate_gbxml_geometry()` re-synchronizes automatically on
+  every call, so running it after each repair (as instructed above) is what keeps the model
+  simulable. Check `paired_vertex_mismatches_skipped` — those are pairs it would not guess at (a
+  side carrying windows/doors, or a mirrored polygon that collapses), and they still block
+  simulation. `paired_area_mismatches` is informational: E+ accepts those.
+- `repair_and_validate_gbxml_geometry()` mutates the model (via `match_surfaces()` and the pair
+  sync) before reporting — if you need to inspect pre-match state, save a copy of the model first.
 - After geometry is clean, spaces still need standards space types — see the
   `attribute-space-types` skill.

--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -64,6 +64,13 @@ left once merge and weld have closed what they can.
   outside_boundary_condition="Outdoors")`, which takes the whole flagged list in one call and
   keeps sun/wind exposure coherent with the condition automatically. Expect this count to be
   large on a badly broken export; on the project's own test fixture it is 103 of 117 patches.
+- **Also check `construction_fallback_count` after `patch_missing_surfaces()`.** Each patch gets a
+  construction copied from existing geometry (these models rarely have a default construction set,
+  and E+ fails without one). `construction_source` says where it came from per surface — `partner`
+  and `same_boundary` are safe; `type_only_fallback` means the only donor available had a
+  *different* boundary condition, so an exterior assembly may now sit on an interior surface.
+  `construction_warnings` explains it once rather than per surface. Review those before trusting
+  results, and correct any that are wrong with `assign_construction_to_surface`.
 - `trim_overlapping_surfaces()` only trims a pair that is genuinely the same thing twice
   (matching type, boundary condition, and construction, neither carrying a window or door).
   Anything else is reported as skipped — resolve those by hand rather than expecting the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,10 +301,11 @@ jobs:
             3)
               # controls, object mgmt, loads, building, doas, hvac, measures, measure_authoring, skill_qaqc, hvac_supply_wiring
               # + gbXML WMO-fallback climate-zone test (moved from shard 4 to balance runtime)
-              # + paired-vertex sync and ground-contact checks (in-process, no sim — measured at
-              #   ~15s and ~2s, so shard balance is unaffected wherever they land; placed here
-              #   rather than with test_geometry.py in shard 2, which already carries more)
-              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
+              # + paired-vertex sync, ground-contact, and gbXML import-timeout checks (in-process,
+              #   no sim — measured at ~15s, ~2s and ~43s, so shard balance is unaffected wherever
+              #   they land; placed here rather than with test_geometry.py in shard 2, which
+              #   already carries more)
+              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
               EXTRA_ENV=""
               ;;
             4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
               #   no sim — measured at ~15s, ~2s and ~43s, so shard balance is unaffected wherever
               #   they land; placed here rather than with test_geometry.py in shard 2, which
               #   already carries more)
-              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
+              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_patch_construction_choice.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
               EXTRA_ENV=""
               ;;
             4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
               #   no sim — measured at ~15s, ~2s and ~43s, so shard balance is unaffected wherever
               #   they land; placed here rather than with test_geometry.py in shard 2, which
               #   already carries more)
-              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
+              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
               EXTRA_ENV=""
               ;;
             4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,10 @@ jobs:
               #   no sim — measured at ~15s, ~2s and ~43s, so shard balance is unaffected wherever
               #   they land; placed here rather than with test_geometry.py in shard 2, which
               #   already carries more)
-              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_patch_construction_choice.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
+              # + geometry repair write guards (in-process setVertices fault injection, ~2s —
+              #   must not go to shard 2 with test_geometry.py: that file drives the same three
+              #   tools through the stdio server subprocess, which monkeypatch cannot reach)
+              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_geometry_write_guards.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_patch_construction_choice.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
               EXTRA_ENV=""
               ;;
             4)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,10 @@ jobs:
             3)
               # controls, object mgmt, loads, building, doas, hvac, measures, measure_authoring, skill_qaqc, hvac_supply_wiring
               # + gbXML WMO-fallback climate-zone test (moved from shard 4 to balance runtime)
-              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
+              # + paired-vertex sync and ground-contact checks (in-process, no sim — measured at
+              #   ~15s and ~2s, so shard balance is unaffected wherever they land; placed here
+              #   rather than with test_geometry.py in shard 2, which already carries more)
+              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_ground_contact.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
               EXTRA_ENV=""
               ;;
             4)

--- a/docs/examples/22_repair_and_validate_gbxml_geometry.md
+++ b/docs/examples/22_repair_and_validate_gbxml_geometry.md
@@ -21,17 +21,33 @@ actually clean before doing anything else with it. The manual way to check this 
 1. import_gbxml(gbxml_path="/inputs/25_SpacesOneZE.xml",
                  epw_path="/inputs/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw")
 2. repair_and_validate_gbxml_geometry()
-   → runs match_surfaces() internally first (fixes cross-space shared walls —
-     156 surfaces matched on this model), then reports what that can't fix:
+   → two mutating passes (match_surfaces(), which fixes cross-space shared walls —
+     156 surfaces matched on this model — then a paired-vertex sync), followed by
+     three read-only checks reporting what those can't fix:
    { ok: false,
      cross_space_surfaces_matched: 156,
      space_count: 25, surface_count: 228,
+     paired_vertex_mismatches_repaired_count: 0,
+     paired_vertex_mismatches_skipped_count: 0,
+     paired_area_mismatches_count: 0,
      overlapping_surfaces_count: 0, overlapping_surfaces: [],
      non_enclosed_spaces_count: 14,
      non_enclosed_spaces: [
        {"space": "aim2860", "floor_area_m2": 7.46, "has_floor": true, "has_roofceiling": true},
-       ... ] }
+       ... ],
+     ground_contact_missing_count: 0,
+     ground_surfaces_existing_count: 25,
+     partially_below_grade_count: 0,
+     adiabatic_below_grade_count: 0 }
 ```
+
+Three checks, not one. **Non-enclosed spaces and overlaps** are the geometry defects — they set
+`ok`. **Paired-vertex mismatches** are pairs whose two sides disagree on vertex count, which makes
+EnergyPlus abort at `GetSurfaceData` before simulating; repaired ones are fixed, skipped ones set
+`ok` false. **Ground contact** is report-only and never moves `ok`: a model with no ground
+connection still simulates, it is just wrong thermally. On the basement fixture below that check
+reports 17 buried walls against a single existing `Ground` surface — see "Missing ground
+connections" in the gbxml-import skill.
 
 Two calls total, replacing what would otherwise be dozens.
 
@@ -47,7 +63,7 @@ having a subtler non-manifold gap — see "Follow-up" below.
 | Tool | Purpose |
 |------|---------|
 | `import_gbxml` | Translate gbXML -> OSM (Example 21) |
-| `repair_and_validate_gbxml_geometry` | Fix cross-space shared walls (`match_surfaces()`, internal), then report same-space overlaps and non-enclosed spaces in one call |
+| `repair_and_validate_gbxml_geometry` | Fix cross-space shared walls (`match_surfaces()`, internal) and re-sync desynchronized surface pairs, then report same-space overlaps, non-enclosed spaces and missing ground connections in one call |
 | `repair_missing_roof_ceiling` | Follow-up fix for non-enclosed spaces that have a Floor but no RoofCeiling at all (see "Follow-up" below) |
 | `merge_coplanar_sliver_surfaces` | Follow-up fix for non-enclosed spaces fragmented into many same-space coplanar pieces (see "Follow-up" below) |
 | `weld_coincident_vertices` | Follow-up fix for non-enclosed spaces with sub-centimeter corner gaps between non-coplanar surfaces (see "Follow-up" below) |
@@ -167,9 +183,25 @@ surface, not the two a closed volume requires: a genuinely missing surface, not 
      than trusted, in case a new internal chord edge happens to coincide with an
      already-ambiguous pre-existing one.
    { ok: true, patched_count: 117, patched: [...], skipped_count: 5, skipped: [...],
-     ambiguous_boundary_condition_count: 107 }
+     ambiguous_boundary_condition_count: 103, paired_by_fallback_count: 2,
+     construction_fallback_count: 103, construction_missing_count: 0,
+     construction_warnings: [...] }
 4. repair_and_validate_gbxml_geometry()   # confirm: non_enclosed_spaces_count 67 -> 4
 ```
+
+(107 of those patches are unmatched before the ≥99%-overlap fallback pass joins 2 pairs; 103
+remain ambiguous after it.)
+
+Each patch also needs a **construction** — gbXML imports rarely carry a default construction set,
+and EnergyPlus fails outright on a surface without one. One is copied from existing geometry and
+the basis reported per surface in `construction_source`: `partner` (the matched surface's own
+construction — the same physical assembly), `same_space_same_boundary` / `same_boundary` (same
+type *and* exposure), or `type_only_fallback` (same type, **different** exposure). Only the last
+can put an exterior assembly on an interior surface, so it is counted in
+`construction_fallback_count` and explained once in `construction_warnings` rather than repeated
+on all 117 entries. It dominates here — 103 of 117 — because the fixture has no adiabatic geometry
+to copy from, which is exactly the population that ends up adiabatic. Review those before trusting
+results and correct any with `assign_construction_to_surface`.
 
 On the Austin fixture this reconstructs the large majority of the 67 remaining spaces' holes —
 mostly missing partition walls, but one (`sp-1stair`) turned out to be a missing RoofCeiling,

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -224,7 +224,7 @@ Append the new test file to the lightest shard's `FILES=` list in the `case` blo
 | `OSMCP_MAX_CONCURRENCY` | `1` | Max concurrent simulations |
 | `MCP_SIM_TIMEOUT` | `1200` | Simulation poll timeout (seconds) |
 | `MCP_POLL_SECONDS` | `3.0` | Poll interval for simulation status |
-| `OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS` | `1800` | Wall-clock cap on the gbXML measure workflow (`0` = no cap) |
+| `OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS` | `1800` | Wall-clock cap on the gbXML measure workflow (`0` or negative = no cap) |
 
 **Slow hosts and the gbXML fixtures.** `import_gbxml`'s runtime is almost entirely one measure's
 single-threaded surface matching (`gbxml_import_advanced`), so it tracks per-core speed and core

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -224,6 +224,30 @@ Append the new test file to the lightest shard's `FILES=` list in the `case` blo
 | `OSMCP_MAX_CONCURRENCY` | `1` | Max concurrent simulations |
 | `MCP_SIM_TIMEOUT` | `1200` | Simulation poll timeout (seconds) |
 | `MCP_POLL_SECONDS` | `3.0` | Poll interval for simulation status |
+| `OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS` | `1800` | Wall-clock cap on the gbXML measure workflow (`0` = no cap) |
+
+**Slow hosts and the gbXML fixtures.** `import_gbxml`'s runtime is almost entirely one measure's
+single-threaded surface matching (`gbxml_import_advanced`), so it tracks per-core speed and core
+count buys nothing. On the Austin apartment fixture that is ~300s on 2-core CI runners, ~160s on a
+fast dev box, and ~8.5 min on a slower one — where the previous hardcoded 600s cap killed the
+import mid-measure and failed
+`test_gbxml_import.py::test_geometry_repair_pipeline_on_austin_apartment_fixture` with
+`gbXML import exceeded the 600s wall-clock cap`.
+
+Contention matters as much as the host: on that same machine the import took 622-687s run on its
+own but **1228s** when the rest of `tests/test_gbxml_import.py` ran alongside it in one container.
+CI does not hit this because the heavy gbXML tests are split across shards by node ID, but a local
+whole-file run does. If you hit it, raise the cap rather than assuming the test is broken:
+
+```bash
+docker run --rm -v "C:/OS_MCP:/repo" -v "C:/OS_MCP/runs:/runs" \
+  -e RUN_OPENSTUDIO_INTEGRATION=1 -e MCP_SERVER_CMD=openstudio-mcp \
+  -e OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS=2400 \
+  openstudio-mcp:dev bash -lc "cd /repo && pytest -vv tests/test_gbxml_import.py"
+```
+
+A timeout error always names both the cap in force and this variable, so it can be acted on
+without reading the source.
 
 ### Two execution modes
 

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -116,6 +116,20 @@ SIM_TIMEOUT_SECONDS = _safe_float(
     7200.0,
 )
 
+# Wall-clock cap for the gbXML measure-workflow subprocess (import_gbxml). 0 = no cap.
+# Configurable because the runtime is almost entirely one measure's single-threaded surface
+# matching, so it tracks the host's per-core speed and nothing else. A hardcoded literal was
+# raised 300 -> 600 once already and then went marginal again; measured on the Austin fixture on
+# one slower host, the same import took 622-687s run on its own but 1228s when the rest of
+# tests/test_gbxml_import.py ran alongside it in the same container. 1800 covers that observed
+# worst case with margin instead of landing just above it, which is how the previous two values
+# each became too tight.
+GBXML_IMPORT_TIMEOUT_SECONDS = _safe_float(
+    os.environ.get("OPENSTUDIO_MCP_GBXML_IMPORT_TIMEOUT_SECONDS",
+                   os.environ.get("OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS", "1800")),
+    1800.0,
+)
+
 # Unprivileged account confined subprocesses drop to (baked into the image as
 # `sandbox`). See mcp_server/_sandbox_exec.py.
 def _safe_sandbox_id(env_val: str, default: int) -> int:

--- a/mcp_server/config.py
+++ b/mcp_server/config.py
@@ -116,7 +116,9 @@ SIM_TIMEOUT_SECONDS = _safe_float(
     7200.0,
 )
 
-# Wall-clock cap for the gbXML measure-workflow subprocess (import_gbxml). 0 = no cap.
+# Wall-clock cap for the gbXML measure-workflow subprocess (import_gbxml). <= 0 = no cap,
+# matching SIM_TIMEOUT_SECONDS — the call site gates on > 0, so a negative from a
+# misconfigured env var disables the cap rather than reaching subprocess.run.
 # Configurable because the runtime is almost entirely one measure's single-threaded surface
 # matching, so it tracks the host's per-core speed and nothing else. A hardcoded literal was
 # raised 300 -> 600 once already and then went marginal again; measured on the Austin fixture on

--- a/mcp_server/skills/gbxml_import/SKILL.md
+++ b/mcp_server/skills/gbxml_import/SKILL.md
@@ -129,6 +129,18 @@ defects cause this, and none are fixed by `match_surfaces()`:
   and misses patches that land a few centimetres off their counterpart (2 such pairs on the Austin
   fixture; a third candidate at 72% overlap is correctly declined). Override the remainder with
   `set_surface_boundary_conditions`, which takes the flagged names in one call.
+  Each patch also needs a **construction** — these models rarely carry a default construction set,
+  and EnergyPlus fails outright on a surface without one — so one is copied from existing
+  geometry and the basis reported per surface in `construction_source`: `partner` (the matched
+  surface's own construction, the same physical assembly), `same_space_same_boundary` /
+  `same_boundary` (same type *and* exposure), or `type_only_fallback` (same type, **different**
+  exposure). Only the last can put an exterior assembly on an interior surface, so it is counted
+  in `construction_fallback_count` and explained once in `construction_warnings` rather than per
+  surface. Expect it to dominate wherever there is no adiabatic geometry to copy from — 103 of
+  117 patches on the Austin fixture. This replaced a donor that took the first surface of a
+  matching *type* in handle order from the whole model, which drew at random and ignored exposure
+  entirely: on that fixture's RoofCeiling pool (92 interior ceilings, 13 exterior roofs) roughly
+  one run in eight put an R-20 cool-roof assembly on every patched interior ceiling (#134).
 - **Same-space overlaps** (aka shared-wall duplication): the flip side of a missing surface — a
   wall exported once per neighboring room instead of split at the boundary between them, leaving
   a surface duplicated, or a byproduct of patching a missing surface that happens to coincide

--- a/mcp_server/skills/gbxml_import/SKILL.md
+++ b/mcp_server/skills/gbxml_import/SKILL.md
@@ -162,10 +162,23 @@ then name; converted through world coordinates, so a space origin can't displace
 its partner. Result fields: `paired_vertex_mismatches_repaired`,
 `paired_vertex_mismatches_skipped`, `paired_area_mismatches`, each with a `_count`.
 
-Skipped pairs set `ok` to `false` — they still block simulation. Two cases are skipped rather than
-guessed at, both reported with a reason: a side carrying subsurfaces is never rewritten (its
-windows and doors are positioned against the polygon it has), and a mirrored result that collapses
-to near-zero area is abandoned. Pairs whose vertex counts agree but whose areas differ are listed
+Skipped pairs set `ok` to `false` — they still block simulation. Three cases are skipped rather
+than guessed at, each reported with a reason: a side carrying subsurfaces is never rewritten (its
+windows and doors are positioned against the polygon it has); a mirrored result that collapses to
+near-zero area is abandoned; and **any mirror that leaves either space with more unpaired edges
+than it had is rolled back**.
+
+That third guard is the important one. A vertex-count mismatch is *not* always a desync to mirror:
+when `merge_coplanar_sliver_surfaces()` has collapsed one space's wall into a single surface while
+the neighbour's side is still tiled into fragments, the two sides legitimately differ, and
+overwriting the fragment with the merged polygon leaves the neighbour overlapping itself. Measured
+on the Austin fixture, mirroring unguarded cost three spaces (4 non-enclosed became 7) and pushed
+`patch_missing_surfaces()` off its known-good result (117/5/2/103 → 119/8/2/106). With the guard,
+5 of the 7 candidate mirrors are rolled back and the pipeline lands on its expected numbers while
+the 2 genuine desyncs are still repaired. `isEnclosedVolume()` is too coarse to catch this — most
+spaces are *already* non-enclosed when the sync runs, so a closed→open test never fires — which is
+why the guard measures `polyhedron().edgesNotTwo(True)`, the same metric
+`patch_missing_surfaces()` works from. Pairs whose vertex counts agree but whose areas differ are listed
 in `paired_area_mismatches` and never reshaped — E+ accepts them, `matchSurfaces()` has its own
 ~0.0125 m internal tolerance, and reshaping on that weaker signal would be exactly the guess these
 tools refuse to make.

--- a/mcp_server/skills/gbxml_import/SKILL.md
+++ b/mcp_server/skills/gbxml_import/SKILL.md
@@ -28,7 +28,8 @@ exactly as that pipeline would build it — without ever invoking EnergyPlus.
    a guaranteed climate zone and a conditioned-zone volume check — see "Climate zone and zone
    volume guarantees" below.
 5. `repair_and_validate_gbxml_geometry()` — checks the (now-loaded) model for same-space overlaps and
-   non-enclosed volumes match_surfaces() can't fix. One call replaces the manual
+   non-enclosed volumes match_surfaces() can't fix, and re-synchronizes interior surface pairs whose
+   two sides disagree on vertex count. One call replaces the manual
    list_surfaces/get_surface_details/list_spaces/get_space_details diagnostic chain — see "Why
    repair_and_validate_gbxml_geometry" below.
 6. Pass `osm_path` (or the auto-loaded session model) to any model-query/model-management tool.
@@ -70,7 +71,8 @@ left as "Outdoors" instead of matched interior boundaries, and spaces missing a 
 RoofCeiling surface (breaking volume calculation). OpenStudio's own `intersectSurfaces()`/
 `matchSurfaces()` (the existing `match_surfaces()` tool) fix the first case but — by design in the
 SDK — never touch surfaces within the same space, so they can't fix true duplicate/overlapping
-geometry. `repair_and_validate_gbxml_geometry()` runs `match_surfaces()` first, then reports same-space
+geometry. `repair_and_validate_gbxml_geometry()` runs `match_surfaces()` first, then re-synchronizes
+desynchronized interior pairs (see "Paired-vertex desync" below), then reports same-space
 overlaps (via coincident-plane + 2D polygon-intersection checks) and non-enclosed-volume spaces
 (via `Space.isEnclosedVolume()`, not `volume() == 0` — volume() silently falls back to
 `ceilingHeight * floorArea` on non-manifold geometry rather than signaling failure). One call
@@ -138,6 +140,82 @@ defects cause this, and none are fixed by `match_surfaces()`:
   construction, neither carrying a subsurface) — the same guards
   `merge_coplanar_sliver_surfaces()` uses, and for the same reason: `Surface.remove()` cascades
   to child windows/doors, and shrinking a parent strands them outside it.
+
+## Paired-vertex desync
+
+A fifth defect, distinct from the four above in two ways: nothing in the model reports it, and the
+four repair tools are what *cause* it. An interior boundary is two Surfaces pointing at each other
+via `adjacentSurface()`, and EnergyPlus requires both to describe the same polygon with the same
+vertex count. When they disagree, E+ aborts at `GetSurfaceData` before simulating at all
+(`Vertex size mismatch between base surface ... and outside boundary surface`). `validate_model`
+has no geometry checks, and `match_surfaces()` doesn't catch it either — its returned count is a
+count of *surfaces* whose boundary condition is `"Surface"`, not of consistent *pairs*, so a
+mismatched pair increments it twice and looks healthy.
+
+Each repair tool mutates one side of a pair in isolation: `merge_coplanar_sliver_surfaces()`
+replaces a survivor's vertices while the survivor keeps its live `adjacentSurface` pointer, and
+`weld_coincident_vertices()` runs a per-space vertex pool (so one physical corner can snap to
+different coordinates in two adjacent spaces) and can skip one side as degenerate while rewriting
+the other. `repair_and_validate_gbxml_geometry()` therefore re-synchronizes automatically on every
+call — no separate tool — mirroring the authoritative side (largest area, then higher vertex count,
+then name; converted through world coordinates, so a space origin can't displace the result) onto
+its partner. Result fields: `paired_vertex_mismatches_repaired`,
+`paired_vertex_mismatches_skipped`, `paired_area_mismatches`, each with a `_count`.
+
+Skipped pairs set `ok` to `false` — they still block simulation. Two cases are skipped rather than
+guessed at, both reported with a reason: a side carrying subsurfaces is never rewritten (its
+windows and doors are positioned against the polygon it has), and a mirrored result that collapses
+to near-zero area is abandoned. Pairs whose vertex counts agree but whose areas differ are listed
+in `paired_area_mismatches` and never reshaped — E+ accepts them, `matchSurfaces()` has its own
+~0.0125 m internal tolerance, and reshaping on that weaker signal would be exactly the guess these
+tools refuse to make.
+
+## Missing ground connections
+
+A sixth defect, and unlike the others it does not stop the model simulating — it just makes the
+answer wrong. Revit exports under-declare ground contact and the translator faithfully reproduces
+the omission. Measured on this repo's fixtures: `2026_11Ja_path1.xml` is a building **with a
+basement** whose translated model carries exactly **1 Ground surface out of 292** (the source
+declares one `UndergroundSlab` and types the basement's own walls as plain `ExteriorWall`);
+`austin_office.xml` and `austin_apartment_slivers.xml` declare no ground-contact surface type at
+all. The defect is in the export, so reading `surfaceType` back out of the gbXML finds nothing —
+it has to be found geometrically.
+
+It matters because `Outdoors` carries `SunExposed`/`WindExposed`: a buried slab or basement wall
+left that way takes fictitious solar gain and wind convection, the same error class as the
+`patch_missing_surfaces` exposure fix. Nothing else reports it — `validate_model` has no geometry
+checks, and the overlap/enclosure checks never look at boundary conditions.
+
+`repair_and_validate_gbxml_geometry()` reports this on every call, taking z = 0 as grade (the
+site-coordinate convention gbXML and OpenStudio share). Result fields:
+`ground_contact_missing_count` / `ground_contact_missing` (names), plus
+`ground_surfaces_existing_count`, `partially_below_grade_count`, and
+`adiabatic_below_grade_count`. On that basement fixture it reports 17 walls against 1 existing
+Ground surface.
+
+**Report only — it never sets a boundary condition.** Whether a slab is on grade, over a
+crawlspace, or over open parking is a modeling judgment that changes energy results materially.
+The names are shaped to be replayed into one batched call:
+`set_surface_boundary_conditions(surface_names=[...], outside_boundary_condition="Ground")`, which
+derives `NoSun`/`NoWind` automatically for a non-`Outdoors` condition. Review the list first.
+
+Three details worth knowing:
+
+- **A wall counts as a basement wall when most of its height is buried**, not only when it is
+  entirely below grade. Every one of that fixture's 17 basement walls runs z = −3.05 to z = +0.91
+  — 77% buried, none of them fully — so an "entirely below grade" rule finds nothing there. Walls
+  crossing grade with less than half buried go to `partially_below_grade` instead: visible, but
+  not proposed for a batch fix. Setting a partly-buried wall to `Ground` does bury its
+  above-grade portion; splitting it at z = 0 would be strictly more correct and no tool here does
+  that, which is part of why this is reported rather than repaired.
+- **Ten boundary conditions already mean ground-coupled**, not one — `Ground`, `Foundation`, and
+  the eight `Ground*` preprocessor variants. The check reads them from the SDK, so an F/C-factor
+  or Kiva `Foundation` surface is never reported as defective.
+- `ok` is **not** affected. A model with no ground connection still simulates, and this fires on
+  essentially every gbXML import, so `ok` keeps meaning "geometry is structurally sound".
+  `ground_surfaces_existing_count` sits next to the finding on purpose: "1 existing, 17 missing"
+  reads very differently from "40 existing, 1 missing", and no geometric rule can tell you which
+  of those means the model's origin simply is not at grade.
 
 Re-check with `repair_and_validate_gbxml_geometry()` after any of these. Order matters less between
 `merge_coplanar_sliver_surfaces()` and `weld_coincident_vertices()` (they touch different surface

--- a/mcp_server/skills/gbxml_import/operations.py
+++ b/mcp_server/skills/gbxml_import/operations.py
@@ -224,8 +224,14 @@ def import_gbxml_op(
                 # host. It is single-threaded, so core count buys nothing and the wall
                 # clock tracks per-core speed. A hardcoded literal was raised 300 -> 600
                 # for a boundary flake and then flaked again at ~625s, which is why the
-                # cap is configuration now. 0 -> None, i.e. no cap.
-                timeout=GBXML_IMPORT_TIMEOUT_SECONDS or None,
+                # cap is configuration now. Any non-positive value means no cap, matching
+                # SIM_TIMEOUT_SECONDS. `or None` caught only 0.0: a negative from a
+                # misconfigured env var stayed truthy and reached subprocess.run, where it
+                # does not raise ValueError but puts the deadline in the past, so every
+                # import died in ~0ms and the handler below reported it as a real timeout
+                # against a nonsense cap ("exceeded the -1s wall-clock cap") — which reads
+                # as "raise the timeout", the opposite of the fix.
+                timeout=GBXML_IMPORT_TIMEOUT_SECONDS if GBXML_IMPORT_TIMEOUT_SECONDS > 0 else None,
                 check=False,
             )
 

--- a/mcp_server/skills/gbxml_import/operations.py
+++ b/mcp_server/skills/gbxml_import/operations.py
@@ -326,9 +326,14 @@ def import_gbxml_op(
     except subprocess.TimeoutExpired:
         # Names the cap and the knob: the old message stated a fixed "10 min" that went stale
         # the moment the cap moved, leaving a timeout that could not be acted on.
+        # :g not :.0f — a fractional cap is a legitimate fail-fast debugging value, and .0f
+        # rendered 0.5 as "0s", colliding with the <= 0 = "no cap" convention this same message
+        # points the reader at (a timeout reported against a cap that means "no timeout"). .0f
+        # also rounds half-to-even, so 1.5 and 2.5 both rendered "2s", and it reported 7.75 as
+        # a larger cap than the one actually enforced.
         return {
             "ok": False,
-            "error": f"gbXML import exceeded the {GBXML_IMPORT_TIMEOUT_SECONDS:.0f}s wall-clock "
+            "error": f"gbXML import exceeded the {GBXML_IMPORT_TIMEOUT_SECONDS:g}s wall-clock "
                      f"cap (OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS)",
         }
     except Exception as e:

--- a/mcp_server/skills/gbxml_import/operations.py
+++ b/mcp_server/skills/gbxml_import/operations.py
@@ -22,6 +22,7 @@ import openstudio
 
 from mcp_server import model_manager, sandbox
 from mcp_server.config import (
+    GBXML_IMPORT_TIMEOUT_SECONDS,
     GBXML_MEASURES_DIR,
     GBXML_SEED_OSM,
     OSCLI_GEM_PATH,
@@ -217,10 +218,14 @@ def import_gbxml_op(
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
                 env=run_env,
-                # gbxml_import_advanced is CPU-bound surface matching; the Austin
-                # fixture alone takes ~300s on 2-core CI runners (~160s locally),
-                # so 300 flaked at the boundary — 600 gives 2x headroom.
-                timeout=600,
+                # gbxml_import_advanced is CPU-bound surface matching and is where
+                # essentially all of this runs: on the Austin fixture it alone takes
+                # ~300s on 2-core CI runners (~160s locally), and ~8.5 min on a slower
+                # host. It is single-threaded, so core count buys nothing and the wall
+                # clock tracks per-core speed. A hardcoded literal was raised 300 -> 600
+                # for a boundary flake and then flaked again at ~625s, which is why the
+                # cap is configuration now. 0 -> None, i.e. no cap.
+                timeout=GBXML_IMPORT_TIMEOUT_SECONDS or None,
                 check=False,
             )
 
@@ -313,7 +318,13 @@ def import_gbxml_op(
         return result
 
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "gbXML import timed out (10 min)"}
+        # Names the cap and the knob: the old message stated a fixed "10 min" that went stale
+        # the moment the cap moved, leaving a timeout that could not be acted on.
+        return {
+            "ok": False,
+            "error": f"gbXML import exceeded the {GBXML_IMPORT_TIMEOUT_SECONDS:.0f}s wall-clock "
+                     f"cap (OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS)",
+        }
     except Exception as e:
         return {"ok": False, "error": f"Failed to import gbXML: {e}"}
 

--- a/mcp_server/skills/gbxml_import/operations.py
+++ b/mcp_server/skills/gbxml_import/operations.py
@@ -32,7 +32,9 @@ from mcp_server.config import (
 from mcp_server.model_manager import get_model
 from mcp_server.skills.gbxml_import.climate_zone import ensure_climate_zone
 from mcp_server.skills.gbxml_import.zone_checks import check_conditioned_zone_volumes
+from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
 from mcp_server.skills.geometry.operations import match_surfaces
+from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
 from mcp_server.skills.geometry.winding import normalize_local_frame_winding
 from mcp_server.skills.measures.runner_messages import OSW_MAX_BYTES, parse_all_step_messages
 from mcp_server.util import create_run_dir, read_file_bounded, read_tail_bounded, reject_escaping_symlinks
@@ -405,12 +407,40 @@ def _surface_overlaps(space: openstudio.model.Space) -> list[dict[str, Any]]:
 
 
 def repair_and_validate_gbxml_geometry_op() -> dict[str, Any]:
-    """Fix cross-space shared walls, then report same-space overlaps + non-enclosed spaces."""
+    """Fix cross-space shared walls and desynchronized surface pairs, then report what is left.
+
+    Two mutating passes (match_surfaces, then the paired-vertex sync) followed by three read-only
+    checks: same-space overlaps, non-enclosed spaces, and missing ground connections. Only the
+    first two affect `ok` — a model with no ground connection still simulates.
+    """
     try:
         model = get_model()
         match_result = match_surfaces()  # mutates: fixes the common cross-space case first
         if not match_result.get("ok"):
             return {"ok": False, "error": "match_surfaces() failed before geometry validation"}
+
+        # mutates: re-synchronizes interior pairs whose two sides drifted apart in an earlier
+        # repair. Must run after match_surfaces() (which establishes the pairing this reads)
+        # and before the checks below, so overlaps and enclosure are measured on final geometry.
+        sync_result = sync_paired_surface_vertices()
+        if not sync_result.get("ok"):
+            return {"ok": False, "error": sync_result.get("error", "paired vertex sync failed")}
+        pairs_repaired = sync_result["paired_vertex_mismatches_repaired"]
+        pairs_skipped = sync_result["paired_vertex_mismatches_skipped"]
+        area_mismatches = sync_result["paired_area_mismatches"]
+        # Vertices moved, so the count above is stale. sync already re-ran match_surfaces() and
+        # hands back the post-repair count — running it again here would repeat a full
+        # intersectSurfaces() pass over the model for nothing.
+        matched_surfaces = match_result["matched_surfaces"]
+        if sync_result["rematched_surfaces"] is not None:
+            matched_surfaces = sync_result["rematched_surfaces"]
+
+        # Read-only, and last of the three: match_surfaces() flips shared walls to "Surface",
+        # which takes them out of contention, so running this any earlier would report interior
+        # partitions as missing ground connections.
+        ground_result = find_missing_ground_contact()
+        if not ground_result.get("ok"):
+            return {"ok": False, "error": ground_result.get("error", "ground contact check failed")}
 
         overlaps: list[dict[str, Any]] = []
         non_enclosed: list[dict[str, Any]] = []
@@ -429,19 +459,38 @@ def repair_and_validate_gbxml_geometry_op() -> dict[str, Any]:
                 })
 
         result = {
-            "ok": not overlaps and not non_enclosed,
-            "cross_space_surfaces_matched": match_result["matched_surfaces"],
+            # Repaired pairs do not fail the check — they are fixed. Pairs this could NOT
+            # repair do, since they still abort EnergyPlus. Area-only mismatches are
+            # informational: E+ accepts them (see sync_paired_surface_vertices).
+            "ok": not overlaps and not non_enclosed and not pairs_skipped,
+            "cross_space_surfaces_matched": matched_surfaces,
             "space_count": len(model.getSpaces()),
             "surface_count": len(model.getSurfaces()),
+            "paired_vertex_mismatches_repaired_count": len(pairs_repaired),
+            "paired_vertex_mismatches_repaired": pairs_repaired[:MAX_REPORTED_ISSUES],
+            "paired_vertex_mismatches_skipped_count": len(pairs_skipped),
+            "paired_vertex_mismatches_skipped": pairs_skipped[:MAX_REPORTED_ISSUES],
+            "paired_area_mismatches_count": len(area_mismatches),
+            "paired_area_mismatches": area_mismatches[:MAX_REPORTED_ISSUES],
             "overlapping_surfaces_count": len(overlaps),
             "overlapping_surfaces": overlaps[:MAX_REPORTED_ISSUES],
             "non_enclosed_spaces_count": len(non_enclosed),
             "non_enclosed_spaces": non_enclosed[:MAX_REPORTED_ISSUES],
         }
+        if len(pairs_repaired) > MAX_REPORTED_ISSUES:
+            result["paired_vertex_mismatches_repaired_truncated"] = True
+        if len(pairs_skipped) > MAX_REPORTED_ISSUES:
+            result["paired_vertex_mismatches_skipped_truncated"] = True
+        if len(area_mismatches) > MAX_REPORTED_ISSUES:
+            result["paired_area_mismatches_truncated"] = True
         if len(overlaps) > MAX_REPORTED_ISSUES:
             result["overlapping_surfaces_truncated"] = True
         if len(non_enclosed) > MAX_REPORTED_ISSUES:
             result["non_enclosed_spaces_truncated"] = True
+        # Merged rather than nested so the ground keys read like every other key here. `ok` is
+        # deliberately NOT affected: a model with no ground connection still simulates, it is
+        # just wrong thermally, and this fires on essentially every gbXML import.
+        result.update({k: v for k, v in ground_result.items() if k != "ok"})
         return result
     except RuntimeError as e:
         return {"ok": False, "error": str(e)}

--- a/mcp_server/skills/gbxml_import/tools.py
+++ b/mcp_server/skills/gbxml_import/tools.py
@@ -71,7 +71,11 @@ def register(mcp):
         other check in this server catches, validate_model included. Repaired
         pairs are reported in paired_vertex_mismatches_repaired; any this could
         not repair are in paired_vertex_mismatches_skipped with a reason, and
-        set ok to False because they still block simulation. Pairs whose vertex
+        set ok to False because they still block simulation. A mismatch is not
+        always a desync — one side may be a merged surface whose partner is
+        still tiled into fragments — so any mirror that would leave a space with
+        more unpaired edges than it had is rolled back and reported as skipped.
+        Pairs whose vertex
         counts agree but whose areas differ are listed in
         paired_area_mismatches: reported only, never reshaped, since E+ accepts
         them.

--- a/mcp_server/skills/gbxml_import/tools.py
+++ b/mcp_server/skills/gbxml_import/tools.py
@@ -57,11 +57,35 @@ def register(mcp):
         """Check the loaded model for surface overlaps and non-enclosed space volumes.
 
         Runs match_surfaces() first (fixes shared walls between adjacent
-        spaces — the common case), then reports same-space duplicate/
-        overlapping surfaces and spaces whose volume can't be computed as a
-        closed manifold (usually a missing Floor or RoofCeiling surface) —
-        problems match_surfaces() cannot fix. One call replaces the manual
-        list_surfaces/get_surface_details/list_spaces/get_space_details
-        diagnostic chain.
+        spaces — the common case), then re-synchronizes any interior surface
+        pair whose two sides ended up with different vertex counts, then
+        reports same-space duplicate/overlapping surfaces and spaces whose
+        volume can't be computed as a closed manifold (usually a missing Floor
+        or RoofCeiling surface) — problems match_surfaces() cannot fix. One
+        call replaces the manual list_surfaces/get_surface_details/list_spaces/
+        get_space_details diagnostic chain.
+
+        The vertex-pair sync matters because the other repair tools each mutate
+        one side of a pair in isolation, and a pair whose sides disagree makes
+        EnergyPlus abort at GetSurfaceData before simulating — a failure no
+        other check in this server catches, validate_model included. Repaired
+        pairs are reported in paired_vertex_mismatches_repaired; any this could
+        not repair are in paired_vertex_mismatches_skipped with a reason, and
+        set ok to False because they still block simulation. Pairs whose vertex
+        counts agree but whose areas differ are listed in
+        paired_area_mismatches: reported only, never reshaped, since E+ accepts
+        them.
+
+        Also reports missing ground connections, taking z=0 as grade: gbXML
+        exports under-declare ground contact, so slabs and basement walls
+        commonly arrive as Outdoors and take fictitious solar gain and wind
+        convection. ground_contact_missing lists the surfaces (Floors and Walls
+        at or below grade, plus walls with most of their height buried) —
+        shaped to be replayed into one set_surface_boundary_conditions(...,
+        outside_boundary_condition="Ground") call. Report only, and ok is NOT
+        affected: such a model still simulates, it is just wrong thermally.
+        Review before applying — a slab over a crawlspace is not ground
+        contact. See also ground_surfaces_existing_count,
+        partially_below_grade_count, and adiabatic_below_grade_count.
         """
         return repair_and_validate_gbxml_geometry_op()

--- a/mcp_server/skills/geometry/ground_contact.py
+++ b/mcp_server/skills/geometry/ground_contact.py
@@ -1,0 +1,177 @@
+"""Find surfaces that sit at or below grade but are not connected to the ground.
+
+Revit gbXML exports under-declare ground contact and the OpenStudio translator faithfully
+reproduces the omission. Measured on this repo's own fixtures: `2026_11Ja_path1.xml` is a
+building WITH a basement whose translated model carries exactly one Ground surface out of 292
+(the source declares a single `UndergroundSlab`, and types the basement's own walls as plain
+`ExteriorWall`); `austin_office.xml` and `austin_apartment_slivers.xml` declare no ground-contact
+surface type at all. So the defect cannot be found by reading `surfaceType` back out of the
+gbXML — the source is what is wrong. It has to be found geometrically.
+
+This matters beyond bookkeeping: `Outdoors` carries `SunExposed`/`WindExposed`, so a buried slab
+or basement wall left that way takes fictitious solar gain and wind convection — the same class
+of error the `patch_missing_surfaces` exposure fix addressed. Nothing else reports it. The model
+still simulates, so `validate_model` stays quiet and the enclosure/overlap checks in
+`repair_and_validate_gbxml_geometry` never look at boundary conditions.
+
+Report only, never repaired. Whether a slab is on grade, over a crawlspace, or over open parking
+is a modeling judgment that changes energy results materially, and guessing it is exactly what
+this package's other repair tools refuse to do. The output is a list of names shaped to be handed
+straight to `set_surface_boundary_conditions(surface_names=[...],
+outside_boundary_condition="Ground")`, which already derives `NoSun`/`NoWind` for a non-Outdoors
+condition.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import openstudio
+
+from mcp_server.model_manager import get_model
+
+# Same scale as the sibling modules' geometric guards (MIN_WELDED_SURFACE_AREA_M2,
+# PAIR_AREA_TOLERANCE_M2) — below this, a vertex is on the grade plane, not above or below it.
+GRADE_TOLERANCE_M = 0.01
+# The actionable list is capped far above the sibling MAX_REPORTED_ISSUES (20) on purpose: these
+# names are the input to a single batched set_surface_boundary_conditions() call, and truncating
+# at 20 would force an agent through repeated diagnose-and-fix rounds on a model with a hundred
+# buried surfaces — costing far more context than the longer list does.
+GROUND_NAME_CAP = 200
+# Diagnostic-only lists keep the sibling cap, since they are read, not replayed.
+MAX_REPORTED_NAMES = 20
+# Share of a wall's height that must sit below grade before it is treated as a basement wall
+# rather than an above-grade wall that happens to dip. Measured on the repo's own basement
+# fixture (2026_11Ja_path1), every one of its 17 basement walls runs z=-3.05 to z=+0.91 — 77%
+# buried. An "entirely below grade" rule finds none of them, which is to say it finds nothing at
+# all on the only real basement model available.
+MIN_BURIED_WALL_FRACTION = 0.5
+
+
+def ground_boundary_conditions() -> frozenset[str]:
+    """Every boundary condition that already means "coupled to the ground".
+
+    Derived from the SDK rather than hardcoded, so it cannot drift from the bindings. There are
+    ten of them, not one: a check written as `== "Ground"` would flag every F/C-factor and Kiva
+    `Foundation` surface as defective — precisely the constructions ASHRAE 90.1 baseline work
+    uses.
+    """
+    return frozenset(
+        value for value in openstudio.model.Surface.validOutsideBoundaryConditionValues()
+        if value.startswith("Ground") or value == "Foundation"
+    )
+
+
+def world_z_range(surface: openstudio.model.Surface) -> tuple[float, float] | None:
+    """(min z, max z) of a surface in world coordinates, or None if it has no parent space.
+
+    Surface.vertices() are relative to the owning Space's origin, so reading z off them directly
+    misplaces every surface in a space that carries one — a model whose spaces are stacked by
+    origin would report its top floor as buried. Building rotation is about the z axis alone and
+    cannot change a vertex's height, so the space transformation is the whole correction.
+    """
+    space = surface.space()
+    if not space.is_initialized():
+        return None
+    world = space.get().transformation() * surface.vertices()
+    heights = [vertex.z() for vertex in world]
+    if not heights:
+        return None
+    return min(heights), max(heights)
+
+
+def find_missing_ground_contact() -> dict[str, Any]:
+    """Report at-or-below-grade surfaces that are not ground-coupled. Never mutates.
+
+    Grade is the z = 0 plane, the site-coordinate convention gbXML and OpenStudio both use.
+    An `Outdoors` surface is a finding when:
+
+    - it is a Floor or Wall entirely at or below grade, or
+    - it is a Wall crossing grade with at least MIN_BURIED_WALL_FRACTION of its height buried.
+
+    Both land in `ground_contact_missing`, the list shaped to be replayed into one batched
+    `set_surface_boundary_conditions()` call. A wall crossing grade with less than that buried is
+    reported separately in `partially_below_grade` — visible, but not proposed for a batch fix.
+
+    Setting a partly-buried wall to `Ground` does bury the part above grade too. Splitting it at
+    z = 0 would be strictly more correct, and no tool here does that; this is reported rather
+    than repaired precisely so that call stays with the modeler.
+
+    A below-grade Floor or Wall already set `Adiabatic` is counted in
+    `adiabatic_below_grade_count` and never named — that is usually a deliberate assumption
+    `patch_missing_surfaces` recorded, and listing a hundred of them would be noise. It covers
+    the same Floor/Wall population as `ground_contact_missing_count`, so the two are directly
+    comparable.
+
+    Also returns `ground_surfaces_existing_count`, so an implausible result is visible next to
+    the finding: "1 existing, 40 missing" reads very differently from "40 existing, 1 missing",
+    and no geometric rule can tell which of those means the model's origin is not at grade.
+    """
+    try:
+        model = get_model()
+        ground_family = ground_boundary_conditions()
+
+        missing: list[str] = []
+        partial: list[str] = []
+        adiabatic_below = 0
+        existing_ground = 0
+
+        for surface in model.getSurfaces():
+            condition = surface.outsideBoundaryCondition()
+            if condition in ground_family:
+                existing_ground += 1
+                continue
+            # "Surface" is a matched interior boundary — it has a partner, not a ground face.
+            if condition not in ("Outdoors", "Adiabatic"):
+                continue
+
+            z_range = world_z_range(surface)
+            if z_range is None:
+                continue
+            z_min, z_max = z_range
+
+            if z_max > GRADE_TOLERANCE_M:
+                # Partly above grade. Only a wall crossing grade is worth reporting, and a
+                # basement wall is one that is mostly buried — see MIN_BURIED_WALL_FRACTION.
+                if surface.surfaceType() != "Wall" or z_min >= -GRADE_TOLERANCE_M:
+                    continue
+                if condition == "Adiabatic":
+                    continue
+                buried_fraction = -z_min / (z_max - z_min)
+                if buried_fraction >= MIN_BURIED_WALL_FRACTION:
+                    missing.append(surface.nameString())
+                else:
+                    partial.append(surface.nameString())
+                continue
+
+            # Restricted to Floor and Wall for both buckets, so the two counts describe the same
+            # population and differ only by boundary condition — a below-grade RoofCeiling is the
+            # top of a space, not a candidate ground connection.
+            if surface.surfaceType() not in ("Floor", "Wall"):
+                continue
+            if condition == "Adiabatic":
+                adiabatic_below += 1
+            else:
+                missing.append(surface.nameString())
+
+        result: dict[str, Any] = {
+            "ok": True,
+            "ground_contact_missing_count": len(missing),
+            "ground_surfaces_existing_count": existing_ground,
+            "partially_below_grade_count": len(partial),
+            "adiabatic_below_grade_count": adiabatic_below,
+        }
+        # Name lists are emitted only when there is something to name, so a clean model costs
+        # the caller four integers rather than four empty containers.
+        if missing:
+            result["ground_contact_missing"] = missing[:GROUND_NAME_CAP]
+            if len(missing) > GROUND_NAME_CAP:
+                result["ground_contact_missing_truncated"] = True
+        if partial:
+            result["partially_below_grade"] = partial[:MAX_REPORTED_NAMES]
+            if len(partial) > MAX_REPORTED_NAMES:
+                result["partially_below_grade_truncated"] = True
+        return result
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to check ground contact: {e}"}

--- a/mcp_server/skills/geometry/ground_contact.py
+++ b/mcp_server/skills/geometry/ground_contact.py
@@ -115,7 +115,10 @@ def find_missing_ground_contact() -> dict[str, Any]:
         adiabatic_below = 0
         existing_ground = 0
 
-        for surface in model.getSurfaces():
+        # Name order — see match_surfaces() in geometry/operations.py (issue #134). Nothing here
+        # mutates, so only the reported list order depends on it, but a findings list that
+        # reshuffles between runs is a diff for no reason.
+        for surface in sorted(model.getSurfaces(), key=lambda s: s.nameString()):
             condition = surface.outsideBoundaryCondition()
             if condition in ground_family:
                 existing_ground += 1

--- a/mcp_server/skills/geometry/merge_coplanar_sliver_surfaces.py
+++ b/mcp_server/skills/geometry/merge_coplanar_sliver_surfaces.py
@@ -103,9 +103,11 @@ def merge_coplanar_sliver_surfaces() -> dict[str, Any]:
         planned: list[dict[str, Any]] = []
 
         # Pass 1: decide, mutating nothing.
-        for space in model.getSpaces():
+        # Name order throughout — see match_surfaces() in geometry/operations.py for why handle
+        # order is not reproducible across imports (issue #134).
+        for space in sorted(model.getSpaces(), key=lambda s: s.nameString()):
             space_name = space.nameString()
-            surfaces = list(space.surfaces())
+            surfaces = sorted(space.surfaces(), key=lambda s: s.nameString())
 
             for surface_type in ("Wall", "Floor", "RoofCeiling"):
                 same_type = [s for s in surfaces if s.surfaceType() == surface_type]

--- a/mcp_server/skills/geometry/merge_coplanar_sliver_surfaces.py
+++ b/mcp_server/skills/geometry/merge_coplanar_sliver_surfaces.py
@@ -83,6 +83,12 @@ def merge_coplanar_sliver_surfaces() -> dict[str, Any]:
     so the merged loops are re-oriented against the survivor's pre-merge normal — without
     that, every merged RoofCeiling would come back facing downward.
 
+    The survivor's rewrite is verified before anything is removed. setVertices() can
+    reject a polygon silently, leaving the survivor on its old fragment, and the group's
+    other fragments are deleted purely on the strength of that write — so an unchecked
+    call would destroy them against a merge that never happened and report it as merged.
+    A rejected rewrite leaves the whole group intact and is reported as skipped.
+
     Run repair_and_validate_gbxml_geometry() before and after to see the effect on
     non_enclosed_spaces_count. match_surfaces() is re-run once, batched, if anything
     changed — a wall that genuinely borders more than one neighbor along its run will
@@ -192,7 +198,21 @@ def merge_coplanar_sliver_surfaces() -> dict[str, Any]:
             survivor = plan["survivor"]
             new_loops_3d = plan["new_loops_3d"]
 
-            survivor.setVertices(new_loops_3d[0])
+            # Checked before anything is created or removed: plan["others"] are deleted below
+            # purely on the strength of this write. A rejection is silent (setVertices does not
+            # raise, and OpenStudio's complaint goes to a logger this server pins at Fatal) and
+            # leaves the survivor on its old fragment, so an unchecked call would destroy the
+            # rest of the group against a merge that never happened — and report it as merged.
+            if not survivor.setVertices(new_loops_3d[0]):
+                skipped.append({
+                    "space": plan["space_name"], "surface_type": plan["surface_type"],
+                    "surfaces": [survivor.nameString(), *(s.nameString() for s in plan["others"])],
+                    "reason": "OpenStudio rejected the merged polygon (setVertices returned "
+                              "false); the group's fragments are left in place rather than "
+                              "removed against a survivor that never took the merged shape",
+                })
+                continue
+
             rebuilt_names = [survivor.nameString()]
 
             for extra_loop in new_loops_3d[1:]:

--- a/mcp_server/skills/geometry/operations.py
+++ b/mcp_server/skills/geometry/operations.py
@@ -345,9 +345,17 @@ def match_surfaces() -> dict[str, Any]:
     try:
         model = get_model()
 
-        # Build a mutable SpaceVector — SWIG needs a non-const reference
+        # Build a mutable SpaceVector — SWIG needs a non-const reference.
+        # Name order, not model order: model.getSpaces() is handle-ordered and handles are UUIDs
+        # minted afresh on every import, and this vector is handed straight to the SDK, whose
+        # intersectSurfaces() splitting and matchSurfaces() pairing both depend on the order they
+        # are given. Feeding it a random order made the whole repair pipeline nondeterministic —
+        # measured on the Austin fixture across fresh handle assignments, patch_missing_surfaces
+        # returned 117/5/2/103, 117/5/1/105 and 117/6/1/105 on different runs, and
+        # trim_overlapping_surfaces flipped between 1/18 and 0/19 (issue #134). Space names come
+        # from the source gbXML and are stable.
         space_vector = openstudio.model.SpaceVector()
-        for sp in model.getSpaces():
+        for sp in sorted(model.getSpaces(), key=lambda s: s.nameString()):
             space_vector.append(sp)
 
         # Intersect: split surfaces where spaces overlap

--- a/mcp_server/skills/geometry/paired_vertex_sync.py
+++ b/mcp_server/skills/geometry/paired_vertex_sync.py
@@ -1,0 +1,240 @@
+"""Re-synchronize the two sides of an interior surface pair after a repair desynchronized them.
+
+A different defect from the four this package's other repair tools address, and the only one
+that is invisible until EnergyPlus runs. An interior boundary is two OpenStudio Surfaces that
+point at each other via `adjacentSurface()`; E+ requires both to describe the same polygon with
+the same vertex count. When they disagree it aborts before simulating at all:
+
+    RoofCeiling:Detailed="...", Vertex size mismatch between base surface ... and outside
+    boundary surface ...  The vertex sizes are 4 for base surface and 5 for outside boundary
+    surface.  GetSurfaceData: Errors discovered, program terminates.
+
+Nothing else catches this. `validate_model` has no geometry checks, and `match_surfaces()` does
+not help despite calling `intersectSurfaces` — it hands the SDK surfaces that are ALREADY paired
+("Surface" boundary condition with a live `adjacentSurface` pointer) with no unmatch pass first,
+so `intersectSurfaces` never re-splits them; and its returned count is a count of *surfaces*
+whose boundary condition string is "Surface", not of consistent *pairs*, so a mismatched pair
+increments it twice and looks healthy.
+
+The repair tools create the defect because each mutates one side of a pair in isolation:
+`merge_coplanar_sliver_surfaces` replaces a survivor's vertices while the survivor keeps its live
+`adjacentSurface` pointer, and `weld_coincident_vertices` runs a per-space vertex pool (so one
+physical corner can snap to different coordinates in two adjacent spaces) and can skip one side
+as degenerate while rewriting the other.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import openstudio
+
+from mcp_server.model_manager import get_model
+from mcp_server.skills.geometry.operations import match_surfaces
+
+# Same scale as the sibling repair tools' area guards (MIN_WELDED_SURFACE_AREA_M2,
+# MIN_MERGED_SURFACE_AREA_M2) — below this a mirrored polygon is degenerate, not geometry.
+MIN_SYNCED_SURFACE_AREA_M2 = 0.01
+# Area disagreement between two sides that DO have matching vertex counts. Reported only,
+# never repaired: matchSurfaces() has its own ~0.0125m internal tolerance, so small positional
+# drift between paired surfaces is expected and harmless, and E+ accepts it.
+PAIR_AREA_TOLERANCE_M2 = 0.01
+# A polygon needs three points; fewer means the source surface is already corrupt.
+MIN_VERTICES = 3
+
+
+def choose_authoritative_index(sides: list[tuple[str, int, float]]) -> int:
+    """Pick which side of a desynchronized pair to keep, from (name, vertex_count, area_m2).
+
+    Deterministic so a repair run is reproducible and its results can be pinned exactly in
+    tests: largest area wins, then the higher vertex count, then the lexicographically smaller
+    name. Area leads because the side that drifted is typically the one a weld shrank or a
+    degenerate-skip left behind, while a merge survivor is the larger, more complete polygon.
+
+    Pure by design — no OpenStudio objects — so the selection rule is unit-testable without
+    the SDK.
+    """
+    ranked = sorted(range(len(sides)), key=lambda i: (-sides[i][2], -sides[i][1], sides[i][0]))
+    return ranked[0]
+
+
+def _pair_key(surface: openstudio.model.Surface, partner: openstudio.model.Surface) -> tuple:
+    """Canonical, order-independent identity for a pair, so it is examined once."""
+    return tuple(sorted((str(surface.handle()), str(partner.handle()))))
+
+
+def _space_name(surface: openstudio.model.Surface) -> str:
+    space = surface.space()
+    return space.get().nameString() if space.is_initialized() else ""
+
+
+def mirror_onto_partner(
+    keep: openstudio.model.Surface,
+    rewrite: openstudio.model.Surface,
+) -> openstudio.Point3dVector | None:
+    """The kept side's polygon expressed in the partner's own coordinates, reversed.
+
+    Surface.vertices() are relative to the owning Space's origin and relative north, so
+    copying them across spaces verbatim is only correct when both spaces have an identity
+    transformation. gbXML imports do produce identity transforms (verified: the OS:Space
+    origin and Direction of Relative North fields come through empty), which is why the
+    verbatim copy happened to work — but a model that has been through a tool which sets
+    a space origin would have had a surface silently teleported by the difference. Going
+    through world coordinates is correct either way and costs one matrix multiply.
+
+    Returns None when either side has no parent space, since there is then no frame to
+    convert between.
+    """
+    keep_space, rewrite_space = keep.space(), rewrite.space()
+    if not keep_space.is_initialized() or not rewrite_space.is_initialized():
+        return None
+    world = keep_space.get().transformation() * keep.vertices()
+    return openstudio.reverse(rewrite_space.get().transformation().inverse() * world)
+
+
+def sync_paired_surface_vertices() -> dict[str, Any]:
+    """Mirror one side of each vertex-count-mismatched interior pair onto the other.
+
+    Walks every Surface whose outsideBoundaryCondition is "Surface" and which has an
+    adjacentSurface, examining each pair once. A pair whose two sides carry different vertex
+    counts is repaired: the authoritative side is chosen by choose_authoritative_index() and the
+    partner's vertices are replaced by mirror_onto_partner(), the same polygon in the partner's
+    own coordinate frame with reversed winding — the correspondence matchSurfaces() itself
+    establishes.
+
+    A pair whose counts agree but whose areas differ by more than PAIR_AREA_TOLERANCE_M2 is
+    REPORTED and NOT repaired. E+ accepts it, and silently reshaping a surface on that weaker
+    signal would be exactly the kind of guess the sibling repair tools refuse to make.
+
+    Two guards prevent turning a recoverable defect into a worse one: a side carrying
+    subsurfaces is never rewritten (its windows and doors are positioned against the polygon it
+    has, and would be orphaned outside a replacement), and a mirrored result that collapses
+    below MIN_SYNCED_SURFACE_AREA_M2 is abandoned. Both are reported as skipped with a reason
+    rather than applied.
+
+    match_surfaces() is re-run once, batched, if anything changed.
+    """
+    try:
+        model = get_model()
+        repaired: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        area_mismatches: list[dict[str, Any]] = []
+        seen: set[tuple] = set()
+
+        for surface in model.getSurfaces():
+            if surface.outsideBoundaryCondition() != "Surface":
+                continue
+            adjacent = surface.adjacentSurface()
+            if not adjacent.is_initialized():
+                continue
+            partner = adjacent.get()
+
+            key = _pair_key(surface, partner)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            a_vertices = list(surface.vertices())
+            b_vertices = list(partner.vertices())
+            a_name, b_name = surface.nameString(), partner.nameString()
+
+            if len(a_vertices) < MIN_VERTICES or len(b_vertices) < MIN_VERTICES:
+                skipped.append({
+                    "surface": a_name, "partner": b_name,
+                    "reason": "one side has fewer than three vertices (already degenerate); "
+                              "left unchanged",
+                })
+                continue
+
+            a_area, b_area = float(surface.grossArea()), float(partner.grossArea())
+
+            if len(a_vertices) == len(b_vertices):
+                if abs(a_area - b_area) > PAIR_AREA_TOLERANCE_M2:
+                    area_mismatches.append({
+                        "surface": a_name, "partner": b_name,
+                        "area_m2": round(a_area, 4), "partner_area_m2": round(b_area, 4),
+                    })
+                continue
+
+            sides = [(a_name, len(a_vertices), a_area), (b_name, len(b_vertices), b_area)]
+            keep_index = choose_authoritative_index(sides)
+            keep = surface if keep_index == 0 else partner
+            rewrite = partner if keep_index == 0 else surface
+
+            if rewrite.subSurfaces():
+                skipped.append({
+                    "surface": keep.nameString(), "partner": rewrite.nameString(),
+                    "reason": "the side that would be rewritten carries subsurfaces "
+                              "(windows/doors); replacing its vertices could orphan them "
+                              "outside the new polygon, not attempted",
+                })
+                continue
+
+            mirrored = mirror_onto_partner(keep, rewrite)
+            if mirrored is None:
+                skipped.append({
+                    "surface": keep.nameString(), "partner": rewrite.nameString(),
+                    "reason": "one side has no parent space, so its vertices cannot be "
+                              "converted into the other's coordinate frame; left unchanged",
+                })
+                continue
+
+            area = openstudio.getArea(mirrored)
+            if not area.is_initialized() or area.get() <= MIN_SYNCED_SURFACE_AREA_M2:
+                skipped.append({
+                    "surface": keep.nameString(), "partner": rewrite.nameString(),
+                    "reason": "mirrored result was degenerate (near-zero area); left unchanged",
+                })
+                continue
+
+            vertices_before = len(rewrite.vertices())
+            area_before = float(rewrite.grossArea())
+            rewrite.setVertices(mirrored)
+            repaired.append({
+                "surface": rewrite.nameString(),
+                "space": _space_name(rewrite),
+                "partner": keep.nameString(),
+                "partner_space": _space_name(keep),
+                "kept": keep.nameString(),
+                "vertices_before": vertices_before,
+                "vertices_after": len(rewrite.vertices()),
+                "area_before_m2": round(area_before, 4),
+                "area_after_m2": round(float(rewrite.grossArea()), 4),
+            })
+
+        rematched: int | None = None
+        if repaired:
+            # Vertices have already moved, so a rematching failure must be reported rather than
+            # swallowed — otherwise this returns ok:True with boundaries left unmatched against
+            # the new geometry.
+            match_result = match_surfaces()
+            if match_result.get("ok"):
+                # Handed back so the caller can report a post-repair count without paying for a
+                # second intersectSurfaces() pass over the whole model, which is the expensive
+                # part of match_surfaces() and would be pure duplicate work here.
+                rematched = match_result["matched_surfaces"]
+            else:
+                return {
+                    "ok": False,
+                    "error": f"Synchronized {len(repaired)} surface pair(s) but match_surfaces() "
+                             f"failed afterward, so shared boundaries may be unmatched: "
+                             f"{match_result.get('error')}",
+                    "paired_vertex_mismatches_repaired_count": len(repaired),
+                    "paired_vertex_mismatches_repaired": repaired,
+                }
+
+        return {
+            "ok": True,
+            # None when nothing was repaired, i.e. no rematch was needed and the caller's own
+            # earlier count still stands.
+            "rematched_surfaces": rematched,
+            "paired_vertex_mismatches_repaired_count": len(repaired),
+            "paired_vertex_mismatches_repaired": repaired,
+            "paired_vertex_mismatches_skipped_count": len(skipped),
+            "paired_vertex_mismatches_skipped": skipped,
+            "paired_area_mismatches_count": len(area_mismatches),
+            "paired_area_mismatches": area_mismatches,
+        }
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to synchronize paired surface vertices: {e}"}

--- a/mcp_server/skills/geometry/paired_vertex_sync.py
+++ b/mcp_server/skills/geometry/paired_vertex_sync.py
@@ -67,6 +67,33 @@ def _space_name(surface: openstudio.model.Surface) -> str:
     return space.get().nameString() if space.is_initialized() else ""
 
 
+def _unpaired_edge_counts(*surfaces: openstudio.model.Surface) -> dict[str, int]:
+    """How many edges each affected space uses other than exactly twice, keyed by space name.
+
+    `isEnclosedVolume()` is too coarse to guard this repair. These models arrive with most spaces
+    already non-enclosed (67 of 74 on the Austin fixture at the point the sync runs), so a
+    closed->open test never fires and every harmful mirror sails through. The damage is not
+    opening a hole, it is making an existing hole bigger and defeating patch_missing_surfaces
+    downstream. `polyhedron().edgesNotTwo(True)` — the same manifold metric
+    patch_missing_surfaces works from, with the same includeCreatedEdges=True, since False hides
+    edges Polyhedron's own auto-heal step creates — measures that directly.
+    """
+    counts: dict[str, int] = {}
+    for surface in surfaces:
+        space = surface.space()
+        if not space.is_initialized():
+            continue
+        name = space.get().nameString()
+        if name not in counts:
+            counts[name] = len(list(space.get().polyhedron().edgesNotTwo(True)))
+    return counts
+
+
+def _degrades_manifold(before: dict[str, int], after: dict[str, int]) -> bool:
+    """True if the mirror left either space with more unpaired edges than it had."""
+    return any(after.get(name, count) > count for name, count in before.items())
+
+
 def mirror_onto_partner(
     keep: openstudio.model.Surface,
     rewrite: openstudio.model.Surface,
@@ -105,11 +132,17 @@ def sync_paired_surface_vertices() -> dict[str, Any]:
     REPORTED and NOT repaired. E+ accepts it, and silently reshaping a surface on that weaker
     signal would be exactly the kind of guess the sibling repair tools refuse to make.
 
-    Two guards prevent turning a recoverable defect into a worse one: a side carrying
+    Three guards prevent turning a recoverable defect into a worse one. A side carrying
     subsurfaces is never rewritten (its windows and doors are positioned against the polygon it
-    has, and would be orphaned outside a replacement), and a mirrored result that collapses
-    below MIN_SYNCED_SURFACE_AREA_M2 is abandoned. Both are reported as skipped with a reason
-    rather than applied.
+    has, and would be orphaned outside a replacement). A mirrored result that collapses below
+    MIN_SYNCED_SURFACE_AREA_M2 is abandoned. And every applied mirror is measured against both
+    spaces' unpaired-edge counts and rolled back if either got worse — on the Austin fixture,
+    mirroring unguarded cost three spaces (4 non-enclosed spaces became 7), because a
+    vertex-count mismatch is not always a desync: when
+    merge_coplanar_sliver_surfaces has collapsed one space's wall into a single surface while the
+    neighbour's side is still tiled into fragments, the two sides legitimately differ, and
+    overwriting the fragment with the merged polygon leaves a hole. All three are reported as
+    skipped with a reason rather than applied.
 
     match_surfaces() is re-run once, batched, if anything changed.
     """
@@ -188,7 +221,22 @@ def sync_paired_surface_vertices() -> dict[str, Any]:
 
             vertices_before = len(rewrite.vertices())
             area_before = float(rewrite.grossArea())
+            original = openstudio.Point3dVector(list(rewrite.vertices()))
+            edges_before = _unpaired_edge_counts(keep, rewrite)
+
             rewrite.setVertices(mirrored)
+
+            if _degrades_manifold(edges_before, _unpaired_edge_counts(keep, rewrite)):
+                rewrite.setVertices(original)
+                skipped.append({
+                    "surface": keep.nameString(), "partner": rewrite.nameString(),
+                    "reason": "mirroring left a space with more unpaired edges than it had (the "
+                              "two sides differ because one is a merged surface and the other is "
+                              "still tiled into fragments, not because a repair desynchronized "
+                              "them); rolled back and left unchanged",
+                })
+                continue
+
             repaired.append({
                 "surface": rewrite.nameString(),
                 "space": _space_name(rewrite),

--- a/mcp_server/skills/geometry/paired_vertex_sync.py
+++ b/mcp_server/skills/geometry/paired_vertex_sync.py
@@ -33,6 +33,15 @@ from mcp_server.skills.geometry.operations import match_surfaces
 
 # Same scale as the sibling repair tools' area guards (MIN_WELDED_SURFACE_AREA_M2,
 # MIN_MERGED_SURFACE_AREA_M2) — below this a mirrored polygon is degenerate, not geometry.
+#
+# Load-bearing beyond cosmetics: it also screens setVertices()'s own precondition.
+# setVertices() returns false — silently, since OpenStudio reports the rejection to a logger
+# this server pins at Fatal to protect the JSON-RPC stream — when a polygon has fewer than
+# three vertices or no computable plane. getArea() IS |Newell| / 2, and Plane construction
+# fails only when |Newell| is ~0, so an area above this threshold implies a computable plane
+# (verified against OpenStudio 3.11). Lowering it toward zero, or letting a non-rigid
+# transform into mirror_onto_partner, breaks that implication. The setVertices return is
+# checked regardless — see sync_paired_surface_vertices.
 MIN_SYNCED_SURFACE_AREA_M2 = 0.01
 # Area disagreement between two sides that DO have matching vertex counts. Reported only,
 # never repaired: matchSurfaces() has its own ~0.0125m internal tolerance, so small positional
@@ -118,6 +127,34 @@ def mirror_onto_partner(
     return openstudio.reverse(rewrite_space.get().transformation().inverse() * world)
 
 
+def _restore_or_fail(
+    rewrite: openstudio.model.Surface,
+    original: openstudio.Point3dVector,
+    keep_name: str,
+    repaired: list[dict[str, Any]],
+    cause: str,
+) -> dict[str, Any] | None:
+    """Put `rewrite`'s original polygon back. None on success, a terminal result on failure.
+
+    A rejected restore is not a skip. Reporting the pair as "rolled back and left unchanged"
+    while the model still holds the polygon this function just decided was harmful would be a
+    lie about damaged geometry — worse than the misreported repair a rejected forward write
+    would cause. The caller has to reload rather than continue, so this ends the run.
+    """
+    if rewrite.setVertices(original):
+        return None
+    return {
+        "ok": False,
+        "error": (
+            f"Mirrored {keep_name} onto {rewrite.nameString()} and then had to undo it "
+            f"({cause}), but OpenStudio rejected the restore of its original vertices. The "
+            f"model now holds the rejected geometry and must be reloaded before it is used."
+        ),
+        "paired_vertex_mismatches_repaired_count": len(repaired),
+        "paired_vertex_mismatches_repaired": repaired,
+    }
+
+
 def sync_paired_surface_vertices() -> dict[str, Any]:
     """Mirror one side of each vertex-count-mismatched interior pair onto the other.
 
@@ -143,6 +180,15 @@ def sync_paired_surface_vertices() -> dict[str, Any]:
     neighbour's side is still tiled into fragments, the two sides legitimately differ, and
     overwriting the fragment with the merged polygon leaves a hole. All three are reported as
     skipped with a reason rather than applied.
+
+    Every write is verified rather than assumed. setVertices() returns a bool and rejects a
+    polygon it cannot plane-fit, without raising and without a visible log line, so an
+    unchecked call would let a no-op be counted as a repair while the mismatch that aborts E+
+    survives — the manifold guard cannot tell "harmless mirror" from "nothing happened",
+    since both leave the edge counts identical. A rejected write is reported as skipped. A
+    rejected *rollback* is worse than either, because the model then holds geometry this
+    function already judged harmful, so it ends the run with ok False rather than reporting
+    the pair as merely skipped.
 
     match_surfaces() is re-run once, batched, if anything changed.
     """
@@ -227,10 +273,44 @@ def sync_paired_surface_vertices() -> dict[str, Any]:
             original = openstudio.Point3dVector(list(rewrite.vertices()))
             edges_before = _unpaired_edge_counts(keep, rewrite)
 
-            rewrite.setVertices(mirrored)
+            # A rejected write leaves the old vertices in place, so the manifold guard below
+            # would see no change, read it as a harmless mirror, and report a repair that never
+            # happened — while the mismatch that aborts E+ at GetSurfaceData survives untouched.
+            # Nothing else would surface it: setVertices() does not raise, and its rejection
+            # message goes to a logger this server silences (see MIN_SYNCED_SURFACE_AREA_M2).
+            if not rewrite.setVertices(mirrored):
+                skipped.append({
+                    "surface": keep.nameString(), "partner": rewrite.nameString(),
+                    "reason": "OpenStudio rejected the mirrored polygon (setVertices returned "
+                              "false), so the two sides still carry different vertex counts and "
+                              "still block EnergyPlus; left unchanged",
+                })
+                continue
+
+            # The invariant E+ actually checks. setVertices() writes exactly what it is handed,
+            # so a true return already implies this — asserted anyway so the repair report stays
+            # self-verifying rather than resting on that being true of every future SDK version.
+            if len(rewrite.vertices()) != len(keep.vertices()):
+                failure = _restore_or_fail(
+                    rewrite, original, keep.nameString(), repaired,
+                    "the write was accepted but did not take",
+                )
+                if failure is not None:
+                    return failure
+                skipped.append({
+                    "surface": keep.nameString(), "partner": rewrite.nameString(),
+                    "reason": "OpenStudio accepted the mirrored polygon but the two sides still "
+                              "carry different vertex counts; rolled back and left unchanged",
+                })
+                continue
 
             if _degrades_manifold(edges_before, _unpaired_edge_counts(keep, rewrite)):
-                rewrite.setVertices(original)
+                failure = _restore_or_fail(
+                    rewrite, original, keep.nameString(), repaired,
+                    "it left a space with more unpaired edges than it had",
+                )
+                if failure is not None:
+                    return failure
                 skipped.append({
                     "surface": keep.nameString(), "partner": rewrite.nameString(),
                     "reason": "mirroring left a space with more unpaired edges than it had (the "

--- a/mcp_server/skills/geometry/paired_vertex_sync.py
+++ b/mcp_server/skills/geometry/paired_vertex_sync.py
@@ -153,7 +153,10 @@ def sync_paired_surface_vertices() -> dict[str, Any]:
         area_mismatches: list[dict[str, Any]] = []
         seen: set[tuple] = set()
 
-        for surface in model.getSurfaces():
+        # Name order — see match_surfaces() in geometry/operations.py (issue #134). Order matters
+        # here because each applied mirror mutates geometry that the manifold guard then measures
+        # for every later pair, so a handle-ordered walk could repair a different subset per run.
+        for surface in sorted(model.getSurfaces(), key=lambda s: s.nameString()):
             if surface.outsideBoundaryCondition() != "Surface":
                 continue
             adjacent = surface.adjacentSurface()

--- a/mcp_server/skills/geometry/patch_missing_surfaces.py
+++ b/mcp_server/skills/geometry/patch_missing_surfaces.py
@@ -179,7 +179,10 @@ def patch_missing_surfaces() -> dict[str, Any]:
         new_surfaces: list[openstudio.model.Surface] = []
         attempted_spaces: list[openstudio.model.Space] = []
 
-        for space in model.getSpaces():
+        # Name order, not handle order — see match_surfaces() in geometry/operations.py. This
+        # loop's order becomes new_surfaces' order, which pair_coincident_unmatched() consumes
+        # first-match-wins, so a random order changed which patches got paired (issue #134).
+        for space in sorted(model.getSpaces(), key=lambda s: s.nameString()):
             name = space.nameString()
             if space.isEnclosedVolume():
                 continue

--- a/mcp_server/skills/geometry/patch_missing_surfaces.py
+++ b/mcp_server/skills/geometry/patch_missing_surfaces.py
@@ -47,12 +47,96 @@ from mcp_server.skills.geometry.surface_pairing import pair_coincident_unmatched
 MIN_PATCHED_SURFACE_AREA_M2 = 0.0001
 
 
-def _donor_construction(model: openstudio.model.Model, surface_type: str):
-    return next(
-        (c.get() for s in model.getSurfaces()
-         if s.surfaceType() == surface_type and (c := s.construction()).is_initialized()),
-        None,
+def build_construction_pools(
+    model: openstudio.model.Model,
+) -> dict[tuple[str, str], list[tuple[str, str, Any]]]:
+    """Candidate donor constructions keyed by (surface type, boundary condition).
+
+    Built once per run rather than rescanned per patch, and in name order so the choice cannot
+    depend on handle order — handles are UUIDs minted afresh on every import (issue #134).
+
+    Keying on the boundary condition as well as the type is the point. The earlier version took
+    the first surface of a matching *type* from the whole model, so on the Austin fixture a
+    patched interior ceiling could draw from the 13 exterior roofs sitting in the same
+    RoofCeiling pool as the 92 interior ceilings — an R-20 cool roof assembly on an interior
+    boundary, silently misstating the heat transfer across it.
+
+    Surfaces with no construction are skipped, which conveniently excludes the patches
+    themselves: this runs before any of them is assigned one, so a patch can never seed
+    another patch's construction.
+    """
+    pools: dict[tuple[str, str], list[tuple[str, str, Any]]] = {}
+    for surface in sorted(model.getSurfaces(), key=lambda s: s.nameString()):
+        construction = surface.construction()
+        if not construction.is_initialized():
+            continue
+        space = surface.space()
+        space_name = space.get().nameString() if space.is_initialized() else ""
+        key = (surface.surfaceType(), surface.outsideBoundaryCondition())
+        pools.setdefault(key, []).append((space_name, surface.nameString(), construction.get()))
+    return pools
+
+
+def choose_construction(
+    pools: dict[tuple[str, str], list[tuple[str, str, Any]]],
+    surface_type: str,
+    boundary_condition: str,
+    space_name: str,
+    partner_construction: Any | None,
+) -> tuple[Any | None, str]:
+    """Pick a construction for one reconstructed surface. Returns (construction, basis).
+
+    In priority order: the partner's own construction when this surface was paired (the two sides
+    are the same physical assembly, so there is nothing to guess); then a surface of the same type
+    AND boundary condition, preferring the same space; then, only if no such surface exists
+    anywhere, any surface of the type regardless of exposure — reported as a fallback rather than
+    applied silently, since that is the case that can cross an interior/exterior boundary.
+    """
+    if partner_construction is not None:
+        return partner_construction, "partner"
+
+    matching = pools.get((surface_type, boundary_condition), [])
+    for candidate_space, _name, construction in matching:
+        if candidate_space == space_name:
+            return construction, "same_space_same_boundary"
+    if matching:
+        return matching[0][2], "same_boundary"
+
+    any_exposure = sorted(
+        (entry for (kind, _bc), entries in pools.items() if kind == surface_type
+         for entry in entries),
+        key=lambda entry: entry[1],
     )
+    if any_exposure:
+        return any_exposure[0][2], "type_only_fallback"
+    return None, "none_available"
+
+
+def _construction_warnings(fallback_count: int, missing_count: int) -> list[str]:
+    """One disclosure per condition, not per surface.
+
+    Each patched surface carries a short `construction_source` slug; the prose lives here and is
+    emitted once. On the Austin fixture the fallback case alone covers 103 of 117 patches, so
+    repeating a sentence on every entry would add tens of kilobytes to a response an agent has to
+    read, to say the same thing 103 times.
+    """
+    warnings: list[str] = []
+    if fallback_count:
+        warnings.append(
+            f"{fallback_count} patch(es) borrowed a construction from a surface of the same type "
+            "but a DIFFERENT boundary condition (construction_source 'type_only_fallback') — no "
+            "surface of both the same type and exposure exists in the model. That can put an "
+            "exterior assembly on an interior surface or the reverse; check them before trusting "
+            "simulation results.",
+        )
+    if missing_count:
+        warnings.append(
+            f"{missing_count} patch(es) got no construction at all (construction_source "
+            "'none_available') — no default construction set and no existing surface of the type "
+            "to borrow from. Assign one before simulating or EnergyPlus will likely fail with a "
+            "missing-construction error.",
+        )
+    return warnings
 
 
 def _build_surface(
@@ -74,10 +158,9 @@ def _build_surface(
 
     surface.setSpace(space)
     surface.setOutsideBoundaryCondition("Outdoors")
-    surface_type = surface.surfaceType()
-    donor_construction = _donor_construction(model, surface_type)
-    if not surface.construction().is_initialized() and donor_construction is not None:
-        surface.setConstruction(donor_construction)
+    # No construction yet. It is assigned after the pairing pass below, once the surface's real
+    # boundary condition is known — every surface is created Outdoors here so match_surfaces()
+    # can pair it, so choosing an assembly at this point would be choosing against a placeholder.
     return True, surface, area.get()
 
 
@@ -219,7 +302,6 @@ def patch_missing_surfaces() -> dict[str, Any]:
                         skipped.append({"space": name, "component": comp_idx, "reason": result})
                         continue
                     surface = result
-                    resolved_construction = surface.construction()
                     new_surfaces.append(surface)
                     patched.append({
                         "space": name,
@@ -227,15 +309,8 @@ def patch_missing_surfaces() -> dict[str, Any]:
                         "surface_type": surface.surfaceType(),
                         "new_surface_name": surface.nameString(),
                         "area_m2": round(area_val, 4),
-                        "construction": resolved_construction.get().nameString()
-                            if resolved_construction.is_initialized() else None,
-                        "construction_warning": (
-                            None if resolved_construction.is_initialized()
-                            else "No construction assigned — no default construction set "
-                                 "and no existing surface of this type to borrow one from. "
-                                 "Assign one before simulating or EnergyPlus will likely "
-                                 "fail with a missing-construction error."
-                        ),
+                        # construction/construction_source/construction_warning are filled in
+                        # after pairing, once the real boundary condition is known.
                         # >1 means several distinct edge pairings were equally valid and
                         # one was chosen deterministically; the reconstruction is a
                         # legitimate reading of the geometry but not the only one.
@@ -267,6 +342,10 @@ def patch_missing_surfaces() -> dict[str, Any]:
             paired_names = {p["surface"] for p in paired_by_fallback}
             paired_names.update(p["paired_with"] for p in paired_by_fallback)
 
+            # Built here, before any patch has a construction, so the pools contain only
+            # pre-existing geometry — see build_construction_pools.
+            construction_pools = build_construction_pools(model)
+
             for entry, surface in zip(patched, new_surfaces, strict=True):
                 matched = surface.outsideBoundaryCondition() == "Surface"
                 entry["paired_by_fallback"] = surface.nameString() in paired_names
@@ -295,6 +374,27 @@ def patch_missing_surfaces() -> dict[str, Any]:
                          "WindExposed) before trusting simulation results."
                 )
 
+                partner_construction = None
+                adjacent = surface.adjacentSurface()
+                if adjacent.is_initialized():
+                    partner = adjacent.get().construction()
+                    if partner.is_initialized():
+                        partner_construction = partner.get()
+
+                construction, basis = choose_construction(
+                    construction_pools,
+                    surface.surfaceType(),
+                    surface.outsideBoundaryCondition(),
+                    entry["space"],
+                    partner_construction,
+                )
+                if construction is not None:
+                    surface.setConstruction(construction)
+                entry["construction"] = (
+                    construction.nameString() if construction is not None else None
+                )
+                entry["construction_source"] = basis
+
         already_flagged_spaces = {s["space"] for s in skipped}
         for space in attempted_spaces:
             if space.isEnclosedVolume():
@@ -311,16 +411,24 @@ def patch_missing_surfaces() -> dict[str, Any]:
                           "pre-existing edge; not further resolved automatically",
             })
 
-        return {
+        fallback_count = sum(1 for e in patched if e.get("construction_source") == "type_only_fallback")
+        missing_count = sum(1 for e in patched if e.get("construction_source") == "none_available")
+        result = {
             "ok": True,
             "patched_count": len(patched),
             "patched": patched,
             "skipped_count": len(skipped),
             "skipped": skipped,
             "ambiguous_boundary_condition_count": ambiguous_bc_count,
+            "construction_fallback_count": fallback_count,
+            "construction_missing_count": missing_count,
             "paired_by_fallback_count": len(paired_by_fallback),
             "paired_by_fallback": paired_by_fallback,
         }
+        warnings = _construction_warnings(fallback_count, missing_count)
+        if warnings:
+            result["construction_warnings"] = warnings
+        return result
     except RuntimeError as e:
         return {"ok": False, "error": str(e)}
     except Exception as e:

--- a/mcp_server/skills/geometry/repair.py
+++ b/mcp_server/skills/geometry/repair.py
@@ -76,9 +76,10 @@ def repair_missing_roof_ceiling() -> dict[str, Any]:
         skipped: list[dict[str, Any]] = []
         new_surfaces: list[openstudio.model.Surface] = []
 
-        for space in model.getSpaces():
+        # Name order — see match_surfaces() in geometry/operations.py (issue #134).
+        for space in sorted(model.getSpaces(), key=lambda s: s.nameString()):
             name = space.nameString()
-            surfaces = list(space.surfaces())
+            surfaces = sorted(space.surfaces(), key=lambda s: s.nameString())
 
             if any(s.surfaceType() == "RoofCeiling" for s in surfaces):
                 continue

--- a/mcp_server/skills/geometry/tools.py
+++ b/mcp_server/skills/geometry/tools.py
@@ -235,6 +235,20 @@ def register(mcp):
         facets are topological closures that need not correspond to a real building
         element. Override any that are genuinely exterior with
         set_surface_boundary_conditions.
+
+        Each patch also gets a construction copied from existing geometry, since these
+        models rarely carry a default construction set and EnergyPlus fails outright on
+        a surface without one. Where it came from is reported per surface in
+        construction_source: "partner" (the matched surface's own construction — the two
+        sides are the same assembly), "same_space_same_boundary"/"same_boundary" (a
+        surface of the same type AND exposure), or "type_only_fallback" (same type,
+        DIFFERENT exposure — the only case that can put an exterior assembly on an
+        interior surface). The last two counts are summarised in
+        construction_fallback_count / construction_missing_count with one explanation
+        each in construction_warnings, rather than a paragraph repeated per surface.
+        Expect the fallback to dominate on a model with no adiabatic geometry to copy
+        from: it covers 103 of 117 patches on the project's own Austin fixture. Review
+        those before trusting simulation results.
         """
         return patch_missing_surfaces()
 

--- a/mcp_server/skills/geometry/trim_overlapping_surfaces.py
+++ b/mcp_server/skills/geometry/trim_overlapping_surfaces.py
@@ -202,7 +202,10 @@ def trim_overlapping_surfaces() -> dict[str, Any]:
     subsurface. Anything else is reported as skipped — blending different thermal
     semantics, or cascading a parent removal into its windows and doors, would be silent
     data loss rather than a repair. Both sides' remainders are validated before either is
-    written, so a pair is trimmed completely or not at all.
+    written, and both writes are then verified, so a pair is trimmed completely or not at
+    all: a rejected first write changes nothing, and a rejected second one rolls the first
+    back. Only if that rollback is itself rejected — leaving a half-trimmed space nothing
+    can undo — does this return ok False and tell the caller to reload.
 
     Run repair_and_validate_gbxml_geometry() before and after to see the effect on
     overlapping_surfaces_count and non_enclosed_spaces_count — trimming an overlap can
@@ -281,8 +284,41 @@ def trim_overlapping_surfaces() -> dict[str, Any]:
                     })
                     continue
 
-                s1.setVertices(prepared1)
-                s2.setVertices(prepared2)
+                # _prepare_remainder validates both sides before either is written so a pair
+                # is trimmed completely or not at all. That covers a validation failure but
+                # not a write failure: setVertices can reject a polygon silently, and an
+                # unchecked second call would leave exactly the half-trimmed space the split
+                # exists to prevent, reported as a clean trim.
+                s1_original = openstudio.Point3dVector(list(s1.vertices()))
+                if not s1.setVertices(prepared1):
+                    skipped.append({
+                        "space": name, "surface_1": s1_name, "surface_2": s2_name,
+                        "reason": "OpenStudio rejected surface_1's trimmed remainder "
+                                  "(setVertices returned false); neither side was changed",
+                    })
+                    continue
+                if not s2.setVertices(prepared2):
+                    # s1 already took its remainder, so the pair is half-trimmed until this
+                    # lands. A refused restore leaves the space in that state, which must not
+                    # be reported as a skip — the caller has to reload.
+                    if not s1.setVertices(s1_original):
+                        return {
+                            "ok": False,
+                            "error": f"OpenStudio rejected {s2_name}'s trimmed remainder and "
+                                     f"then rejected the restore of {s1_name}'s original "
+                                     f"vertices, leaving space '{name}' half-trimmed. The "
+                                     f"model must be reloaded before it is used.",
+                            "trimmed_count": len(trimmed),
+                            "trimmed": trimmed,
+                        }
+                    skipped.append({
+                        "space": name, "surface_1": s1_name, "surface_2": s2_name,
+                        "reason": "OpenStudio rejected surface_2's trimmed remainder "
+                                  "(setVertices returned false); surface_1 was rolled back so "
+                                  "the pair stays all-or-nothing",
+                    })
+                    continue
+
                 any_change = True
                 already_handled.update((s1_name, s2_name))
                 trimmed.append({

--- a/mcp_server/skills/geometry/weld_coincident_vertices.py
+++ b/mcp_server/skills/geometry/weld_coincident_vertices.py
@@ -61,9 +61,12 @@ def weld_coincident_vertices() -> dict[str, Any]:
         skipped: list[dict[str, Any]] = []
         any_change = False
 
-        for space in model.getSpaces():
+        # Name order — see match_surfaces() in geometry/operations.py (issue #134). It matters
+        # here because the per-space vertex pool snaps each point to the first one it meets
+        # within tolerance, so the order decides which coordinate wins.
+        for space in sorted(model.getSpaces(), key=lambda s: s.nameString()):
             space_name = space.nameString()
-            surfaces = list(space.surfaces())
+            surfaces = sorted(space.surfaces(), key=lambda s: s.nameString())
             if not surfaces:
                 continue
 

--- a/mcp_server/skills/geometry/weld_coincident_vertices.py
+++ b/mcp_server/skills/geometry/weld_coincident_vertices.py
@@ -49,8 +49,10 @@ def weld_coincident_vertices() -> dict[str, Any]:
     normal — is preserved by construction. Two safety checks apply before rewriting: if
     two of a surface's *own* vertices snapped to the same point (degenerate edge), or the
     welded polygon's area collapses below MIN_WELDED_SURFACE_AREA_M2, that surface is
-    left alone and reported as skipped rather than corrupted. match_surfaces() is re-run
-    once, batched, if anything changed.
+    left alone and reported as skipped rather than corrupted. The write itself is then
+    verified: setVertices() can reject a polygon silently, and counting a rejected write
+    as a weld would inflate vertices_snapped for a snap that never happened while the
+    corner gap survived. match_surfaces() is re-run once, batched, if anything changed.
 
     Run repair_and_validate_gbxml_geometry() before and after to see the effect on
     non_enclosed_spaces_count.
@@ -114,7 +116,18 @@ def weld_coincident_vertices() -> dict[str, Any]:
                     })
                     continue
 
-                surface.setVertices(new_vertices)
+                # A rejection is silent — setVertices does not raise, and OpenStudio's
+                # complaint goes to a logger this server pins at Fatal — so an unchecked
+                # call would count a surface as welded and inflate vertices_snapped for a
+                # snap that never happened, while the corner gap it was closing survives.
+                if not surface.setVertices(new_vertices):
+                    skipped.append({
+                        "space": space_name, "surface": surface.nameString(),
+                        "reason": "OpenStudio rejected the welded polygon (setVertices "
+                                  "returned false); left unchanged",
+                    })
+                    continue
+
                 surfaces_modified.append(surface.nameString())
                 vertices_snapped += sum(
                     0 if (a.x() == b.x() and a.y() == b.y() and a.z() == b.z()) else 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Public API (no leading underscore):
   unwrap(res)            — extract dict/str from MCP CallToolResult
   server_params()        — build StdioServerParameters from env vars
   poll_until_done(s, id) — async poll get_run_status until terminal state
+  patch_set_vertices(mp, surface, factory) — fault-inject Surface.setVertices (in-process)
   EPW_PATH / POLL_SECONDS / SIM_TIMEOUT — simulation constants
 """
 import asyncio
@@ -127,6 +128,28 @@ async def setup_example(session, model_name):
     assert cr.get("ok") is True
     lr = unwrap(await session.call_tool("load_osm_model", {"osm_path": cr["osm_path"]}))
     assert lr.get("ok") is True
+
+
+# ---------------------------------------------------------------------------
+# In-process fault injection — geometry repair write guards
+# ---------------------------------------------------------------------------
+
+def patch_set_vertices(monkeypatch, surface, make_replacement) -> None:
+    """Swap Surface.setVertices on whichever class in the SWIG MRO defines it.
+
+    Patching the class rather than the instance is what makes this bite: the repair
+    tools walk model.getSurfaces() and operate on fresh proxy objects, not the ones a
+    test holds. `make_replacement` receives the original unbound function, so a fake can
+    delegate to it (e.g. succeed once, then refuse).
+
+    Deliberately no `openstudio` import — it walks type(surface).__mro__ instead — so
+    conftest stays importable from unit-test contexts that must not load the SDK.
+
+    Only usable from in-process tests. Tests driving the MCP stdio server run the code
+    under test in a subprocess this cannot reach.
+    """
+    target = next(c for c in type(surface).__mro__ if "setVertices" in c.__dict__)
+    monkeypatch.setattr(target, "setVertices", make_replacement(target.setVertices))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gbxml_import.py
+++ b/tests/test_gbxml_import.py
@@ -427,6 +427,31 @@ def test_repair_and_validate_gbxml_geometry_detects_shared_wall_duplication_over
                     90.72543765430825, rel=1e-9), flagged
                 assert flagged["sp-0basement"]["has_roofceiling"] is True, flagged
 
+                # Regression: this building HAS a basement and the translated model carries
+                # exactly one Ground surface out of 292 — its basement slab. The source gbXML
+                # declares a single UndergroundSlab and types the basement's own walls as plain
+                # ExteriorWall, so the defect is in the export, not the translator, and cannot be
+                # found by reading surfaceType back out of the gbXML. All 17 basement walls run
+                # z=-3.05 to z=+0.91: 77% buried, none of them *entirely* buried, which is why
+                # the check treats a mostly-buried wall as a basement wall. An "entirely below
+                # grade" rule reports 0 findings on this model.
+                assert result["ground_surfaces_existing_count"] == 1, result
+                assert result["ground_contact_missing_count"] == 17, result
+                assert set(result["ground_contact_missing"]) == {
+                    "su-e-0-e-w-10", "su-e-0-e-w-12", "su-e-0-e-w-15", "su-e-0-e-w-17",
+                    "su-n-0-e-w-2", "su-n-0-e-w-5", "su-ne-0-e-w-1", "su-ne-0-e-w-16",
+                    "su-nw-0-e-w-3", "su-s-0-e-w-11", "su-s-0-e-w-13", "su-s-0-e-w-7",
+                    "su-s-0-e-w-9", "su-se-0-e-w-14", "su-se-0-e-w-8", "su-w-0-e-w-4",
+                    "su-w-0-e-w-6",
+                }, result
+                assert result["partially_below_grade_count"] == 0, result
+                assert result["adiabatic_below_grade_count"] == 0, result
+                assert "partially_below_grade" not in result, result
+                assert "ground_contact_missing_truncated" not in result, result
+                # The ground check is report-only and must not have moved ok, which still means
+                # "geometry is structurally sound and will simulate".
+                assert result["ok"] is False, result  # from the 9 overlaps / 14 non-enclosed
+
     asyncio.run(_run())
 
 

--- a/tests/test_gbxml_import_timeout.py
+++ b/tests/test_gbxml_import_timeout.py
@@ -34,13 +34,23 @@ GBXML_PATH_AUSTIN_SLIVERS = "/repo/tests/assets/gbxml/austin_apartment_slivers.x
 AUSTIN_EPW_PATH = "/repo/tests/assets/USA_TX_Austin-Camp.Mabry.ANGB.722544_TMYx.2009-2023.epw"
 
 
-def test_timeout_returns_an_actionable_error_naming_the_cap_and_the_knob(monkeypatch):
+@pytest.mark.parametrize(("cap", "rendered"), [(1.0, "1s"), (0.5, "0.5s")])
+def test_timeout_returns_an_actionable_error_naming_the_cap_and_the_knob(
+    monkeypatch, cap, rendered,
+):
     # Regression: the timeout message was a hardcoded "gbXML import timed out (10 min)". It went
     # stale the moment the cap moved and named nothing the caller could change, so a timeout was
     # a dead end. It must report the cap actually in force and the env var that sets it.
+    #
+    # The cap it reports has to be the real one. Formatting it with .0f rendered a 0.5s cap as
+    # "0s" — not merely lossy but self-contradicting, since <= 0 is documented as "no cap" in
+    # config.py, docs/testing/testing.md and at the call site, so the message claimed a timeout
+    # against a cap meaning "no timeout". Sub-second caps are reachable: _safe_float accepts any
+    # finite value, and the call site treats anything > 0 as live. 0.5 is here because it is
+    # both the reported case and the one that lands exactly on .0f's half-to-even boundary.
     from mcp_server.skills.gbxml_import import operations as ops
 
-    monkeypatch.setattr(ops, "GBXML_IMPORT_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(ops, "GBXML_IMPORT_TIMEOUT_SECONDS", cap)
 
     result = ops.import_gbxml_op(
         gbxml_path=GBXML_PATH_AUSTIN_SLIVERS,
@@ -51,8 +61,10 @@ def test_timeout_returns_an_actionable_error_naming_the_cap_and_the_knob(monkeyp
     # Returned, not raised — operations never raise through the MCP layer.
     assert result["ok"] is False, result
     assert "OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS" in result["error"], result
-    assert "1s wall-clock cap" in result["error"], result
+    assert f"{rendered} wall-clock cap" in result["error"], result
     assert "10 min" not in result["error"], result
+    # The specific contradiction, not just the general rounding.
+    assert "the 0s" not in result["error"], result
 
 
 @pytest.mark.parametrize("cap", [0.0, -1.0, -0.5])

--- a/tests/test_gbxml_import_timeout.py
+++ b/tests/test_gbxml_import_timeout.py
@@ -1,0 +1,124 @@
+"""Tests for the configurable gbXML import wall-clock cap — requires OpenStudio (Docker).
+
+The cap exists because the gbXML measure workflow's runtime is almost entirely one measure's
+single-threaded surface matching, so it tracks the host's per-core speed and nothing else. A
+hardcoded literal was raised 300 -> 600 once for a boundary flake and then flaked again at ~625s
+on a slower machine, taking
+tests/test_gbxml_import.py::test_geometry_repair_pipeline_on_austin_apartment_fixture with it.
+The same import on that host measured 622-687s run on its own and 1228s with the rest of its own
+test file alongside it, which is why the default has headroom over the observed worst case rather
+than sitting just above the number that happened to be measured first.
+
+These run in seconds rather than the ~10 minutes a real import costs: setting the cap to ~1s makes
+the subprocess get killed almost immediately, which exercises the genuine timeout path. Driven
+in-process with monkeypatch.setattr on the module constant, the pattern
+tests/test_sim_queue.py uses for SIM_TIMEOUT_SECONDS.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+GBXML_PATH_AUSTIN_SLIVERS = "/repo/tests/assets/gbxml/austin_apartment_slivers.xml"
+AUSTIN_EPW_PATH = "/repo/tests/assets/USA_TX_Austin-Camp.Mabry.ANGB.722544_TMYx.2009-2023.epw"
+
+
+def test_timeout_returns_an_actionable_error_naming_the_cap_and_the_knob(monkeypatch):
+    # Regression: the timeout message was a hardcoded "gbXML import timed out (10 min)". It went
+    # stale the moment the cap moved and named nothing the caller could change, so a timeout was
+    # a dead end. It must report the cap actually in force and the env var that sets it.
+    from mcp_server.skills.gbxml_import import operations as ops
+
+    monkeypatch.setattr(ops, "GBXML_IMPORT_TIMEOUT_SECONDS", 1.0)
+
+    result = ops.import_gbxml_op(
+        gbxml_path=GBXML_PATH_AUSTIN_SLIVERS,
+        epw_path=AUSTIN_EPW_PATH,
+        run_name=f"pytest_timeout_{uuid.uuid4().hex[:10]}",
+    )
+
+    # Returned, not raised — operations never raise through the MCP layer.
+    assert result["ok"] is False, result
+    assert "OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS" in result["error"], result
+    assert "1s wall-clock cap" in result["error"], result
+    assert "10 min" not in result["error"], result
+
+
+def test_zero_disables_the_cap_rather_than_timing_out_instantly(monkeypatch):
+    # Regression: 0 means "no cap" across this server's timeouts (see SIM_TIMEOUT_SECONDS).
+    # Passing 0 straight through to subprocess.run would invert that into "time out immediately",
+    # so the falsy-to-None conversion is pinned here. The subprocess is stubbed rather than run,
+    # since an uncapped real import would take ~10 minutes to prove one keyword argument.
+    from mcp_server.skills.gbxml_import import operations as ops
+
+    monkeypatch.setattr(ops, "GBXML_IMPORT_TIMEOUT_SECONDS", 0.0)
+
+    seen: dict[str, object] = {}
+    real_run = subprocess.run
+
+    def _capture(*args, **kwargs):
+        # Only the workflow invocation matters; anything else the op shells out to runs for real.
+        if "timeout" in kwargs and "openstudio" in " ".join(str(a) for a in args[0]):
+            seen["timeout"] = kwargs["timeout"]
+            raise subprocess.TimeoutExpired(cmd="openstudio", timeout=0)
+        return real_run(*args, **kwargs)
+
+    monkeypatch.setattr(ops.subprocess, "run", _capture)
+
+    result = ops.import_gbxml_op(
+        gbxml_path=GBXML_PATH_AUSTIN_SLIVERS,
+        epw_path=AUSTIN_EPW_PATH,
+        run_name=f"pytest_nocap_{uuid.uuid4().hex[:10]}",
+    )
+
+    assert seen["timeout"] is None, seen
+    assert result["ok"] is False, result  # the stub raises TimeoutExpired to end the call early
+
+
+def test_cap_defaults_to_1800_and_is_overridable_by_either_env_var(monkeypatch):
+    # Validates: the constant follows this server's established two-name env convention
+    # (OPENSTUDIO_MCP_* taking precedence over OSMCP_*), and that a malformed or non-finite value
+    # falls back to the default instead of disabling enforcement — _safe_float rejects NaN/inf
+    # precisely because a non-finite cap makes every comparison against it false.
+    import importlib
+
+    from mcp_server import config
+
+    def _reload_with(**env):
+        for name in ("OPENSTUDIO_MCP_GBXML_IMPORT_TIMEOUT_SECONDS",
+                     "OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS"):
+            monkeypatch.delenv(name, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        return importlib.reload(config).GBXML_IMPORT_TIMEOUT_SECONDS
+
+    try:
+        assert _reload_with() == 1800.0
+        # Both overrides use values distinct from the default, so an override that was silently
+        # ignored would fail here rather than coincidentally matching.
+        assert _reload_with(OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS="900") == 900.0
+        assert _reload_with(OPENSTUDIO_MCP_GBXML_IMPORT_TIMEOUT_SECONDS="2400") == 2400.0
+        # The long name wins when both are set.
+        assert _reload_with(
+            OPENSTUDIO_MCP_GBXML_IMPORT_TIMEOUT_SECONDS="2400",
+            OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS="900",
+        ) == 2400.0
+        assert _reload_with(OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS="not-a-number") == 1800.0
+        assert _reload_with(OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS="nan") == 1800.0
+        assert _reload_with(OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS="inf") == 1800.0
+        # 0 is a legitimate value meaning "no cap", not a parse failure.
+        assert _reload_with(OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS="0") == 0.0
+    finally:
+        # Other tests in this session import the same module object.
+        importlib.reload(config)

--- a/tests/test_gbxml_import_timeout.py
+++ b/tests/test_gbxml_import_timeout.py
@@ -55,14 +55,19 @@ def test_timeout_returns_an_actionable_error_naming_the_cap_and_the_knob(monkeyp
     assert "10 min" not in result["error"], result
 
 
-def test_zero_disables_the_cap_rather_than_timing_out_instantly(monkeypatch):
-    # Regression: 0 means "no cap" across this server's timeouts (see SIM_TIMEOUT_SECONDS).
-    # Passing 0 straight through to subprocess.run would invert that into "time out immediately",
-    # so the falsy-to-None conversion is pinned here. The subprocess is stubbed rather than run,
-    # since an uncapped real import would take ~10 minutes to prove one keyword argument.
+@pytest.mark.parametrize("cap", [0.0, -1.0, -0.5])
+def test_non_positive_cap_disables_rather_than_timing_out_instantly(monkeypatch, cap):
+    # Regression: <= 0 means "no cap" across this server's timeouts (SIM_TIMEOUT_SECONDS
+    # gates on `<= 0`; resolve_gc_days clamps with max(0.0, ...)). This call site used
+    # `X or None`, which caught only 0.0 — a negative from a misconfigured env var stayed
+    # truthy and reached subprocess.run. That does not raise ValueError: it puts the
+    # deadline in the past, so TimeoutExpired fires in ~0ms and lands in the dedicated
+    # handler, which reported "exceeded the -1s wall-clock cap" — a confident, wrong
+    # diagnosis pointing at the workload instead of the config. -0.5 is here because it
+    # formats as "-0s", losing even the minus sign that hints at the real cause.
     from mcp_server.skills.gbxml_import import operations as ops
 
-    monkeypatch.setattr(ops, "GBXML_IMPORT_TIMEOUT_SECONDS", 0.0)
+    monkeypatch.setattr(ops, "GBXML_IMPORT_TIMEOUT_SECONDS", cap)
 
     seen: dict[str, object] = {}
     real_run = subprocess.run
@@ -71,7 +76,7 @@ def test_zero_disables_the_cap_rather_than_timing_out_instantly(monkeypatch):
         # Only the workflow invocation matters; anything else the op shells out to runs for real.
         if "timeout" in kwargs and "openstudio" in " ".join(str(a) for a in args[0]):
             seen["timeout"] = kwargs["timeout"]
-            raise subprocess.TimeoutExpired(cmd="openstudio", timeout=0)
+            raise subprocess.TimeoutExpired(cmd="openstudio", timeout=cap)
         return real_run(*args, **kwargs)
 
     monkeypatch.setattr(ops.subprocess, "run", _capture)

--- a/tests/test_geometry_write_guards.py
+++ b/tests/test_geometry_write_guards.py
@@ -1,0 +1,337 @@
+"""Every geometry repair tool must verify its setVertices writes — requires OpenStudio (Docker).
+
+Surface.setVertices() returns a bool, does not raise when it rejects a polygon, leaves the
+old vertices fully intact, and reports its complaint to an OpenStudio logger this server
+pins at Fatal (see stdout_suppression.py). A discarded return is therefore invisible in
+every direction: the tool reports a mutation that never happened, and — worse at two of
+these sites — acts on the assumption that it did.
+
+Driven in-process rather than through the MCP server because these tests fault-inject
+setVertices, and tests/test_geometry.py (which owns the behavioral coverage for these same
+three tools) drives them through the stdio server subprocess, which monkeypatch cannot
+reach. The real repair behavior stays covered there; this file covers only the write guards.
+
+A rejection is not reachable through any of these tools today — each screens its polygon
+with getArea() against a MIN_* threshold, and setVertices only refuses a polygon with fewer
+than 3 vertices or no computable plane, which is the same |Newell| ~ 0 condition getArea
+reports as zero. Measured on OpenStudio 3.11, rejection starts around 1e-5 m2 regardless of
+aspect ratio, so the 0.01 thresholds in weld/merge hold ~1000x margin and
+trim_overlapping_surfaces' MIN_REMAINDER_AREA_M2 = 0.0001 holds ~10x. These tests exist so
+that margin is not the only thing standing between a rejected write and a false report.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from conftest import patch_set_vertices
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+ALWAYS_REJECT = lambda _original: lambda *_args: False  # noqa: E731
+
+
+def _refuse_only_call(n: int):
+    """A setVertices fake that lets every write through except the nth, which it refuses.
+
+    Lets a test place the rejection at a precise point in a multi-write sequence — e.g.
+    after the first side of a trim pair has already been rewritten.
+    """
+    def _factory(original):
+        calls = []
+
+        def _fake(self, vertices):
+            calls.append(1)
+            return False if len(calls) == n else original(self, vertices)
+
+        return _fake
+    return _factory
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _load_empty_model(tmp_path: Path) -> None:
+    """Load a model with no geometry, so every count below comes from this test alone."""
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    osm_path = tmp_path / "empty.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(osm_path)), True)
+    load_model(osm_path)
+
+
+def _space_named(name: str):
+    from mcp_server.model_manager import get_model
+
+    return next(s for s in get_model().getSpaces() if s.nameString() == name)
+
+
+# --- merge_coplanar_sliver_surfaces ----------------------------------------------------
+
+def _build_split_ceiling(tmp_path: Path):
+    """One space whose ceiling is two coplanar fragments — merge's target defect."""
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print, create_surface
+
+    _load_empty_model(tmp_path)
+    created = create_space_from_floor_print(
+        name="MergeSpace",
+        floor_vertices=[[0, 0], [10, 0], [10, 10], [0, 10]],
+        floor_to_ceiling_height=3.0,
+    )
+    assert created["ok"] is True, created
+
+    space = _space_named("MergeSpace")
+    ceilings = [s for s in space.surfaces() if s.surfaceType() == "RoofCeiling"]
+    assert len(ceilings) == 1, [s.nameString() for s in ceilings]
+    ceilings[0].remove()
+
+    # A is the larger fragment (60 m2 vs 40 m2), so it becomes the survivor and B is
+    # what the tool would remove.
+    for frag_name, x0, x1 in (("CeilingFragA", 0, 6), ("CeilingFragB", 6, 10)):
+        frag = create_surface(
+            name=frag_name,
+            vertices=[[x0, 0, 3], [x1, 0, 3], [x1, 10, 3], [x0, 10, 3]],
+            space_name="MergeSpace",
+            surface_type="RoofCeiling",
+            outside_boundary_condition="Outdoors",
+        )
+        assert frag["ok"] is True, frag
+    return space
+
+
+def test_merge_does_not_delete_fragments_when_the_survivor_rewrite_is_rejected(
+    tmp_path, monkeypatch,
+):
+    # Regression: the survivor's setVertices return was discarded, and plan["others"] were
+    # removed unconditionally on the next loop. A rejected write is silent and leaves the
+    # survivor on its old fragment, so the tool destroyed the rest of the group against a
+    # merge that never happened — and reported it as merged, with fragments_before: 2 and
+    # surfaces_after: 1. This is the only one of the three sibling sites where a discarded
+    # return loses geometry rather than merely misreporting, which is why the assertion
+    # that matters is on the model, not the payload.
+    from mcp_server.skills.geometry.merge_coplanar_sliver_surfaces import (
+        merge_coplanar_sliver_surfaces,
+    )
+
+    space = _build_split_ceiling(tmp_path)
+    before = sorted(s.nameString() for s in space.surfaces())
+
+    patch_set_vertices(monkeypatch, space.surfaces()[0], ALWAYS_REJECT)
+
+    result = merge_coplanar_sliver_surfaces()
+
+    # Asserted before the payload, deliberately: the guarantee that matters here is that
+    # no geometry was destroyed, so an unguarded regression should fail on the missing
+    # fragment rather than on a report field.
+    assert sorted(s.nameString() for s in space.surfaces()) == before
+    ceilings = [s for s in space.surfaces() if s.surfaceType() == "RoofCeiling"]
+    assert len(ceilings) == 2, [s.nameString() for s in ceilings]
+    assert sum(float(s.grossArea()) for s in ceilings) == pytest.approx(100.0, abs=0.01)
+
+    assert result["ok"] is True, result
+    assert result["merged_group_count"] == 0, result
+    assert result["merged"] == [], result
+    assert result["skipped_group_count"] == 1, result
+    entry = result["skipped"][0]
+    assert "setVertices returned false" in entry["reason"], entry
+    assert entry["space"] == "MergeSpace", entry
+    assert sorted(entry["surfaces"]) == ["CeilingFragA", "CeilingFragB"], entry
+
+
+# --- trim_overlapping_surfaces ---------------------------------------------------------
+
+def _build_overlapping_walls(tmp_path: Path):
+    """A non-enclosed space with two coplanar walls that genuinely overlap in area."""
+    from mcp_server.skills.geometry.operations import create_surface
+    from mcp_server.skills.spaces.operations import create_space
+
+    _load_empty_model(tmp_path)
+    created = create_space(name="TrimSpace")
+    assert created["ok"] is True, created
+
+    for wall_name, x0, x1 in (("OverlapA", 0, 3), ("OverlapB", 1, 4)):
+        wall = create_surface(
+            name=wall_name,
+            vertices=[[x0, 0, 0], [x1, 0, 0], [x1, 0, 3], [x0, 0, 3]],
+            space_name="TrimSpace",
+            surface_type="Wall",
+            outside_boundary_condition="Outdoors",
+        )
+        assert wall["ok"] is True, wall
+
+    space = _space_named("TrimSpace")
+    assert space.isEnclosedVolume() is False, "two walls alone must be non-enclosed"
+    return space
+
+
+def test_trim_changes_neither_side_when_the_first_write_is_rejected(tmp_path, monkeypatch):
+    # Regression: both writes discarded their return. _prepare_remainder validates each side
+    # before either is written precisely so a pair is trimmed completely or not at all, but
+    # that only covers a validation failure — a rejected write left the same half-applied
+    # state the split exists to prevent, reported as a clean trim.
+    from mcp_server.skills.geometry.trim_overlapping_surfaces import trim_overlapping_surfaces
+
+    space = _build_overlapping_walls(tmp_path)
+    areas_before = sorted(round(float(s.grossArea()), 6) for s in space.surfaces())
+
+    patch_set_vertices(monkeypatch, space.surfaces()[0], ALWAYS_REJECT)
+
+    result = trim_overlapping_surfaces()
+
+    assert result["ok"] is True, result
+    assert result["trimmed_count"] == 0, result
+    assert result["skipped_count"] == 1, result
+    entry = result["skipped"][0]
+    assert "surface_1's trimmed remainder" in entry["reason"], entry
+    assert "neither side was changed" in entry["reason"], entry
+
+    assert sorted(round(float(s.grossArea()), 6) for s in space.surfaces()) == areas_before
+
+
+def test_trim_rolls_back_the_first_side_when_the_second_write_is_rejected(
+    tmp_path, monkeypatch,
+):
+    # Regression: the half-applied case the module's own docstrings promise cannot happen.
+    # With the first write landing and the second rejected, surface_1 must be restored so
+    # the pair really is all-or-nothing, rather than the space being left half-trimmed and
+    # reported as a clean trim.
+    from mcp_server.skills.geometry.trim_overlapping_surfaces import trim_overlapping_surfaces
+
+    space = _build_overlapping_walls(tmp_path)
+    areas_before = sorted(round(float(s.grossArea()), 6) for s in space.surfaces())
+
+    # Refuse only the second write, so the rollback that follows it can land.
+    patch_set_vertices(monkeypatch, space.surfaces()[0], _refuse_only_call(2))
+
+    result = trim_overlapping_surfaces()
+
+    assert result["ok"] is True, result
+    assert result["trimmed_count"] == 0, result
+    assert result["skipped_count"] == 1, result
+    entry = result["skipped"][0]
+    assert "surface_2's trimmed remainder" in entry["reason"], entry
+    assert "rolled back" in entry["reason"], entry
+
+    # Rolled back means restored, not merely "not obviously worse" — both walls keep their
+    # full pre-trim area, so no fragment of the trim survived.
+    assert sorted(round(float(s.grossArea()), 6) for s in space.surfaces()) == areas_before
+
+
+def test_trim_fails_the_run_when_the_rollback_itself_is_rejected(tmp_path, monkeypatch):
+    # Regression: with the second write rejected AND its rollback refused, the space really
+    # is left half-trimmed and nothing can undo it. That must not be reported as a skip
+    # alongside ok True — a caller would read it as a survivable outcome and keep building
+    # on damaged geometry. Same ruling as _restore_or_fail in paired_vertex_sync.py.
+    from mcp_server.skills.geometry.trim_overlapping_surfaces import trim_overlapping_surfaces
+
+    space = _build_overlapping_walls(tmp_path)
+
+    # Only the first write lands; both the second and the rollback after it are refused.
+    def _land_only_the_first(original):
+        calls = []
+
+        def _fake(self, vertices):
+            calls.append(1)
+            return original(self, vertices) if len(calls) == 1 else False
+
+        return _fake
+
+    patch_set_vertices(monkeypatch, space.surfaces()[0], _land_only_the_first)
+
+    result = trim_overlapping_surfaces()
+
+    assert result["ok"] is False, result
+    assert "must be reloaded" in result["error"], result
+    assert "half-trimmed" in result["error"], result
+    assert result["trimmed_count"] == 0, result
+    # Terminal, not a skip — no skipped list to read this off as recoverable.
+    assert "skipped" not in result, result
+
+    # The error is telling the truth: one side really did keep its trimmed remainder.
+    areas = sorted(round(float(s.grossArea()), 6) for s in space.surfaces())
+    assert areas != sorted([9.0, 9.0]), areas
+
+
+# --- weld_coincident_vertices ----------------------------------------------------------
+
+# A 4x4x3 box whose east wall is shifted 1.5cm out, inside WELD_TOLERANCE_M (0.02), so the
+# weld has real work to do. Ported from test_geometry.py's _box_vertices.
+_BOX = {
+    "Floor": ("Floor", [[0, 0, 0], [0, 4, 0], [4, 4, 0], [4, 0, 0]]),
+    "Ceiling": ("RoofCeiling", [[0, 0, 3], [4, 0, 3], [4, 4, 3], [0, 4, 3]]),
+    "WallSouth": ("Wall", [[0, 0, 0], [4, 0, 0], [4, 0, 3], [0, 0, 3]]),
+    "WallNorth": ("Wall", [[4, 4, 0], [0, 4, 0], [0, 4, 3], [4, 4, 3]]),
+    "WallWest": ("Wall", [[0, 4, 0], [0, 0, 0], [0, 0, 3], [0, 4, 3]]),
+    "WallEast": ("Wall", [[4.015, 0, 0], [4.015, 4, 0], [4.015, 4, 3], [4.015, 0, 3]]),
+}
+
+
+def _build_offset_box(tmp_path: Path):
+    from mcp_server.skills.geometry.operations import create_surface
+    from mcp_server.skills.spaces.operations import create_space
+
+    _load_empty_model(tmp_path)
+    created = create_space(name="WeldSpace")
+    assert created["ok"] is True, created
+
+    for surface_name, (surface_type, vertices) in _BOX.items():
+        res = create_surface(
+            name=f"Weld{surface_name}",
+            vertices=vertices,
+            space_name="WeldSpace",
+            surface_type=surface_type,
+            outside_boundary_condition="Outdoors",
+        )
+        assert res["ok"] is True, res
+
+    space = _space_named("WeldSpace")
+    assert space.isEnclosedVolume() is False, "the 1.5cm offset must leave the space open"
+    return space
+
+
+def test_weld_does_not_count_a_rejected_write_as_a_snapped_surface(tmp_path, monkeypatch):
+    # Regression: the setVertices return was discarded, so a rejected write still appended
+    # the surface to surfaces_modified and added its points to vertices_snapped — reporting
+    # a weld that never happened while the corner gap it was closing survived, under ok
+    # True. Unlike the merge and trim sites nothing is destroyed here; the damage is purely
+    # a false report, which is exactly what makes it hard to notice.
+    from mcp_server.skills.geometry.weld_coincident_vertices import weld_coincident_vertices
+
+    space = _build_offset_box(tmp_path)
+    vertices_before = {
+        s.nameString(): [(v.x(), v.y(), v.z()) for v in s.vertices()] for s in space.surfaces()
+    }
+
+    patch_set_vertices(monkeypatch, space.surfaces()[0], ALWAYS_REJECT)
+
+    result = weld_coincident_vertices()
+
+    assert result["ok"] is True, result
+    assert result["welded_space_count"] == 0, result
+    assert result["welded"] == [], result
+    assert result["skipped_surface_count"] >= 1, result
+    assert all(
+        "setVertices returned false" in entry["reason"] for entry in result["skipped"]
+    ), result["skipped"]
+    assert {entry["space"] for entry in result["skipped"]} == {"WeldSpace"}, result["skipped"]
+
+    # No surface moved, so the gap the weld was closing is still there to be found.
+    after = {
+        s.nameString(): [(v.x(), v.y(), v.z()) for v in s.vertices()] for s in space.surfaces()
+    }
+    assert after == vertices_before
+    assert space.isEnclosedVolume() is False

--- a/tests/test_ground_contact.py
+++ b/tests/test_ground_contact.py
@@ -1,0 +1,312 @@
+"""Tests for find_missing_ground_contact — requires OpenStudio (Docker).
+
+Driven in-process, like tests/test_paired_vertex_sync.py, because no MCP tool places a space at
+a chosen elevation or sets a space origin, and both are exactly what the grade rule turns on.
+Building the geometry directly is what makes every asserted count exact rather than
+fixture-dependent. The end-to-end path through repair_and_validate_gbxml_geometry is covered on
+the real basement fixture in test_gbxml_import.py.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _load_empty_model(tmp_path: Path) -> None:
+    """A model with no geometry, so every count comes from the test alone."""
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    osm_path = tmp_path / "empty.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(osm_path)), True)
+    load_model(osm_path)
+
+
+def _space_at(name: str, floor_z: float, height: float = 3.0):
+    """A 10x10 space whose floor sits at world z=floor_z, built from explicit surfaces.
+
+    create_space_from_floor_print() always extrudes upward from z=0, so it cannot place a floor
+    below grade — the case this module exists for. Surfaces are created directly instead.
+    """
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+
+    # Make the space at z=0, then move its surfaces bodily to the intended elevation. Surface
+    # type is fixed at creation and survives the move, so the floor stays a Floor.
+    created = create_space_from_floor_print(
+        name=name, floor_vertices=[[0, 0], [10, 0], [10, 10], [0, 10]], floor_to_ceiling_height=height,
+    )
+    assert created["ok"] is True, created
+
+    space = next(s for s in get_model().getSpaces() if s.nameString() == name)
+    for surface in space.surfaces():
+        moved = openstudio.Point3dVector(
+            [openstudio.Point3d(v.x(), v.y(), v.z() + floor_z) for v in surface.vertices()],
+        )
+        assert surface.setVertices(moved) is True
+    return space
+
+
+def _surfaces_of(space, surface_type: str):
+    return [s for s in space.surfaces() if s.surfaceType() == surface_type]
+
+
+def test_ground_family_covers_every_sdk_ground_condition():
+    # Validates: the "already connected" set is derived from the SDK and covers all ten
+    # ground-coupled conditions, not just the literal "Ground". A `== "Ground"` check would
+    # report every F/C-factor and Kiva Foundation surface as defective — the exact constructions
+    # ASHRAE 90.1 baseline work uses
+    import openstudio
+
+    from mcp_server.skills.geometry.ground_contact import ground_boundary_conditions
+
+    family = ground_boundary_conditions()
+    assert "Ground" in family
+    assert "Foundation" in family
+    assert "GroundFCfactorMethod" in family
+    assert "GroundBasementPreprocessorLowerWall" in family
+    assert len(family) == 10, sorted(family)
+    # Nothing outdoor-facing or interior may leak in.
+    assert family.isdisjoint({"Outdoors", "Surface", "Adiabatic", "OtherSideCoefficients"})
+    valid = set(openstudio.model.Surface.validOutsideBoundaryConditionValues())
+    assert family <= valid, family - valid
+
+
+def test_slab_at_grade_left_outdoors_is_reported(tmp_path):
+    # Validates: a floor at z=0 still set Outdoors is the unambiguous case — it is reported by
+    # name, and the name is what set_surface_boundary_conditions() takes
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    space = _space_at("AtGrade", floor_z=0.0)
+    floor = _surfaces_of(space, "Floor")[0]
+    assert floor.outsideBoundaryCondition() == "Ground", floor.outsideBoundaryCondition()
+    # fromFloorPrint() sets a z=0 floor to Ground already; force the defect under test.
+    assert floor.setOutsideBoundaryCondition("Outdoors") is True
+
+    result = find_missing_ground_contact()
+
+    assert result["ok"] is True, result
+    assert result["ground_contact_missing_count"] == 1, result
+    assert result["ground_contact_missing"] == [floor.nameString()], result
+    assert result["ground_surfaces_existing_count"] == 0, result
+    assert result["partially_below_grade_count"] == 0, result
+    assert result["adiabatic_below_grade_count"] == 0, result
+    assert "ground_contact_missing_truncated" not in result, result
+
+
+def test_slab_already_ground_is_not_reported(tmp_path):
+    # Validates: the same slab, correctly set, produces no finding and is counted as existing
+    # ground contact — the number that makes an implausible result visible next to the finding
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    space = _space_at("AtGrade", floor_z=0.0)
+    assert _surfaces_of(space, "Floor")[0].outsideBoundaryCondition() == "Ground"
+
+    result = find_missing_ground_contact()
+
+    assert result["ground_contact_missing_count"] == 0, result
+    assert result["ground_surfaces_existing_count"] == 1, result
+    # Clean models stay cheap: no name lists at all.
+    assert "ground_contact_missing" not in result, result
+    assert "partially_below_grade" not in result, result
+
+
+def test_every_ground_family_condition_suppresses_the_finding(tmp_path):
+    # Regression: a check written against the literal "Ground" would report a slab set to
+    # GroundFCfactorMethod or Foundation as missing ground contact. Driven from the SDK's own
+    # value list so a new condition in a future OpenStudio cannot silently start false-positiving
+    from mcp_server.skills.geometry.ground_contact import (
+        find_missing_ground_contact,
+        ground_boundary_conditions,
+    )
+
+    _load_empty_model(tmp_path)
+    space = _space_at("AtGrade", floor_z=0.0)
+    floor = _surfaces_of(space, "Floor")[0]
+
+    for condition in sorted(ground_boundary_conditions()):
+        assert floor.setOutsideBoundaryCondition(condition) is True, condition
+        result = find_missing_ground_contact()
+        assert result["ground_contact_missing_count"] == 0, (condition, result)
+        assert result["ground_surfaces_existing_count"] == 1, (condition, result)
+
+
+def test_fully_buried_surfaces_are_actionable(tmp_path):
+    # Validates: a space entirely below grade contributes its floor and all four walls to the
+    # actionable list, while its ceiling — sitting exactly at grade but a RoofCeiling — is left
+    # alone, since a ceiling below grade is not a ground connection
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    buried = _space_at("Basement", floor_z=-3.0)  # floor at -3, walls -3..0, ceiling at 0
+    for surface in buried.surfaces():
+        assert surface.setOutsideBoundaryCondition("Outdoors") is True
+
+    result = find_missing_ground_contact()
+
+    buried_names = {s.nameString() for s in buried.surfaces() if s.surfaceType() in ("Floor", "Wall")}
+    assert len(buried_names) == 5, buried_names
+    assert result["ground_contact_missing_count"] == 5, result
+    assert set(result["ground_contact_missing"]) == buried_names, result
+    assert result["partially_below_grade_count"] == 0, result
+
+
+def test_wall_crossing_grade_is_split_by_how_much_of_it_is_buried(tmp_path):
+    # Regression: an "entirely below grade" rule finds nothing on a real basement model. Every
+    # one of the 17 basement walls in tests/assets/2026_11Ja_path1.xml runs z=-3.05 to z=+0.91 —
+    # 77% buried, and 0 of them fully buried — so the whole ground-connection defect in that
+    # model would be reported as non-actionable. A wall mostly below grade is a basement wall;
+    # one that merely dips below is not
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    # 3 m tall walls: floor at -2 puts 2/3 below grade; floor at -1 puts 1/3 below.
+    mostly = _space_at("MostlyBuried", floor_z=-2.0)
+    barely = _space_at("BarelyBuried", floor_z=-1.0)
+    for surface in list(mostly.surfaces()) + list(barely.surfaces()):
+        assert surface.setOutsideBoundaryCondition("Outdoors") is True
+
+    result = find_missing_ground_contact()
+
+    mostly_walls = {s.nameString() for s in mostly.surfaces() if s.surfaceType() == "Wall"}
+    barely_walls = {s.nameString() for s in barely.surfaces() if s.surfaceType() == "Wall"}
+    # Both floors are fully below grade and actionable regardless; only the walls differ.
+    floors = {
+        s.nameString() for s in list(mostly.surfaces()) + list(barely.surfaces())
+        if s.surfaceType() == "Floor"
+    }
+    assert len(floors) == 2, floors
+
+    assert result["ground_contact_missing_count"] == 6, result
+    assert set(result["ground_contact_missing"]) == mostly_walls | floors, result
+    assert result["partially_below_grade_count"] == 4, result
+    assert set(result["partially_below_grade"]) == barely_walls, result
+    assert barely_walls.isdisjoint(set(result["ground_contact_missing"])), result
+
+
+def test_elevated_space_reports_nothing(tmp_path):
+    # Validates: a space entirely above grade produces no finding — the check must not sweep
+    # every Outdoors wall in the model into a "fix me" list
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    space = _space_at("Upper", floor_z=3.0)
+    for surface in space.surfaces():
+        assert surface.setOutsideBoundaryCondition("Outdoors") is True
+
+    result = find_missing_ground_contact()
+
+    assert result["ground_contact_missing_count"] == 0, result
+    assert result["partially_below_grade_count"] == 0, result
+
+
+def test_space_origin_is_applied_before_the_grade_test(tmp_path):
+    # Regression: Surface.vertices() are relative to the owning Space's origin, so reading z off
+    # them directly misplaces every surface in a space that carries one. Here the floor sits at
+    # local z=0 in a space whose origin is z=3 — it is 3 m ABOVE grade in world coordinates and
+    # must not be reported. A vertices()-only implementation reports it as a buried slab
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    space = _space_at("Lifted", floor_z=0.0)
+    assert space.setZOrigin(3.0) is True
+    for surface in space.surfaces():
+        assert surface.setOutsideBoundaryCondition("Outdoors") is True
+
+    result = find_missing_ground_contact()
+
+    assert result["ground_contact_missing_count"] == 0, result
+    assert result["partially_below_grade_count"] == 0, result
+
+
+def test_adiabatic_below_grade_is_counted_not_named(tmp_path):
+    # Validates: a below-grade surface already set Adiabatic is a deliberate assumption
+    # patch_missing_surfaces may have recorded, so it is counted but never listed — naming a
+    # hundred of them would be noise in a response an agent has to read
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    space = _space_at("Basement", floor_z=-3.0)
+    for surface in space.surfaces():
+        if surface.surfaceType() in ("Floor", "Wall"):
+            assert surface.setOutsideBoundaryCondition("Adiabatic") is True
+
+    result = find_missing_ground_contact()
+
+    assert result["adiabatic_below_grade_count"] == 5, result
+    assert result["ground_contact_missing_count"] == 0, result
+    assert "ground_contact_missing" not in result, result
+
+
+def test_actionable_list_caps_but_keeps_the_count_exact(tmp_path):
+    # Validates: past GROUND_NAME_CAP the list is truncated and flagged, while the count stays
+    # exact. The cap is deliberately far above the sibling 20-issue cap — these names are replayed
+    # into one batched set_surface_boundary_conditions() call, and a short list would force
+    # repeated diagnose-and-fix rounds
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.ground_contact import GROUND_NAME_CAP, find_missing_ground_contact
+
+    _load_empty_model(tmp_path)
+    space = _space_at("Basement", floor_z=-3.0)
+    model = get_model()
+
+    extra = GROUND_NAME_CAP + 5
+    for i in range(extra):
+        # Wound clockwise seen from above so the normal points down and OpenStudio types these
+        # as Floor. The counterclockwise order makes them RoofCeiling, which this check ignores
+        # by design — a ceiling below grade is not a ground connection.
+        surface = openstudio.model.Surface(
+            openstudio.Point3dVector([
+                openstudio.Point3d(0, 1, -3), openstudio.Point3d(1, 1, -3),
+                openstudio.Point3d(1, 0, -3), openstudio.Point3d(0, 0, -3),
+            ]),
+            model,
+        )
+        surface.setName(f"BuriedFloor{i}")
+        assert surface.setSpace(space) is True
+        assert surface.surfaceType() == "Floor", surface.surfaceType()
+        assert surface.setOutsideBoundaryCondition("Outdoors") is True
+
+    result = find_missing_ground_contact()
+
+    # The basement's own floor is left Ground by fromFloorPrint, so only its 4 Outdoors walls
+    # join the extras.
+    assert result["ground_surfaces_existing_count"] == 1, result
+    assert result["ground_contact_missing_count"] == extra + 4, result
+    assert len(result["ground_contact_missing"]) == GROUND_NAME_CAP, result
+    assert result["ground_contact_missing_truncated"] is True, result
+
+
+def test_reports_no_model_loaded_instead_of_raising():
+    # Validates: returns ok False rather than raising through MCP when no model is loaded
+    # (operations contract — nothing raises through the tool layer)
+    from mcp_server.skills.geometry.ground_contact import find_missing_ground_contact
+
+    result = find_missing_ground_contact()
+    assert result["ok"] is False, result
+    assert "model" in result["error"].lower(), result

--- a/tests/test_paired_vertex_sync.py
+++ b/tests/test_paired_vertex_sync.py
@@ -15,6 +15,7 @@ import os
 from pathlib import Path
 
 import pytest
+from conftest import patch_set_vertices
 
 pytestmark = [
     pytest.mark.integration,
@@ -135,17 +136,6 @@ def _fragment_partner_side(b_side) -> None:
     assert b_side.setVertices(openstudio.Point3dVector(lower)) is True
     assert len(b_side.vertices()) == 5
     assert b_space.isEnclosedVolume() is True, "B must start closed for the guard to be meaningful"
-
-
-def _patch_set_vertices(monkeypatch, surface, make_replacement) -> None:
-    """Swap setVertices on whichever class in the SWIG MRO actually defines it.
-
-    Patching the class rather than the instance is what makes this bite: the code under test
-    walks model.getSurfaces() and gets fresh proxy objects, not the ones a test holds.
-    `make_replacement` receives the original unbound function so a fake can delegate to it.
-    """
-    target = next(c for c in type(surface).__mro__ if "setVertices" in c.__dict__)
-    monkeypatch.setattr(target, "setVertices", make_replacement(target.setVertices))
 
 
 def test_choose_authoritative_index_prefers_larger_area():
@@ -427,7 +417,7 @@ def test_rejected_write_is_reported_as_skipped_not_as_a_repair(tmp_path, monkeyp
     _shrink(b_side, extra_vertex=True)
     assert len(b_side.vertices()) == 5
 
-    _patch_set_vertices(monkeypatch, b_side, lambda _original: lambda *_args: False)
+    patch_set_vertices(monkeypatch, b_side,lambda _original: lambda *_args: False)
 
     result = sync_paired_surface_vertices()
 
@@ -467,7 +457,7 @@ def test_rejected_rollback_fails_the_run_instead_of_reporting_a_clean_skip(tmp_p
 
         return _fake
 
-    _patch_set_vertices(monkeypatch, b_side, _let_the_mirror_land_then_refuse_the_restore)
+    patch_set_vertices(monkeypatch, b_side,_let_the_mirror_land_then_refuse_the_restore)
 
     result = sync_paired_surface_vertices()
 

--- a/tests/test_paired_vertex_sync.py
+++ b/tests/test_paired_vertex_sync.py
@@ -334,6 +334,64 @@ def test_sync_repairs_across_spaces_with_different_origins(tmp_path):
     assert b_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
 
 
+def test_sync_rolls_back_a_mirror_that_worsens_the_partner_space(tmp_path):
+    # Regression: a vertex-count mismatch is not always a desync to mirror. When
+    # merge_coplanar_sliver_surfaces has collapsed one space's wall into a single surface while
+    # the neighbour's side is still tiled into fragments, the two sides legitimately differ, and
+    # overwriting the fragment with the merged polygon leaves the neighbour overlapping itself.
+    # Measured on the Austin fixture, mirroring unguarded cost three spaces (4 non-enclosed
+    # became 7) and pushed patch_missing_surfaces off its known-good result (117/5/2/103 ->
+    # 119/8/2/106). isEnclosedVolume() is too coarse to catch it — 67 of those 74 spaces are
+    # already non-enclosed when the sync runs, so closed->open never fires — hence the guard
+    # measures polyhedron().edgesNotTwo(True), the same metric patch_missing_surfaces works from.
+    import openstudio
+
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    b_space = b_side.space().get()
+
+    # Split B's side of the shared wall into two stacked halves, mirroring the fragmented-partner
+    # case: the lower half stays paired with A's full-height wall, the upper half is a separate
+    # surface. B stays closed, so any later break is attributable to the sync alone.
+    def _at_height(vertices, low: float, high: float):
+        return openstudio.Point3dVector(
+            [openstudio.Point3d(v.x(), v.y(), low if v.z() == 0 else high) for v in vertices],
+        )
+
+    full = list(b_side.vertices())
+    upper = openstudio.model.Surface(_at_height(full, 1.5, 3.0), b_space.model())
+    upper.setName("SyncBUpperHalf")
+    assert upper.setSpace(b_space) is True
+    assert upper.surfaceType() == "Wall", upper.surfaceType()
+
+    # Lower half, plus a collinear midpoint so the pair disagrees on vertex count. A's side keeps
+    # the full 30 m2, so it wins on area and B's fragment is what would be overwritten.
+    lower = list(_at_height(full, 0.0, 1.5))
+    lower.insert(1, openstudio.Point3d(
+        (lower[0].x() + lower[1].x()) / 2, (lower[0].y() + lower[1].y()) / 2,
+        (lower[0].z() + lower[1].z()) / 2,
+    ))
+    assert b_side.setVertices(openstudio.Point3dVector(lower)) is True
+    assert len(b_side.vertices()) == 5
+    assert b_space.isEnclosedVolume() is True, "B must start closed for the guard to be meaningful"
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired_count"] == 0, result
+    assert result["paired_vertex_mismatches_skipped_count"] == 1, result
+    entry = result["paired_vertex_mismatches_skipped"][0]
+    assert "unpaired edges" in entry["reason"], entry
+    assert "rolled back" in entry["reason"], entry
+
+    # Rolled back means byte-for-byte restored, not merely "not obviously worse".
+    assert len(b_side.vertices()) == 5, b_side.vertices()
+    assert b_side.grossArea() == pytest.approx(15.0, abs=1e-6)
+    assert a_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
+    assert b_space.isEnclosedVolume() is True
+
+
 def test_sync_reports_no_model_loaded_instead_of_raising():
     # Validates: the operation returns ok False rather than raising through MCP when no
     # model is loaded (operations contract — nothing raises through the tool layer)

--- a/tests/test_paired_vertex_sync.py
+++ b/tests/test_paired_vertex_sync.py
@@ -103,6 +103,51 @@ def _shrink(surface, extra_vertex: bool) -> None:
     assert surface.setVertices(points) is True, "setVertices rejected the substitute polygon"
 
 
+def _fragment_partner_side(b_side) -> None:
+    """Leave B's side of the shared wall as a fragment of a wall A still spans whole.
+
+    Reproduces the merged-vs-tiled case: B's wall becomes two stacked surfaces, only the
+    lower of which stays paired with A's full-height wall, plus a collinear midpoint so the
+    pair disagrees on vertex count without disagreeing on anything else. B stays enclosed,
+    so any later break is attributable to the sync alone.
+    """
+    import openstudio
+
+    b_space = b_side.space().get()
+
+    def _at_height(vertices, low: float, high: float):
+        return openstudio.Point3dVector(
+            [openstudio.Point3d(v.x(), v.y(), low if v.z() == 0 else high) for v in vertices],
+        )
+
+    full = list(b_side.vertices())
+    upper = openstudio.model.Surface(_at_height(full, 1.5, 3.0), b_space.model())
+    upper.setName("SyncBUpperHalf")
+    assert upper.setSpace(b_space) is True
+    assert upper.surfaceType() == "Wall", upper.surfaceType()
+
+    # A's side keeps the full 30 m2, so it wins on area and B's fragment is what gets rewritten.
+    lower = list(_at_height(full, 0.0, 1.5))
+    lower.insert(1, openstudio.Point3d(
+        (lower[0].x() + lower[1].x()) / 2, (lower[0].y() + lower[1].y()) / 2,
+        (lower[0].z() + lower[1].z()) / 2,
+    ))
+    assert b_side.setVertices(openstudio.Point3dVector(lower)) is True
+    assert len(b_side.vertices()) == 5
+    assert b_space.isEnclosedVolume() is True, "B must start closed for the guard to be meaningful"
+
+
+def _patch_set_vertices(monkeypatch, surface, make_replacement) -> None:
+    """Swap setVertices on whichever class in the SWIG MRO actually defines it.
+
+    Patching the class rather than the instance is what makes this bite: the code under test
+    walks model.getSurfaces() and gets fresh proxy objects, not the ones a test holds.
+    `make_replacement` receives the original unbound function so a fake can delegate to it.
+    """
+    target = next(c for c in type(surface).__mro__ if "setVertices" in c.__dict__)
+    monkeypatch.setattr(target, "setVertices", make_replacement(target.setVertices))
+
+
 def test_choose_authoritative_index_prefers_larger_area():
     # Validates: area is the leading criterion, ahead of vertex count — the drifted side
     # is typically the one a weld shrank, so the larger polygon is the one to keep
@@ -344,37 +389,11 @@ def test_sync_rolls_back_a_mirror_that_worsens_the_partner_space(tmp_path):
     # 119/8/2/106). isEnclosedVolume() is too coarse to catch it — 67 of those 74 spaces are
     # already non-enclosed when the sync runs, so closed->open never fires — hence the guard
     # measures polyhedron().edgesNotTwo(True), the same metric patch_missing_surfaces works from.
-    import openstudio
-
     from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
 
     a_side, b_side = _build_adjacent_pair(tmp_path)
     b_space = b_side.space().get()
-
-    # Split B's side of the shared wall into two stacked halves, mirroring the fragmented-partner
-    # case: the lower half stays paired with A's full-height wall, the upper half is a separate
-    # surface. B stays closed, so any later break is attributable to the sync alone.
-    def _at_height(vertices, low: float, high: float):
-        return openstudio.Point3dVector(
-            [openstudio.Point3d(v.x(), v.y(), low if v.z() == 0 else high) for v in vertices],
-        )
-
-    full = list(b_side.vertices())
-    upper = openstudio.model.Surface(_at_height(full, 1.5, 3.0), b_space.model())
-    upper.setName("SyncBUpperHalf")
-    assert upper.setSpace(b_space) is True
-    assert upper.surfaceType() == "Wall", upper.surfaceType()
-
-    # Lower half, plus a collinear midpoint so the pair disagrees on vertex count. A's side keeps
-    # the full 30 m2, so it wins on area and B's fragment is what would be overwritten.
-    lower = list(_at_height(full, 0.0, 1.5))
-    lower.insert(1, openstudio.Point3d(
-        (lower[0].x() + lower[1].x()) / 2, (lower[0].y() + lower[1].y()) / 2,
-        (lower[0].z() + lower[1].z()) / 2,
-    ))
-    assert b_side.setVertices(openstudio.Point3dVector(lower)) is True
-    assert len(b_side.vertices()) == 5
-    assert b_space.isEnclosedVolume() is True, "B must start closed for the guard to be meaningful"
+    _fragment_partner_side(b_side)
 
     result = sync_paired_surface_vertices()
 
@@ -390,6 +409,108 @@ def test_sync_rolls_back_a_mirror_that_worsens_the_partner_space(tmp_path):
     assert b_side.grossArea() == pytest.approx(15.0, abs=1e-6)
     assert a_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
     assert b_space.isEnclosedVolume() is True
+
+
+def test_rejected_write_is_reported_as_skipped_not_as_a_repair(tmp_path, monkeypatch):
+    # Regression: setVertices() returns a bool and leaves the surface's old vertices in place
+    # when it rejects a polygon — without raising, and with its only complaint going to an
+    # OpenStudio logger this server pins at Fatal. An unchecked call therefore looks exactly
+    # like a harmless mirror to the manifold guard (edge counts unchanged either way), so the
+    # pair would be counted as repaired while the vertex-count mismatch that aborts E+ at
+    # GetSurfaceData survives untouched, under ok True. Fault-injected because the guards
+    # above the write make a real rejection unreachable today: MIN_VERTICES bounds the count
+    # and the MIN_SYNCED_SURFACE_AREA_M2 check implies a computable plane. That coupling is
+    # what this asserts the code no longer depends on.
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    _shrink(b_side, extra_vertex=True)
+    assert len(b_side.vertices()) == 5
+
+    _patch_set_vertices(monkeypatch, b_side, lambda _original: lambda *_args: False)
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired_count"] == 0, result
+    assert result["paired_vertex_mismatches_repaired"] == [], result
+    assert result["paired_vertex_mismatches_skipped_count"] == 1, result
+    entry = result["paired_vertex_mismatches_skipped"][0]
+    assert "setVertices returned false" in entry["reason"], entry
+    assert entry["partner"] == b_side.nameString(), entry
+
+    # No repair means no rematch was needed, and the defect is still on the model for a
+    # later pass to find rather than silently written off as fixed.
+    assert result["rematched_surfaces"] is None, result
+    assert len(a_side.vertices()) == 4, a_side.vertices()
+    assert len(b_side.vertices()) == 5, b_side.vertices()
+
+
+def test_rejected_rollback_fails_the_run_instead_of_reporting_a_clean_skip(tmp_path, monkeypatch):
+    # Regression: the rollback in the manifold guard was also unchecked, and it is the more
+    # dangerous of the two writes. A refused restore leaves the model holding the mirror this
+    # function just decided was harmful, so reporting the pair as "rolled back and left
+    # unchanged" would be a false statement about damaged geometry. It must end the run with
+    # ok False and say the model needs reloading.
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    b_name = b_side.nameString()
+    _fragment_partner_side(b_side)
+
+    def _let_the_mirror_land_then_refuse_the_restore(original):
+        calls = []
+
+        def _fake(self, vertices):
+            calls.append(1)
+            return original(self, vertices) if len(calls) == 1 else False
+
+        return _fake
+
+    _patch_set_vertices(monkeypatch, b_side, _let_the_mirror_land_then_refuse_the_restore)
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is False, result
+    assert b_name in result["error"], result
+    assert "must be reloaded" in result["error"], result
+    assert result["paired_vertex_mismatches_repaired_count"] == 0, result
+    # Terminal, not a skip — a caller must not read this as a survivable outcome.
+    assert "paired_vertex_mismatches_skipped" not in result, result
+
+    # The error is telling the truth: the harmful mirror really is still applied.
+    assert b_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6), b_side.grossArea()
+    assert len(b_side.vertices()) == len(a_side.vertices()), b_side.vertices()
+
+
+def test_setvertices_rejection_modes_stay_inside_the_area_guard(tmp_path):
+    # Validates: the two conditions under which OpenStudio rejects a polygon — fewer than
+    # three vertices, and no computable plane — are both screened by the guards that run
+    # before the write, and a rejection leaves the surface untouched rather than half-written.
+    # getArea() is |Newell| / 2 and Plane construction fails only when |Newell| is ~0, so an
+    # area above MIN_SYNCED_SURFACE_AREA_M2 implies a plane. Pinned here so an OpenStudio
+    # upgrade that changes either behavior fails loudly instead of quietly invalidating the
+    # reasoning behind the guard order.
+    import openstudio
+
+    from mcp_server.skills.geometry.paired_vertex_sync import MIN_SYNCED_SURFACE_AREA_M2
+
+    a_side, _ = _build_adjacent_pair(tmp_path)
+    original = list(a_side.vertices())
+
+    too_few = openstudio.Point3dVector(original[:2])
+    collinear = openstudio.Point3dVector([
+        openstudio.Point3d(10, 0, 0), openstudio.Point3d(10, 5, 0), openstudio.Point3d(10, 10, 0),
+    ])
+
+    for name, polygon in (("too_few", too_few), ("collinear", collinear)):
+        assert a_side.setVertices(polygon) is False, name
+        # Rejected means untouched, which is exactly why an unchecked call is invisible.
+        assert len(a_side.vertices()) == len(original), name
+        assert a_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6), name
+
+        area = openstudio.getArea(polygon)
+        assert not area.is_initialized() or area.get() <= MIN_SYNCED_SURFACE_AREA_M2, name
 
 
 def test_sync_reports_no_model_loaded_instead_of_raising():

--- a/tests/test_paired_vertex_sync.py
+++ b/tests/test_paired_vertex_sync.py
@@ -1,0 +1,344 @@
+"""Tests for sync_paired_surface_vertices — requires OpenStudio (Docker).
+
+Driven in-process rather than through the MCP server because the defect under test —
+the two sides of an interior surface pair carrying different vertex counts — cannot be
+created through any MCP tool. No tool sets vertices on an existing surface; the repair
+tools that produce the defect in the field (weld_coincident_vertices,
+merge_coplanar_sliver_surfaces) only do so incidentally, on geometry broken in specific
+ways. Building the pair directly is what makes these assertions exact rather than
+fixture-dependent. The end-to-end path through repair_and_validate_gbxml_geometry is
+covered on the real Austin fixture in test_gbxml_import.py.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+# Space A occupies x 0..10, space B x 10..20, both y 0..10 and 3 m tall, so the
+# shared wall at x=10 is a single 10 x 3 = 30 m2 rectangle on each side.
+SHARED_WALL_AREA_M2 = 30.0
+# The polygon each test substitutes for the B side: same plane, 2 m tall instead of 3.
+SHRUNK_WALL_AREA_M2 = 20.0
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _load_empty_model(tmp_path: Path) -> None:
+    """Load a model with no geometry, so every count below comes from this test alone."""
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    osm_path = tmp_path / "empty.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(osm_path)), True)
+    load_model(osm_path)
+
+
+def _build_adjacent_pair(tmp_path: Path):
+    """Two adjacent spaces with their shared wall matched; returns (a_side, b_side)."""
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print, match_surfaces
+
+    _load_empty_model(tmp_path)
+
+    for name, x0, x1 in (("SyncA", 0, 10), ("SyncB", 10, 20)):
+        created = create_space_from_floor_print(
+            name=name,
+            floor_vertices=[[x0, 0], [x1, 0], [x1, 10], [x0, 10]],
+            floor_to_ceiling_height=3.0,
+        )
+        assert created["ok"] is True, created
+
+    matched = match_surfaces()
+    assert matched["ok"] is True, matched
+
+    model = get_model()
+    paired = [
+        s for s in model.getSurfaces()
+        if s.outsideBoundaryCondition() == "Surface" and s.adjacentSurface().is_initialized()
+    ]
+    # Exactly one interior boundary exists, so anything the tests count afterward is
+    # attributable to the pair they deliberately break.
+    assert len(paired) == 2, [s.nameString() for s in paired]
+
+    by_space = {s.space().get().nameString(): s for s in paired}
+    assert set(by_space) == {"SyncA", "SyncB"}, sorted(by_space)
+    assert by_space["SyncA"].grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
+    assert by_space["SyncB"].grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
+    return by_space["SyncA"], by_space["SyncB"]
+
+
+def _shrink(surface, extra_vertex: bool) -> None:
+    """Replace a side with a 20 m2 polygon in the same plane, optionally 5-sided.
+
+    The extra point is collinear, so the vertex count changes without the area changing
+    with it — that separates the two signals the code treats differently.
+    """
+    import openstudio
+
+    points = [
+        openstudio.Point3d(10, 0, 0),
+        openstudio.Point3d(10, 10, 0),
+        openstudio.Point3d(10, 10, 2),
+    ]
+    if extra_vertex:
+        points.append(openstudio.Point3d(10, 5, 2))
+    points.append(openstudio.Point3d(10, 0, 2))
+    assert surface.setVertices(points) is True, "setVertices rejected the substitute polygon"
+
+
+def test_choose_authoritative_index_prefers_larger_area():
+    # Validates: area is the leading criterion, ahead of vertex count — the drifted side
+    # is typically the one a weld shrank, so the larger polygon is the one to keep
+    from mcp_server.skills.geometry.paired_vertex_sync import choose_authoritative_index
+
+    # The smaller side has MORE vertices, so a vertex-count-first rule would pick it.
+    assert choose_authoritative_index([("a", 4, 30.0), ("b", 5, 20.0)]) == 0
+    assert choose_authoritative_index([("a", 5, 20.0), ("b", 4, 30.0)]) == 1
+
+
+def test_choose_authoritative_index_tiebreaks_on_vertex_count_then_name():
+    # Validates: equal areas fall through to the higher vertex count, and a full tie
+    # falls through to the lexicographically smaller name, so the choice is total and
+    # never depends on iteration order
+    from mcp_server.skills.geometry.paired_vertex_sync import choose_authoritative_index
+
+    assert choose_authoritative_index([("a", 4, 30.0), ("b", 5, 30.0)]) == 1
+    assert choose_authoritative_index([("b", 4, 30.0), ("a", 4, 30.0)]) == 1
+    assert choose_authoritative_index([("a", 4, 30.0), ("b", 4, 30.0)]) == 0
+
+
+def test_sync_repairs_vertex_count_mismatch(tmp_path):
+    # Validates: a pair whose sides carry 4 and 5 vertices is repaired by mirroring the
+    # larger-area side onto the smaller, leaving both sides with the same vertex count
+    # and the same area — the exact condition E+ GetSurfaceData checks before simulating
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    a_name, b_name = a_side.nameString(), b_side.nameString()
+    _shrink(b_side, extra_vertex=True)
+    assert len(b_side.vertices()) == 5
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired_count"] == 1, result
+    assert result["paired_vertex_mismatches_skipped_count"] == 0, result
+    assert result["paired_area_mismatches_count"] == 0, result
+
+    entry = result["paired_vertex_mismatches_repaired"][0]
+    assert entry["surface"] == b_name, entry
+    assert entry["space"] == "SyncB", entry
+    assert entry["partner"] == a_name, entry
+    assert entry["partner_space"] == "SyncA", entry
+    assert entry["kept"] == a_name, entry
+    assert entry["vertices_before"] == 5, entry
+    assert entry["vertices_after"] == 4, entry
+    assert entry["area_before_m2"] == pytest.approx(SHRUNK_WALL_AREA_M2, abs=1e-4), entry
+    assert entry["area_after_m2"] == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-4), entry
+
+    # Assert the model itself, not just the report: both sides now describe one polygon.
+    assert len(a_side.vertices()) == 4
+    assert len(b_side.vertices()) == 4
+    assert b_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
+    # The rewritten side must still point back at its partner — a repair that silently
+    # dropped the pairing would satisfy every count above while breaking the model.
+    assert b_side.outsideBoundaryCondition() == "Surface"
+    assert b_side.adjacentSurface().is_initialized()
+    assert b_side.adjacentSurface().get().nameString() == a_name
+
+
+def test_sync_skips_rewriting_a_side_that_carries_subsurfaces(tmp_path):
+    # Validates: the side that would be rewritten is left alone when it holds windows or
+    # doors, since they are positioned against the polygon it has and replacing that
+    # polygon could strand them outside it — reported as skipped, and skipped pairs are
+    # what keep repair_and_validate_gbxml_geometry's ok False
+    from mcp_server.skills.geometry.operations import create_subsurface
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    b_name = b_side.nameString()
+
+    window = create_subsurface(
+        name="SyncBWindow",
+        vertices=[[10, 2, 1], [10, 8, 1], [10, 8, 2], [10, 2, 2]],
+        parent_surface_name=b_name,
+    )
+    assert window["ok"] is True, window
+
+    # B is the smaller side, so B is the one the repair would rewrite.
+    _shrink(b_side, extra_vertex=True)
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired_count"] == 0, result
+    assert result["paired_vertex_mismatches_skipped_count"] == 1, result
+    assert result["paired_area_mismatches_count"] == 0, result
+
+    entry = result["paired_vertex_mismatches_skipped"][0]
+    assert entry["partner"] == b_name, entry
+    assert entry["surface"] == a_side.nameString(), entry
+    assert "subsurfaces" in entry["reason"], entry
+
+    # Untouched: still mismatched, and the window is still on it.
+    assert len(b_side.vertices()) == 5
+    assert [s.nameString() for s in b_side.subSurfaces()] == ["SyncBWindow"]
+
+
+def test_sync_reports_area_mismatch_without_reshaping(tmp_path):
+    # Validates: sides that agree on vertex count but not on area are reported only.
+    # E+ accepts them and matchSurfaces() has its own ~0.0125 m tolerance, so reshaping
+    # on that weaker signal would be a guess — the geometry must come back unchanged
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    a_name, b_name = a_side.nameString(), b_side.nameString()
+    _shrink(b_side, extra_vertex=False)
+    assert len(b_side.vertices()) == 4
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired_count"] == 0, result
+    assert result["paired_vertex_mismatches_skipped_count"] == 0, result
+    assert result["paired_area_mismatches_count"] == 1, result
+
+    entry = result["paired_area_mismatches"][0]
+    # Which side is reported as "surface" follows model iteration order, so pin the pair
+    # rather than the roles.
+    assert {entry["surface"], entry["partner"]} == {a_name, b_name}, entry
+    assert sorted((entry["area_m2"], entry["partner_area_m2"])) == [
+        pytest.approx(SHRUNK_WALL_AREA_M2, abs=1e-4),
+        pytest.approx(SHARED_WALL_AREA_M2, abs=1e-4),
+    ], entry
+
+    assert b_side.grossArea() == pytest.approx(SHRUNK_WALL_AREA_M2, abs=1e-6)
+    assert a_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
+
+
+def test_sync_is_a_no_op_on_a_consistent_model(tmp_path):
+    # Validates: a model whose pairs already agree reports nothing and rewrites nothing.
+    # This runs on every repair_and_validate_gbxml_geometry call, so a false positive
+    # here would reshape correct geometry on healthy models
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    a_side, b_side = _build_adjacent_pair(tmp_path)
+    a_before = [(v.x(), v.y(), v.z()) for v in a_side.vertices()]
+    b_before = [(v.x(), v.y(), v.z()) for v in b_side.vertices()]
+
+    result = sync_paired_surface_vertices()
+
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired"] == [], result
+    assert result["paired_vertex_mismatches_skipped"] == [], result
+    assert result["paired_area_mismatches"] == [], result
+
+    assert [(v.x(), v.y(), v.z()) for v in a_side.vertices()] == a_before
+    assert [(v.x(), v.y(), v.z()) for v in b_side.vertices()] == b_before
+
+
+def test_sync_repair_is_idempotent(tmp_path):
+    # Validates: running the repair twice reports one fix then none. The second call is
+    # what proves the mirrored polygon actually satisfies the check that triggered the
+    # first — a repair that left the pair inconsistent would report it again forever
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    _a_side, b_side = _build_adjacent_pair(tmp_path)
+    _shrink(b_side, extra_vertex=True)
+
+    first = sync_paired_surface_vertices()
+    assert first["paired_vertex_mismatches_repaired_count"] == 1, first
+
+    second = sync_paired_surface_vertices()
+    assert second["ok"] is True, second
+    assert second["paired_vertex_mismatches_repaired_count"] == 0, second
+    assert second["paired_vertex_mismatches_skipped_count"] == 0, second
+    assert second["paired_area_mismatches_count"] == 0, second
+
+
+def test_sync_repairs_across_spaces_with_different_origins(tmp_path):
+    # Regression: Surface.vertices() are relative to the owning Space's origin, so copying
+    # them verbatim across spaces displaces the polygon by the difference between the two
+    # origins. gbXML imports happen to land identity transforms (their OS:Space origin
+    # fields come through empty), which hid this — a model whose spaces carry origins
+    # would have had the rewritten surface teleported instead of repaired. Space B is
+    # given origin x=10 with its own vertices shifted to match, so it occupies exactly the
+    # same world position as before: a verbatim copy puts the repaired wall at world x=20,
+    # the correct conversion leaves it at x=10.
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    _load_empty_model(tmp_path)
+
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print, match_surfaces
+
+    for name, x0, x1 in (("SyncA", 0, 10), ("SyncB", 10, 20)):
+        assert create_space_from_floor_print(
+            name=name,
+            floor_vertices=[[x0, 0], [x1, 0], [x1, 10], [x0, 10]],
+            floor_to_ceiling_height=3.0,
+        )["ok"] is True
+
+    model = get_model()
+    b_space = next(s for s in model.getSpaces() if s.nameString() == "SyncB")
+    # Re-express B in a frame whose origin is x=10, leaving it where it already is.
+    for surface in b_space.surfaces():
+        shifted = openstudio.Point3dVector(
+            [openstudio.Point3d(v.x() - 10.0, v.y(), v.z()) for v in surface.vertices()],
+        )
+        assert surface.setVertices(shifted) is True
+    assert b_space.setXOrigin(10.0) is True
+
+    assert match_surfaces()["ok"] is True
+    b_side = next(
+        s for s in b_space.surfaces()
+        if s.outsideBoundaryCondition() == "Surface" and s.adjacentSurface().is_initialized()
+    )
+    # In B's own frame the shared wall sits at local x=0 even though it is at world x=10.
+    assert all(v.x() == pytest.approx(0.0, abs=1e-9) for v in b_side.vertices()), b_side.vertices()
+
+    # Shrink B in ITS frame: same plane (local x=0), 2 m tall, with a collinear 5th point.
+    shrunk = openstudio.Point3dVector([
+        openstudio.Point3d(0, 0, 0), openstudio.Point3d(0, 10, 0), openstudio.Point3d(0, 10, 2),
+        openstudio.Point3d(0, 5, 2), openstudio.Point3d(0, 0, 2),
+    ])
+    assert b_side.setVertices(shrunk) is True
+
+    result = sync_paired_surface_vertices()
+    assert result["ok"] is True, result
+    assert result["paired_vertex_mismatches_repaired_count"] == 1, result
+
+    world = b_space.transformation() * b_side.vertices()
+    assert [v.x() for v in world] == [pytest.approx(10.0, abs=1e-9)] * len(world), [
+        (v.x(), v.y(), v.z()) for v in world
+    ]
+    assert b_side.grossArea() == pytest.approx(SHARED_WALL_AREA_M2, abs=1e-6)
+
+
+def test_sync_reports_no_model_loaded_instead_of_raising():
+    # Validates: the operation returns ok False rather than raising through MCP when no
+    # model is loaded (operations contract — nothing raises through the tool layer)
+    from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
+
+    result = sync_paired_surface_vertices()
+    assert result["ok"] is False, result
+    assert "model" in result["error"].lower(), result

--- a/tests/test_patch_construction_choice.py
+++ b/tests/test_patch_construction_choice.py
@@ -1,0 +1,211 @@
+"""Construction assignment for reconstructed surfaces — requires OpenStudio (Docker).
+
+Follow-up to #134. patch_missing_surfaces used to take the first surface of a matching *type* in
+handle order, from the whole model, as its construction donor. Two defects in one line: handles
+are UUIDs minted afresh on every import, so the choice was random; and filtering on type alone
+meant a patched interior ceiling could draw from an exterior roof. On the Austin fixture the
+RoofCeiling pool holds 92 interior ceilings and 13 exterior roofs, and the donor is shared by
+every patch in a run, so roughly one run in eight put an R-20 cool-roof assembly on ~117 interior
+surfaces — while also flipping trim_overlapping_surfaces between 1/18 and 0/19.
+
+Synthetic and in-process: the real fixture costs a ~20 minute import, and every property here is
+expressible in a two-space model.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _named_construction(model, name: str):
+    import openstudio
+
+    construction = openstudio.model.Construction(model)
+    construction.setName(name)
+    return construction
+
+
+def _space(model, name: str, x0: float, x1: float):
+    """A 10 m deep, 3 m tall box spanning x0..x1, built from explicit surfaces."""
+    import openstudio
+
+    space = openstudio.model.Space(model)
+    space.setName(name)
+    faces = {
+        "floor": [(x0, 0, 0), (x1, 0, 0), (x1, 10, 0), (x0, 10, 0)],
+        "ceiling": [(x0, 10, 3), (x1, 10, 3), (x1, 0, 3), (x0, 0, 3)],
+        "south": [(x0, 0, 3), (x1, 0, 3), (x1, 0, 0), (x0, 0, 0)],
+        "north": [(x1, 10, 3), (x0, 10, 3), (x0, 10, 0), (x1, 10, 0)],
+        "west": [(x0, 10, 3), (x0, 0, 3), (x0, 0, 0), (x0, 10, 0)],
+        "east": [(x1, 0, 3), (x1, 10, 3), (x1, 10, 0), (x1, 0, 0)],
+    }
+    made = {}
+    for face, points in faces.items():
+        surface = openstudio.model.Surface(
+            openstudio.Point3dVector([openstudio.Point3d(*p) for p in points]), model,
+        )
+        surface.setName(f"{name}_{face}")
+        assert surface.setSpace(space) is True
+        made[face] = surface
+    return space, made
+
+
+def _load(model, tmp_path: Path, stem: str = "m") -> None:
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    path = tmp_path / f"{stem}.osm"
+    model.save(openstudio.toPath(str(path)), True)
+    load_model(path)
+
+
+def _new_model():
+    import openstudio
+    return openstudio.model.Model()
+
+
+def test_a_paired_patch_takes_its_partners_construction(tmp_path):
+    # Validates: when the reconstructed surface ends up matched to a real partner, the two sides
+    # are the same physical assembly, so the partner's construction is used outright rather than
+    # any heuristic. A decoy of the same surface type carrying a different construction sits in
+    # the model to prove the choice is not just "first wall we found".
+    from mcp_server.skills.geometry.patch_missing_surfaces import patch_missing_surfaces
+
+    model = _new_model()
+    _left, left_faces = _space(model, "Left", 0, 10)
+    _right, right_faces = _space(model, "Right", 10, 20)
+
+    partner_construction = _named_construction(model, "PartnerAssembly")
+    decoy = _named_construction(model, "DecoyAssembly")
+    for surface in list(left_faces.values()) + list(right_faces.values()):
+        surface.setConstruction(decoy)
+    # The surviving side of the shared partition carries the construction the patch should copy.
+    right_faces["west"].setConstruction(partner_construction)
+    # Punch the hole: Left loses its side of the shared partition.
+    left_faces["east"].remove()
+
+    _load(model, tmp_path)
+    result = patch_missing_surfaces()
+
+    assert result["ok"] is True, result
+    assert result["patched_count"] == 1, result
+    entry = result["patched"][0]
+    assert entry["space"] == "Left", entry
+    assert entry["construction_source"] == "partner", entry
+    assert entry["construction"] == "PartnerAssembly", entry
+
+
+def test_an_unpaired_patch_prefers_its_own_boundary_condition_over_another(tmp_path):
+    # Regression (#134): the donor pool was filtered by surface type alone, so an interior
+    # surface could inherit an exterior assembly. An unpaired patch is set Adiabatic, so it must
+    # prefer an existing Adiabatic wall over an Outdoors one even though both are Walls.
+    from mcp_server.skills.geometry.patch_missing_surfaces import patch_missing_surfaces
+
+    model = _new_model()
+    _space_obj, faces = _space(model, "Solo", 0, 10)
+
+    exterior = _named_construction(model, "ExteriorAssembly")
+    interior = _named_construction(model, "InteriorAssembly")
+    for surface in faces.values():
+        surface.setOutsideBoundaryCondition("Outdoors")
+        surface.setConstruction(exterior)
+    # One adiabatic wall, the only surface sharing the patch's eventual boundary condition.
+    # Deliberately the LAST wall in name order (north < south < west once east is removed), so a
+    # type-only donor would reach Solo_north/ExteriorAssembly first and this test would catch it.
+    # Picking an alphabetically-early donor here would let the old behaviour pass by luck.
+    faces["west"].setOutsideBoundaryCondition("Adiabatic")
+    faces["west"].setConstruction(interior)
+    faces["east"].remove()
+
+    _load(model, tmp_path)
+    result = patch_missing_surfaces()
+
+    assert result["ok"] is True, result
+    assert result["patched_count"] == 1, result
+    entry = result["patched"][0]
+    # Unpaired, so Adiabatic — and the Adiabatic donor must win over the 4 Outdoors ones.
+    assert entry["final_boundary_condition"] == "Adiabatic", entry
+    assert entry["construction"] == "InteriorAssembly", entry
+    assert entry["construction_source"] in ("same_space_same_boundary", "same_boundary"), entry
+    assert result["construction_fallback_count"] == 0, result
+    assert "construction_warnings" not in result, result
+
+
+def test_construction_choice_survives_a_fresh_handle_assignment(tmp_path):
+    # Regression (#134): the donor was the first matching surface in handle order, so the choice
+    # was redrawn on every import. clone(False) is newHandles (clone(True) keeps them and would
+    # perturb nothing), which reproduces a fresh import's enumeration in milliseconds.
+    from mcp_server.skills.geometry.patch_missing_surfaces import patch_missing_surfaces
+
+    def _assignments(model, stem):
+        _load(model, tmp_path, stem)
+        result = patch_missing_surfaces()
+        assert result["ok"] is True, result
+        assert result["patched_count"] >= 1, result
+        return sorted((e["construction"], e["construction_source"]) for e in result["patched"])
+
+    def _fixture():
+        model = _new_model()
+        _space(model, "Solo", 0, 10)
+        space_faces = {s.nameString(): s for s in model.getSurfaces()}
+        # A deliberately mixed pool: several Wall constructions, so an arbitrary pick has
+        # something to be arbitrary about.
+        for index, (name, surface) in enumerate(sorted(space_faces.items())):
+            surface.setOutsideBoundaryCondition("Outdoors")
+            surface.setConstruction(_named_construction(model, f"Assembly{index}"))
+        space_faces["Solo_east"].remove()
+        return model
+
+    baseline_model = _fixture()
+    baseline = _assignments(baseline_model, "base")
+
+    source = _fixture()
+    clone = source.clone(False).to_Model()
+    original = {str(s.handle()) for s in source.getSurfaces()}
+    assert {str(s.handle()) for s in clone.getSurfaces()}.isdisjoint(original)
+    assert _assignments(clone, "clone") == baseline, baseline
+
+
+def test_no_available_construction_is_reported_once_not_per_surface(tmp_path):
+    # Validates: a model with no construction anywhere still patches, and says so — in a single
+    # top-level warning plus a per-surface slug, not a paragraph repeated on every entry. On the
+    # Austin fixture the equivalent case covers 103 of 117 patches, so per-entry prose would add
+    # tens of kilobytes to a response an agent has to read.
+    from mcp_server.skills.geometry.patch_missing_surfaces import patch_missing_surfaces
+
+    model = _new_model()
+    _space(model, "Solo", 0, 10)
+    {s.nameString(): s for s in model.getSurfaces()}["Solo_east"].remove()
+
+    _load(model, tmp_path)
+    result = patch_missing_surfaces()
+
+    assert result["ok"] is True, result
+    assert result["patched_count"] == 1, result
+    entry = result["patched"][0]
+    assert entry["construction"] is None, entry
+    assert entry["construction_source"] == "none_available", entry
+    assert "construction_warning" not in entry, entry  # aggregated, not repeated
+
+    assert result["construction_missing_count"] == 1, result
+    assert len(result["construction_warnings"]) == 1, result
+    assert "missing-construction error" in result["construction_warnings"][0], result

--- a/tests/test_trim_order_invariance.py
+++ b/tests/test_trim_order_invariance.py
@@ -1,0 +1,183 @@
+"""Order-invariance guard for trim_overlapping_surfaces — requires OpenStudio (Docker).
+
+Issue #134 reported this tool flaking between 1 trimmed / 18 skipped and 0/19 on the Austin
+fixture, hypothesising that handle-ordered enumeration and an asymmetric compatibility check made
+borderline pairs flip. Investigation found the canonicalization already present — name-sorted
+spaces and surfaces, `already_handled` keyed by name — introduced by the very commit that created
+the module (542591f, PR #124), so the module has never existed on develop without it. Four probes
+against the real fixture (duplicate-name audit, auto-numbering sweep, whole-model clone with fresh
+handles, and reading the compatibility check for symmetry) all came back deterministic.
+
+What was missing was a test. The canonicalization could be removed and every existing test would
+still pass, because the pinned fixture assertions only exercise one enumeration order. These tests
+pin the property directly, and cheaply — the real fixture costs a ~20 minute import, so the
+geometry here is synthetic and built so that name order and handle order DISAGREE.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+# Three coplanar walls on x=0, each overlapping the next. Created in reverse-alphabetical order so
+# handle order (creation order) is the exact reverse of name order — any code that enumerates by
+# handle picks a different first pair than code that enumerates by name.
+WALL_SPANS = (("C_wall", 8.0, 18.0), ("B_wall", 5.0, 15.0), ("A_wall", 0.0, 10.0))
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _build_overlapping_model(tmp_path: Path) -> Path:
+    """A non-enclosed space holding three mutually overlapping coplanar walls.
+
+    Non-enclosed on purpose: trim_overlapping_surfaces is scoped to spaces failing
+    isEnclosedVolume(), so a closed space would be skipped entirely and the test would pass
+    without exercising anything. A floor with no ceiling guarantees it.
+    """
+    import openstudio
+
+    model = openstudio.model.Model()
+    space = openstudio.model.Space(model)
+    space.setName("TrimOrderSpace")
+
+    floor = openstudio.model.Surface(
+        openstudio.Point3dVector([
+            openstudio.Point3d(0, 20, 0), openstudio.Point3d(20, 20, 0),
+            openstudio.Point3d(20, 0, 0), openstudio.Point3d(0, 0, 0),
+        ]),
+        model,
+    )
+    floor.setName("TheFloor")
+    assert floor.setSpace(space) is True
+
+    for name, y0, y1 in WALL_SPANS:
+        wall = openstudio.model.Surface(
+            openstudio.Point3dVector([
+                openstudio.Point3d(0, y0, 3), openstudio.Point3d(0, y0, 0),
+                openstudio.Point3d(0, y1, 0), openstudio.Point3d(0, y1, 3),
+            ]),
+            model,
+        )
+        wall.setName(name)
+        assert wall.setSpace(space) is True
+        assert wall.surfaceType() == "Wall", (name, wall.surfaceType())
+
+    assert space.isEnclosedVolume() is False, "space must be non-enclosed for trim to consider it"
+
+    osm_path = tmp_path / "overlaps.osm"
+    model.save(openstudio.toPath(str(osm_path)), True)
+    return osm_path
+
+
+def _trim_result(osm_path: Path) -> dict:
+    from mcp_server.model_manager import load_model
+    from mcp_server.skills.geometry.trim_overlapping_surfaces import trim_overlapping_surfaces
+
+    load_model(osm_path)
+    return trim_overlapping_surfaces()
+
+
+def test_trim_picks_the_pair_by_name_order_not_creation_order(tmp_path):
+    # Regression (#134): with three mutually overlapping surfaces, `already_handled` makes this
+    # first-come-first-served — whichever pair is seen first is trimmed and the rest are skipped.
+    # Which pair that is therefore reveals the enumeration order outright. Names sort
+    # A_wall < B_wall < C_wall while creation (handle) order is the reverse, so handle-ordered
+    # enumeration would trim C_wall/B_wall instead.
+    result = _trim_result(_build_overlapping_model(tmp_path))
+
+    assert result["ok"] is True, result
+    assert result["trimmed_count"] == 1, result
+    assert result["skipped_count"] == 2, result
+
+    entry = result["trimmed"][0]
+    assert (entry["surface_1"], entry["surface_2"]) == ("A_wall", "B_wall"), entry
+    assert entry["space"] == "TrimOrderSpace", entry
+
+    # The other two pairs are declined for being downstream of the handled one, not for some
+    # unrelated incompatibility that would make this test pass for the wrong reason.
+    for skipped in result["skipped"]:
+        assert "already involved in another overlap" in skipped["reason"], skipped
+
+
+def test_trim_is_unchanged_by_a_fresh_handle_assignment(tmp_path):
+    # Regression (#134): the reported trigger was OpenStudio minting fresh UUIDs on every import,
+    # changing getSurfaces() order. Cloning a model mints a whole new handle set while leaving the
+    # geometry byte-identical, which reproduces that condition without a ~20 minute re-import.
+    # Every stage of the result must be identical, not merely the counts.
+    import openstudio
+
+    osm_path = _build_overlapping_model(tmp_path)
+    baseline = _trim_result(osm_path)
+
+    source = openstudio.model.Model.load(openstudio.toPath(str(osm_path))).get()
+    # clone(False) is newHandles; clone(True) is keepHandles and would perturb nothing. The
+    # assertion below is what catches that mistake — it was made once already while investigating
+    # this issue, and produced a false "deterministic" result.
+    clone = source.clone(False).to_Model()
+    original_handles = {str(s.handle()) for s in source.getSurfaces()}
+    clone_handles = {str(s.handle()) for s in clone.getSurfaces()}
+    assert clone_handles.isdisjoint(original_handles), "clone must not reuse the source's handles"
+
+    clone_path = tmp_path / "overlaps_clone.osm"
+    clone.save(openstudio.toPath(str(clone_path)), True)
+    reordered = _trim_result(clone_path)
+
+    assert reordered["trimmed_count"] == baseline["trimmed_count"], (baseline, reordered)
+    assert reordered["skipped_count"] == baseline["skipped_count"], (baseline, reordered)
+    assert [(e["surface_1"], e["surface_2"]) for e in reordered["trimmed"]] == \
+           [(e["surface_1"], e["surface_2"]) for e in baseline["trimmed"]], (baseline, reordered)
+    assert [e["surface_1_remaining_area_m2"] for e in reordered["trimmed"]] == \
+           [e["surface_1_remaining_area_m2"] for e in baseline["trimmed"]], (baseline, reordered)
+
+
+def test_incompatibility_reason_decides_the_same_way_in_either_operand_order(tmp_path):
+    # Regression (#134): the issue hypothesised the compatibility check was asymmetric, so a
+    # borderline pair would flip between trim and skip depending on which surface arrived first.
+    # It is symmetric — set comparisons, and a subsurface check that fires if EITHER side has one
+    # — and that must stay true, since the pair order is otherwise free to change.
+    import openstudio
+
+    from mcp_server.model_manager import get_model, load_model
+    from mcp_server.skills.geometry.trim_overlapping_surfaces import _incompatibility_reason
+
+    load_model(_build_overlapping_model(tmp_path))
+    model = get_model()
+    a = next(s for s in model.getSurfaces() if s.nameString() == "A_wall")
+    b = next(s for s in model.getSurfaces() if s.nameString() == "B_wall")
+
+    # Compatible both ways to start with.
+    assert _incompatibility_reason(a, b) is None
+    assert _incompatibility_reason(b, a) is None
+
+    # Each guard must fire regardless of operand order. Only the decision is asserted, not the
+    # message text, which legitimately names the surfaces in the order it was given them.
+    assert a.setOutsideBoundaryCondition("Adiabatic") is True
+    assert (_incompatibility_reason(a, b) is None) == (_incompatibility_reason(b, a) is None)
+    assert _incompatibility_reason(a, b) is not None
+    assert a.setOutsideBoundaryCondition("Outdoors") is True
+
+    window = openstudio.model.SubSurface(
+        openstudio.Point3dVector([
+            openstudio.Point3d(0, 2, 2), openstudio.Point3d(0, 2, 1),
+            openstudio.Point3d(0, 4, 1), openstudio.Point3d(0, 4, 2),
+        ]),
+        model,
+    )
+    assert window.setSurface(a) is True
+    assert (_incompatibility_reason(a, b) is None) == (_incompatibility_reason(b, a) is None)
+    assert _incompatibility_reason(a, b) is not None


### PR DESCRIPTION
## Summary

Adds two gbXML repair checks, then fixes a nondeterminism bug (#134) that the work exposed.

**New checks in `repair_and_validate_gbxml_geometry`**
- **Paired-vertex sync** (mutating): interior pairs whose two sides disagree on vertex count make
  EnergyPlus abort at `GetSurfaceData` before simulating. Nothing else caught this —
  `match_surfaces()` counts surfaces, not consistent pairs, so a broken pair looks healthy. The
  other repair tools *cause* it, since each rewrites one side of a pair in isolation.
- **Ground contact** (report-only): Revit exports under-declare ground contact and the translator
  reproduces it — the repo's basement fixture has 1 `Ground` surface out of 292. A buried slab
  left `Outdoors` takes fictitious solar gain and wind convection. Reports 17 buried walls on that
  fixture; never sets a boundary condition itself.

**Fixes #134** — `trim_overlapping_surfaces` flipping between 1/18 and 0/19 on the Austin fixture.
The canonicalization the issue asks for was already present; the instability was in trim's inputs.
`match_surfaces()` handed the SDK a handle-ordered `SpaceVector`, and `patch_missing_surfaces`
picked construction donors by handle order filtered on surface type alone. Over 12 consecutive
fresh handle assignments the pipeline now gives one outcome (117/5/2/103, trim 1/18, 4
non-enclosed), down from several.

That second bug was not only a flake: the donor pool mixed 92 interior ceilings with 13 exterior
roofs, and one donor is shared by every patch in a run, so ~1 run in 8 put an R-20 cool-roof
assembly on ~117 interior surfaces.

**Also** makes the gbXML import wall-clock cap configurable (`OSMCP_GBXML_IMPORT_TIMEOUT_SECONDS`,
default 1800). The hardcoded 600s killed the import mid-measure on slower hosts; that timeout had
been masking the assertion failures above.

## Testing

4 new test files, 27 tests. Regression tests verified to fail against the pre-fix behaviour, not
just pass against the new one. No pinned assertion was loosened.

## Notes for review

- `patch_missing_surfaces` responses now carry `construction_source` per surface; on a model with
  no adiabatic geometry to copy from, `type_only_fallback` dominates (103 of 117 on the Austin
  fixture). Disclosed rather than silent, but the underlying modelling question — what construction
  a reconstructed adiabatic surface *should* get — is deliberately left open.
- No new MCP tools, so the tool roster is unchanged.