### PR TITLE
Search the complete OpenStudio API surface with usable signatures

### DIFF
--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -87,6 +87,23 @@ run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 extract_summary_metrics(run_id=<retrofit_id>)   # compare to baseline
 ```
 
+## Verify SDK Methods Before Writing run_body
+
+Guessed method names are the top cause of `NoMethodError` / `AttributeError` in measures.
+`search_api` returns each method as a signature, not a bare name:
+```
+search_api("BoilerHotWater", method_pattern="Efficiency")
+# -> "setNominalThermalEfficiency(nominalThermalEfficiency) -> Boolean"
+search_api("SqlFile", method_pattern="^annual")     # non-model classes too (openstudio root, gbxml, alfalfa, ...)
+```
+Read the signature literally; names are identical in Ruby and Python:
+- `-> Float` plain value; `-> Float, nil` is an Optional (`.is_initialized` then `.get`)
+- `-> ?` return type unknown (no header/annotation); probe the object before calling `.get`
+- `-> Array<TimeSeries> | TimeSeries, nil` overloaded; the return depends on the arguments
+- `[static] load(path) -> Model, nil` class-level call (`Model.load`), never on an instance
+- `signatures_available: false` in the response = signatures could not be loaded; the method
+  names are still real, only the parameter/return details are missing
+
 ## Language Choice
 
 Both are **fully supported** — `create_measure(language="Ruby"|"Python", ...)` scaffolds, tests

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -80,6 +80,9 @@ If a measure fails due to nonexistent API methods:
 ```
 search_api("CoilCoolingFourPipeBeam")              # list real setters/getters
 search_api("BoilerHotWater", method_pattern="Efficiency")
+# each entry is a signature: "setNominalThermalEfficiency(nominalThermalEfficiency) -> Boolean"
+# "-> X, nil" = Optional (.get after .is_initialized); "-> ?" = unknown, probe first;
+# "[static] " prefix = call on the class, not an instance
 ```
 
 ## Quick Fixes

--- a/mcp_server/skills/api_reference/_headers.py
+++ b/mcp_server/skills/api_reference/_headers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Iterable
 from pathlib import Path
 
 # Default install location inside the MCP image. The Python wheel ships no headers, so
@@ -40,8 +41,13 @@ _ENV_VAR = "OSMCP_OPENSTUDIO_INCLUDE"
 # all-caps class (`class MODEL_API AVM : public X`), since the trailing `(\w+)` must match.
 # A trailing `;` (forward declaration, `class ThermalZone_Impl;`) matches none of `:{$`
 # and is correctly ignored.
-_CLASS_RE = re.compile(r"^\s*class\s+(?:[A-Z][A-Z0-9_]*(?:\([^)]*\))?\s+)*(\w+)\s*(?::|\{|$)")
+_CLASS_RE = re.compile(r"^\s*(?:class|struct)\s+(?:[A-Z][A-Z0-9_]*(?:\([^)]*\))?\s+)*(\w+)\s*(?::|\{|$)")
 _ACCESS_RE = re.compile(r"^\s*(public|protected|private)\s*:")
+
+# `%rename(ZUnit) openstudio::Unit;` / `%rename(toString) openstudio::measure::OSArgument::print;`
+# — SWIG renames classes and methods, and the C++ headers declare only the pre-rename
+# name. Without applying the directive, the exposed class never finds its declaration.
+_RENAME_RE = re.compile(r"^\s*%rename\(\s*(\w+)\s*\)\s*([\w:]+)\s*;")
 
 # `%extend openstudio::model::ModelObject{` — SWIG interface files declare the methods it
 # synthesizes onto a class, which exist in no .hpp. ModelCore.i is where `toIdfObject`
@@ -240,9 +246,18 @@ def map_cpp_type(cpp: str, class_names: set[str] | None = None) -> str:
 
 
 def _parse_header(path: Path) -> dict[str, dict[str, str]]:
-    """Parse one .hpp into ``{class: {method: cpp_return_type}}`` (public members only)."""
+    """Parse one header into ``{class: {method: cpp_return_type}}`` (public members only)."""
     out: dict[str, dict[str, str]] = {}
     current: str | None = None
+    # Nested classes/structs (``struct CalendarDay`` inside ``class Calendar``) and
+    # inline method bodies must not hijack or prematurely close the enclosing class.
+    # Brace depth is tracked per line: a class body closes when depth drops below the
+    # level it had when the body's ``{`` opened — a method-body close keeps depth at
+    # or above that level, the class's own ``};`` drops below it. stack entries are
+    # (outer class, base depth) with base None until the body's ``{`` is seen (the
+    # brace may sit on the following line).
+    stack: list[tuple[str | None, int | None]] = []
+    depth = 0
     pending = ""
     in_block = False
 
@@ -260,12 +275,37 @@ def _parse_header(path: Path) -> dict[str, dict[str, str]]:
 
         class_match = _CLASS_RE.match(line) or _EXTEND_RE.match(line)
         if class_match:
+            depth += line.count("{") - line.count("}")
+            stack.append((current, depth if "{" in line else None))
             current = class_match.group(1)
             out.setdefault(current, {})
             pending = ""
             continue
 
+        # Track brace depth and pop classes whose body has closed. A body opened on an
+        # earlier line pins its base depth the first time a ``{`` line arrives.
+        depth += line.count("{") - line.count("}")
+        if stack and stack[-1][1] is None and "{" in line:
+            stack[-1] = (stack[-1][0], depth)
+        while stack and stack[-1][1] is not None and depth < stack[-1][1]:
+            current, _ = stack.pop()
+
         if current is None:
+            continue
+
+        # A constructor's initializer list — the line after ``Ctor(...)``, which ends
+        # with ``)`` so the multi-line continuation rule below already flushed — is a
+        # continuation of the (skipped) constructor, not a declaration. Without the
+        # skip, ``: m_member(...)...`` parses as a bogus method.
+        if line.lstrip().startswith(":"):
+            continue
+
+        # REGISTER_LOGGER("openstudio.model.ThermalZone"); expands to
+        # `static Logger logChannel();` — a real static accessor SWIG exposes, but the
+        # macro line carries no declaration shape the parser can read, so the method
+        # is registered literally. Logger is a bound class, so it renders as a name.
+        if line.lstrip().startswith("REGISTER_LOGGER("):
+            out[current].setdefault("logChannel", "Logger")
             continue
 
         # Access level is deliberately NOT filtered. This map only answers "what does X
@@ -329,29 +369,130 @@ def _locate_header_dir() -> Path | None:
 
 
 def _build(header_dir: Path) -> dict[str, dict[str, str]]:
-    """Parse every public model header under ``header_dir``.
+    """Parse every public header under ``header_dir``, recursing into submodules.
 
-    ``*_Impl.hpp`` are detail:: internals, not the public API — skipped.
+    Not limited to ``model/``: ``SqlFile`` (utilities/sql), ``RunControl`` and
+    ``AirflowPath`` (both declared in airflow/contam/PrjObjects.hpp), ``UserModel``
+    (isomodel) and friends live in nested subdirs under filenames that don't match
+    the class, and their methods need the same sourced return types as the model
+    classes. ``*_Impl.hpp`` are detail:: internals, not the public API — skipped
+    everywhere.
+
+    Ordering keeps two invariants. ``model/`` parses first, so first-declaration-wins
+    preserves model precedence for classes declared in more than one module. ``.hpp``
+    and ``.hxx`` files precede ``.i`` files, so a real declaration always wins over a
+    SWIG ``%extend`` of the same name.
+
+    Files are parsed module by module and each module's SWIG ``%rename`` directives
+    applied before the global merge: the exposed class name (``ZUnit``, ``Any``,
+    ``ContamForwardTranslator``, …) differs from the declared one (``Unit``,
+    ``boost::any``, ``contam::ForwardTranslator``, …), and the pre-rename names are
+    not unique across modules (six modules declare a ``ForwardTranslator``).
     """
-    model_dir = header_dir / "model" if (header_dir / "model").is_dir() else header_dir
-    # .hpp first so a real declaration always wins over a SWIG %extend of the same name.
-    paths = [p for p in sorted(model_dir.glob("*.hpp")) if not p.name.endswith("_Impl.hpp")]
-    paths += sorted(model_dir.glob("*.i"))
+    model_dir = header_dir / "model"
+
+    def _ordered(paths: Iterable[Path]) -> list[Path]:
+        # model/ first, each group alphabetical (first-declaration-wins below). When
+        # the include root has no model/ subdir (e.g. an env override pointing at a
+        # module dir directly), everything sorts alphabetically.
+        return sorted(paths, key=lambda p: (not p.is_relative_to(model_dir), p))
+
+    # .hpp/.hxx first so a real declaration always wins over a SWIG %extend of the
+    # same name. .hxx carries real declarations too (IddFactory.hxx).
+    headers = [
+        p for p in _ordered(header_dir.rglob("*.hpp")) if not p.name.endswith("_Impl.hpp")
+    ]
+    headers += [
+        p for p in _ordered(header_dir.rglob("*.hxx")) if not p.name.endswith("_Impl.hxx")
+    ]
+    i_files = _ordered(header_dir.rglob("*.i"))
+
+    # Group by top-level module dir so each module's %rename directives can be
+    # applied to that module's classes before the global merge.
+    by_module: dict[str, list[Path]] = {}
+    for path in headers + i_files:
+        parts = path.relative_to(header_dir).parts
+        by_module.setdefault(parts[0] if len(parts) > 1 else "", []).append(path)
 
     result: dict[str, dict[str, str]] = {}
-    for path in paths:
-        for cls, methods in _parse_header(path).items():
+    for module in sorted(by_module, key=lambda m: (m != "model", m)):
+        for cls, methods in _parse_module(by_module[module]).items():
             target = result.setdefault(cls, {})
             for name, cpp_type in methods.items():
                 target.setdefault(name, cpp_type)  # first declaration wins
     return result
 
 
+def _parse_renames(path: Path) -> list[tuple[str, str]]:
+    """Collect SWIG ``%rename(NewName) target;`` directives from an .i file."""
+    renames = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _RENAME_RE.match(line)
+        if match:
+            renames.append((match.group(1), match.group(2)))
+    return renames
+
+
+def _parse_module(paths: list[Path]) -> dict[str, dict[str, str]]:
+    """Parse one module's headers + .i files, applying its SWIG %rename directives.
+
+    Renames are applied in two passes — method renames first, so a class-rename
+    alias created later copies the renamed methods too.
+    """
+    renames: list[tuple[str, str]] = []
+    out: dict[str, dict[str, str]] = {}
+    for path in paths:
+        if path.suffix == ".i":
+            renames.extend(_parse_renames(path))
+        for cls, methods in _parse_header(path).items():
+            target = out.setdefault(cls, {})
+            for name, cpp_type in methods.items():
+                target.setdefault(name, cpp_type)  # first declaration wins
+    for new_name, target in renames:
+        _apply_rename(out, new_name, target, method_only=True)
+    for new_name, target in renames:
+        _apply_rename(out, new_name, target, method_only=False)
+    return out
+
+
+def _apply_rename(
+    out: dict[str, dict[str, str]],
+    new_name: str,
+    target: str,
+    *,
+    method_only: bool,
+) -> None:
+    """Apply one %rename to a module's parsed classes, in place.
+
+    A target whose second-to-last segment is a parsed class carrying that method is a
+    method rename (``openstudio::Unit::print`` -> ``toString``); otherwise the last
+    segment is a class name (``openstudio::contam::ForwardTranslator`` ->
+    ``ContamForwardTranslator``). Aliases are additive — the pre-rename name is kept.
+    """
+    segments = target.split("::")
+    is_method = (
+        len(segments) >= 2
+        and segments[-2] in out
+        and segments[-1] in out[segments[-2]]
+    )
+    if is_method != method_only:
+        return
+    if is_method:
+        out[segments[-2]].setdefault(new_name, out[segments[-2]][segments[-1]])
+        return
+    old_name = segments[-1]
+    if old_name in out and old_name != new_name:
+        renamed = out.setdefault(new_name, {})
+        for name, cpp_type in out[old_name].items():
+            renamed.setdefault(name, cpp_type)
+
+
 def header_types() -> dict[str, dict[str, str]]:
     """Return ``{class_name: {method_name: cpp_return_type}}``, cached per process.
 
-    Empty dict when no headers are installed. Costs ~30 ms for the 613 public model
-    headers, once.
+    Empty dict when no headers are installed. Costs tens of ms for the ~880 public
+    headers (``model/`` plus the nested ``utilities``, ``airflow``, ``isomodel``, …
+    submodules), once.
     """
     global _cache
     if _cache is None:

--- a/mcp_server/skills/api_reference/_headers.py
+++ b/mcp_server/skills/api_reference/_headers.py
@@ -1,0 +1,360 @@
+"""Parse the OpenStudio C++ headers into method return types.
+
+Why headers and not the SWIG wrappers: the Python proxy files carry the class tree and
+parameter names, but **no return-type annotations at all** — 0 of 57,516 class-body
+methods in the 3.11.0 install declare one. Only ~2,876 methods (``Model``, ``IdfObject``,
+``IdfExtensibleGroup``, ``GltfForwardTranslator``) get a type, and those come from
+module-level ``Class.method = _fn`` assignments, not from the class bodies. Everything
+else — every domain class an author actually touches — had no source of truth.
+
+The SDK's own C++ headers ship inside the image and state it exactly:
+
+    boost::optional<double> nominalCapacity() const;   ->  "Float, nil"
+    double efficiency() const;                          ->  "Float"
+
+Those two render identically under any name-based heuristic, yet ``.get`` is mandatory on
+one and raises ``NoMethodError`` on the other. Only the declaration distinguishes them.
+
+Headers and wrappers are complementary, not redundant: the ``Model#get*`` /
+``IdfObject#to_*`` families are SWIG-synthesized and appear in no header, while domain
+classes appear in headers but carry no annotation. ``_signatures`` consults both.
+
+We read the headers as text (never compile them) and cache the parse per process.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+# Default install location inside the MCP image. The Python wheel ships no headers, so
+# this is deliberately independent of `openstudio.__file__` (which resolves to the wheel).
+_INSTALL_GLOB = "/usr/local/openstudio-*/include/openstudio"
+_ENV_VAR = "OSMCP_OPENSTUDIO_INCLUDE"
+
+# `class MODEL_API ThermalZone : public HVACComponent {` — an export macro is the norm, but
+# any number of macros may precede the name and they may take arguments:
+#   class OS_DEPRECATED(3, 5, 0) MODEL_API TableMultiVariableLookup : public Curve
+# Allowing only one *bare* macro silently dropped every method in such a file. The
+# ALL-CAPS macro run is greedy, but backtracking still yields the right name for an
+# all-caps class (`class MODEL_API AVM : public X`), since the trailing `(\w+)` must match.
+# A trailing `;` (forward declaration, `class ThermalZone_Impl;`) matches none of `:{$`
+# and is correctly ignored.
+_CLASS_RE = re.compile(r"^\s*class\s+(?:[A-Z][A-Z0-9_]*(?:\([^)]*\))?\s+)*(\w+)\s*(?::|\{|$)")
+_ACCESS_RE = re.compile(r"^\s*(public|protected|private)\s*:")
+
+# `%extend openstudio::model::ModelObject{` — SWIG interface files declare the methods it
+# synthesizes onto a class, which exist in no .hpp. ModelCore.i is where `toIdfObject`
+# actually lives:  `IdfObject toIdfObject() const { return *self; }`. The bodies are plain
+# C++, so the same declaration parser reads them. SWIG's own directives (`%template`,
+# `%ignore`) sit at column 0 and cannot match _DECL_RE, which requires leading whitespace.
+_EXTEND_RE = re.compile(r"^\s*%extend\s+(?:[\w:]+::)?(\w+)\s*\{")
+
+# A member function declaration: <return type> <name>(<args>) [const] [override];
+# The return type is captured loosely and refined by _split_return_type — C++ types are
+# not a regular language, so we match broadly and validate after.
+# The name may start uppercase (`boost::optional<double> CVRMSE() const;`). Constructors
+# are still excluded: they have no return type, so the prefix group — which requires
+# trailing whitespace — cannot match `ThermalZone(const Model&)`, and `explicit
+# ThermalZone(...)` is caught by the name == class check.
+_DECL_RE = re.compile(r"^\s+(.*?\s[\*&]?)\s*([A-Za-z]\w*)\s*\(")
+
+# clang-format wraps a long declaration by putting the return type on its own line:
+#     bool
+#       setMinimumRegenerationInletAirRelativeHumidityforTemperatureEquation(double ...);
+# Such a line is held and joined to the next rather than parsed and discarded.
+_TYPE_ONLY_RE = re.compile(r"^\s*(?:(?:const|static|virtual|inline)\s+)*[\w:]+(?:<[^;{}]*>)?\s*[\*&]?\s*$")
+
+# A line may *be* a macro call (REGISTER_LOGGER("..."); — 621x) or merely *start* with one
+# (`OS_DEPRECATED(3, 7, 0) double maximumCyclingRate() const;` — 294x). Skipping both threw
+# away real declarations, so the prefix is stripped and the remainder re-tested instead.
+_MACRO_PREFIX_RE = re.compile(r"^\s*([A-Z][A-Z0-9_]{3,})\s*\(")
+
+_QUALIFIERS = ("static", "virtual", "explicit", "inline", "constexpr", "friend", "typedef", "using")
+
+# `OPENSTUDIO_ENUM(DefaultScheduleType, ((HoursofOperationSchedule)(...)(1)) ...)` declares
+# a class via macro expansion — there is no `class` line and no member declarations to read,
+# so the members below are the one thing here not parsed from a declaration. The macro emits
+# the same set for every enum, and each row was confirmed against live Ruby rather than
+# inferred. Note the macro may sit in a header named after a different class
+# (DefaultScheduleType is declared inside DefaultScheduleSet.hpp).
+_ENUM_MACRO_RE = re.compile(r"^\s*OPENSTUDIO_ENUM\s*\(\s*(\w+)")
+_ENUM_MEMBERS = {
+    "enumName": "std::string",  # class method
+    "valueName": "std::string",
+    "valueDescription": "std::string",
+    "value": "int",
+    "getValues": "std::vector<int>",  # class method
+    # Ruby returns OpenStudio::StringIntMap — a SWIG container the bindings filter out of
+    # the class list, so it renders Object like every other container wrapper.
+    "getLookupMap": "std::map<std::string, int>",
+}
+
+_PRIMITIVES = {
+    "void": "void",
+    "bool": "Boolean",
+    "double": "Float",
+    "float": "Float",
+    "int": "Integer",
+    "unsigned": "Integer",
+    "unsigned int": "Integer",
+    "size_t": "Integer",
+    "std::size_t": "Integer",
+    "unsigned long": "Integer",
+    "long": "Integer",
+    "std::string": "String",
+    "string": "String",
+}
+
+_cache: dict[str, dict[str, str]] | None = None
+
+
+def _strip_comments(line: str, *, in_block: bool) -> tuple[str | None, bool]:
+    """Remove comments. Returns (code or None, still-inside-a-block-comment).
+
+    Block state must be tracked, not inferred per line. A doxygen continuation is not
+    required to start with ``*``, and one that doesn't will otherwise read as code —
+    ExteriorLoadInstance.hpp:51 is literally::
+
+        /** Returns the number of instances this space load instance represents.
+      This just forwards to multiplier() here but is included for consistency ...**/
+        int quantity() const;
+
+    The middle line carries a ``(``, so a line-at-a-time stripper feeds it into the
+    continuation buffer and the real declaration behind it is lost. Line-prefix checks
+    alone also miss CoilCoolingWater.hpp:29's ``*  <li> bool addToNode(Node & node);</li>``.
+    """
+    if in_block:
+        if "*/" not in line:
+            return None, True
+        line = line.split("*/", 1)[1]
+
+    # Consume any /* ... */ spans; an unterminated one opens a block.
+    while "/*" in line:
+        before, after = line.split("/*", 1)
+        if "*/" in after:
+            line = before + after.split("*/", 1)[1]
+        else:
+            return (before if before.strip() else None), True
+
+    line = line.split("//", 1)[0] if "//" in line else line
+    stripped = line.strip()
+    if not stripped or stripped.startswith(("*", "#")):
+        return None, False
+    return line, False
+
+
+def _strip_macro_prefix(line: str) -> str | None:
+    """Strip leading macro invocations, returning the code behind them.
+
+    Distinguishes a line that *is* a macro call from one that merely *starts* with one:
+
+        REGISTER_LOGGER("openstudio.model.ThermalZone");        -> None   (skip)
+        OS_DEPRECATED(3, 7, 0) double maximumCyclingRate() const;
+                                    -> "double maximumCyclingRate() const;"
+
+    Returns None when nothing but the macro call remains. Scans for the matching close
+    paren rather than regexing, so nested parens in the arguments cannot truncate it.
+
+    The OS_DEPRECATED version is deliberately dropped: these methods still exist in the
+    bindings and need types like any other, and nothing renders the deprecation today.
+    """
+    remainder = line
+    while True:
+        match = _MACRO_PREFIX_RE.match(remainder)
+        if not match:
+            return remainder if remainder.strip() else None
+        depth = 0
+        for index in range(match.end() - 1, len(remainder)):
+            if remainder[index] == "(":
+                depth += 1
+            elif remainder[index] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+        else:
+            return None  # unterminated — a multi-line macro, not a declaration
+        rest = remainder[index + 1 :]
+        if not rest.strip() or rest.strip() == ";":
+            return None  # the line was only a macro call
+        remainder = rest
+
+
+def _balanced(text: str) -> bool:
+    """True when angle brackets balance — nested templates are real.
+
+    e.g. ``boost::optional<std::pair<ConstructionBase, int>>``.
+    """
+    return text.count("<") == text.count(">")
+
+
+def _split_return_type(prefix: str) -> str | None:
+    """Reduce a declaration prefix to its return type, or None if it isn't one."""
+    text = prefix.strip()
+    for qualifier in _QUALIFIERS:
+        # Repeatedly strip leading qualifiers: `static`, `virtual`, `static virtual`, ...
+        while text.startswith(f"{qualifier} "):
+            text = text[len(qualifier) + 1 :].strip()
+    if not text or text in _QUALIFIERS:
+        return None
+    text = text.removeprefix("const ").strip().rstrip("*&").strip()
+    if not text or not _balanced(text):
+        return None
+    # A bare identifier followed by nothing is a constructor-ish artifact, not a type.
+    return text or None
+
+
+def map_cpp_type(cpp: str, class_names: set[str] | None = None) -> str:
+    """Render a C++ return type the way _signatures renders Python annotations.
+
+    Conventions are deliberately identical to ``_signatures._resolve_return_type``:
+    optionals as ``"X, nil"``, vectors as ``"Array<X>"``. Only the source of truth
+    changes, never the output shape.
+    """
+    text = cpp.strip().removeprefix("const ").strip().rstrip("*&").strip()
+
+    optional = re.fullmatch(r"(?:boost|std)::optional\s*<\s*(.+?)\s*>", text)
+    if optional:
+        inner = map_cpp_type(optional.group(1), class_names)
+        # Optional<Optional<T>> is not a thing; a nested "X, nil" would render nonsense.
+        inner = inner.split(",")[0].strip()
+        return f"{inner}, nil"
+
+    vector = re.fullmatch(r"std::vector\s*<\s*(.+?)\s*>", text)
+    if vector:
+        inner = map_cpp_type(vector.group(1), class_names)
+        return f"Array<{inner}>" if inner not in ("Object", "void") else "Array"
+
+    if text in _PRIMITIVES:
+        return _PRIMITIVES[text]
+
+    # std::map/pair/tuple and friends: no useful Ruby rendering (7 occurrences repo-wide).
+    if "<" in text or "::" in text:
+        return "Object"
+
+    if class_names is not None and text not in class_names:
+        # Header-only classes absent from the bindings (Connection, ComponentWatcher,
+        # DesignSpecificationZoneAirDistribution) must not render a name Ruby lacks.
+        return "Object"
+    return text or "Object"
+
+
+def _parse_header(path: Path) -> dict[str, dict[str, str]]:
+    """Parse one .hpp into ``{class: {method: cpp_return_type}}`` (public members only)."""
+    out: dict[str, dict[str, str]] = {}
+    current: str | None = None
+    pending = ""
+    in_block = False
+
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line, in_block = _strip_comments(raw, in_block=in_block)
+        if line is None:
+            continue
+
+        # A macro-declared enum class: register its generated members and move on. It does
+        # not open a class body, so `current` is left alone.
+        enum_match = _ENUM_MACRO_RE.match(line)
+        if enum_match:
+            out.setdefault(enum_match.group(1), {}).update(_ENUM_MEMBERS)
+            continue
+
+        class_match = _CLASS_RE.match(line) or _EXTEND_RE.match(line)
+        if class_match:
+            current = class_match.group(1)
+            out.setdefault(current, {})
+            pending = ""
+            continue
+
+        if current is None:
+            continue
+
+        # Access level is deliberately NOT filtered. This map only answers "what does X
+        # return" for methods search_api already lists, and it lists them from `dir()` on
+        # the live bindings — which expose some protected members (Model#addVersionObject).
+        # Filtering to `public:` would drop their types without hiding the methods, so it
+        # cost coverage and bought nothing. Data members can't be confused for methods:
+        # they have no `(`, so _DECL_RE never matches them.
+        if _ACCESS_RE.match(line):
+            continue
+
+        # A line that only invokes a macro is skipped; one that merely starts with a macro
+        # keeps its declaration.
+        line = _strip_macro_prefix(line)
+        if line is None:
+            continue
+
+        # Join continuation lines. Two shapes, both real:
+        #   `std::vector<Surface> findSurfaces(boost::optional<double> a,`  -> args wrap
+        #   `bool` / `  setVeryLongName(double x);`                         -> type wraps
+        pending = f"{pending} {line.strip()}" if pending else line
+        if "(" in pending and ";" not in pending and not pending.rstrip().endswith(")"):
+            continue
+        if "(" not in pending and _TYPE_ONLY_RE.match(pending):
+            continue
+        candidate, pending = pending, ""
+
+        decl = _DECL_RE.match(candidate)
+        if not decl:
+            continue
+
+        prefix, name = decl.group(1), decl.group(2)
+        if name == current or name.startswith("~"):  # ctor / dtor
+            continue
+
+        # NB: do NOT also reject cpp_type == current. A method may legitimately return its
+        # own class — `Construction reverseConstruction() const;`,
+        # `static GeneratorPhotovoltaic simple(const Model&);`, `ModelObject clone() const;`
+        # — and the name == current check above already excludes constructors.
+        cpp_type = _split_return_type(prefix)
+        if cpp_type is None:
+            continue
+
+        out[current].setdefault(name, cpp_type)  # overloads: first declaration wins
+
+    return {cls: methods for cls, methods in out.items() if methods}
+
+
+def _locate_header_dir() -> Path | None:
+    """Resolve the OpenStudio include dir, or None when unavailable.
+
+    None is not an error: on a wheel-only box there are no headers, and callers simply
+    fall back to whatever other source they have.
+    """
+    override = os.environ.get(_ENV_VAR)
+    if override:
+        path = Path(override)
+        return path if path.is_dir() else None
+    matches = sorted(Path(p) for p in __import__("glob").glob(_INSTALL_GLOB))
+    return matches[-1] if matches else None
+
+
+def _build(header_dir: Path) -> dict[str, dict[str, str]]:
+    """Parse every public model header under ``header_dir``.
+
+    ``*_Impl.hpp`` are detail:: internals, not the public API — skipped.
+    """
+    model_dir = header_dir / "model" if (header_dir / "model").is_dir() else header_dir
+    # .hpp first so a real declaration always wins over a SWIG %extend of the same name.
+    paths = [p for p in sorted(model_dir.glob("*.hpp")) if not p.name.endswith("_Impl.hpp")]
+    paths += sorted(model_dir.glob("*.i"))
+
+    result: dict[str, dict[str, str]] = {}
+    for path in paths:
+        for cls, methods in _parse_header(path).items():
+            target = result.setdefault(cls, {})
+            for name, cpp_type in methods.items():
+                target.setdefault(name, cpp_type)  # first declaration wins
+    return result
+
+
+def header_types() -> dict[str, dict[str, str]]:
+    """Return ``{class_name: {method_name: cpp_return_type}}``, cached per process.
+
+    Empty dict when no headers are installed. Costs ~30 ms for the 613 public model
+    headers, once.
+    """
+    global _cache
+    if _cache is None:
+        header_dir = _locate_header_dir()
+        _cache = _build(header_dir) if header_dir else {}
+    return _cache

--- a/mcp_server/skills/api_reference/_headers.py
+++ b/mcp_server/skills/api_reference/_headers.py
@@ -114,6 +114,14 @@ _PRIMITIVES = {
 
 _cache: dict[str, dict[str, str]] | None = None
 _cache_by_module: dict[str, dict[str, dict[str, str]]] | None = None
+_cache_typedefs: dict[str, str] | None = None
+
+# `using OptionalTime = boost::optional<Time>;` / `typedef std::vector<Point3d> Point3dVector;`
+# Headers return these aliases directly (TimeSeries::intervalLength -> OptionalTime); without
+# resolving them the type is a name the bindings lack and renders as an opaque Object.
+_TYPEDEF_RE = re.compile(
+    r"^\s*(?:typedef\s+(?P<t_target>.+?)\s+(?P<t_name>\w+)|using\s+(?P<u_name>\w+)\s*=\s*(?P<u_target>.+?))\s*;",
+)
 
 # Joins the return types of overloads that disagree (``std::vector<TimeSeries>`` vs
 # ``boost::optional<TimeSeries>`` for SqlFile::timeSeries). SWIG collapses overloads to one
@@ -217,33 +225,59 @@ def _split_return_type(prefix: str) -> str | None:
     return text or None
 
 
-def map_cpp_type(cpp: str, class_names: set[str] | None = None) -> str:
+def map_cpp_type(
+    cpp: str,
+    class_names: set[str] | None = None,
+    typedefs: dict[str, str] | None = None,
+    _depth: int = 0,
+) -> str:
     """Render a C++ return type the way _signatures renders Python annotations.
 
     Conventions are deliberately identical to ``_signatures._resolve_return_type``:
     optionals as ``"X, nil"``, vectors as ``"Array<X>"``. Only the source of truth
-    changes, never the output shape.
+    changes, never the output shape. ``typedefs`` (``header_typedefs``) expands
+    ``OptionalTime`` / ``Point3dVector`` style aliases before rendering.
     """
     if OVERLOAD_SEP in cpp:
         rendered: list[str] = []
         for part in cpp.split(OVERLOAD_SEP):
-            mapped = map_cpp_type(part, class_names)
+            mapped = map_cpp_type(part, class_names, typedefs)
             if mapped not in rendered:
                 rendered.append(mapped)
         return OVERLOAD_SEP.join(rendered)
 
     text = cpp.strip().removeprefix("const ").strip().rstrip("*&").strip()
 
+    # Primitives before aliases: a header declares ``using string = std::wstring;`` which
+    # would otherwise hijack every ``std::string`` return into Object.
+    if text in _PRIMITIVES:
+        return _PRIMITIVES[text]
+
+    # Alias chains are short (Point3dVectorVector -> std::vector<Point3dVector> ->
+    # std::vector<Point3d>); the depth cap only guards a pathological self-reference.
+    if typedefs and text in typedefs and _depth < 8:
+        return map_cpp_type(typedefs[text], class_names, typedefs, _depth + 1)
+
+    # Namespace-qualified alias or class (``openstudio::OptionalTime``,
+    # ``openstudio::model::Space``): resolve by the bare name. Templates keep their
+    # ``::`` and fall through to the std::map/pair "Object" rule below.
+    if "::" in text and "<" not in text:
+        bare = text.rsplit("::", 1)[-1]
+        if typedefs and bare in typedefs and _depth < 8:
+            return map_cpp_type(typedefs[bare], class_names, typedefs, _depth + 1)
+        if class_names is not None and bare in class_names:
+            return bare
+
     optional = re.fullmatch(r"(?:boost|std)::optional\s*<\s*(.+?)\s*>", text)
     if optional:
-        inner = map_cpp_type(optional.group(1), class_names)
+        inner = map_cpp_type(optional.group(1), class_names, typedefs)
         # Optional<Optional<T>> is not a thing; a nested "X, nil" would render nonsense.
         inner = inner.split(",")[0].strip()
         return f"{inner}, nil"
 
     vector = re.fullmatch(r"std::vector\s*<\s*(.+?)\s*>", text)
     if vector:
-        inner = map_cpp_type(vector.group(1), class_names)
+        inner = map_cpp_type(vector.group(1), class_names, typedefs)
         return f"Array<{inner}>" if inner not in ("Object", "void") else "Array"
 
     if text in _PRIMITIVES:
@@ -369,6 +403,27 @@ def _parse_header(path: Path) -> dict[str, dict[str, str]]:
     return {cls: methods for cls, methods in out.items() if methods}
 
 
+def _parse_typedefs(path: Path) -> dict[str, str]:
+    """Collect ``typedef T Alias;`` / ``using Alias = T;`` from one header, comments stripped.
+
+    Template aliases (``template <class T> using X = ...``) start with ``template`` and
+    do not match; multi-line declarations are rare in the SDK and are skipped.
+    """
+    out: dict[str, str] = {}
+    in_block = False
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line, in_block = _strip_comments(raw, in_block=in_block)
+        if line is None:
+            continue
+        match = _TYPEDEF_RE.match(line)
+        if not match:
+            continue
+        name = match.group("t_name") or match.group("u_name")
+        target = match.group("t_target") or match.group("u_target")
+        out.setdefault(name, target.strip())
+    return out
+
+
 def _add_overload(methods: dict[str, str], name: str, cpp_type: str) -> None:
     """Record one declaration's return type; overloads that disagree are joined.
 
@@ -421,6 +476,29 @@ def header_module_for(wrapper_module: str, header_modules: Iterable[str]) -> str
     rest = wrapper_module.removeprefix("openstudio")
     candidates = [m for m in header_modules if m and rest.startswith(m)]
     return max(candidates, key=len) if candidates else None
+
+
+def _build_typedefs(header_dir: Path) -> dict[str, str]:
+    """``{alias: cpp_type}`` across every public header; model/ first, first declaration wins."""
+    model_dir = header_dir / "model"
+    headers = sorted(
+        (p for ext in ("*.hpp", "*.hxx") for p in header_dir.rglob(ext) if "_Impl" not in p.name),
+        key=lambda p: (not p.is_relative_to(model_dir), p),
+    )
+    out: dict[str, str] = {}
+    for path in headers:
+        for name, target in _parse_typedefs(path).items():
+            out.setdefault(name, target)
+    return out
+
+
+def header_typedefs() -> dict[str, str]:
+    """Return ``{alias: cpp_type}`` for the installed headers, cached; empty without headers."""
+    global _cache_typedefs
+    if _cache_typedefs is None:
+        header_dir = _locate_header_dir()
+        _cache_typedefs = _build_typedefs(header_dir) if header_dir else {}
+    return _cache_typedefs
 
 
 def _build_merged(by_module: dict[str, dict[str, dict[str, str]]]) -> dict[str, dict[str, str]]:

--- a/mcp_server/skills/api_reference/_headers.py
+++ b/mcp_server/skills/api_reference/_headers.py
@@ -113,6 +113,13 @@ _PRIMITIVES = {
 }
 
 _cache: dict[str, dict[str, str]] | None = None
+_cache_by_module: dict[str, dict[str, dict[str, str]]] | None = None
+
+# Joins the return types of overloads that disagree (``std::vector<TimeSeries>`` vs
+# ``boost::optional<TimeSeries>`` for SqlFile::timeSeries). SWIG collapses overloads to one
+# ``(*args)`` entry, so the rendered signature must carry every possible return rather
+# than silently pick the first declaration.
+OVERLOAD_SEP = " | "
 
 
 def _strip_comments(line: str, *, in_block: bool) -> tuple[str | None, bool]:
@@ -217,6 +224,14 @@ def map_cpp_type(cpp: str, class_names: set[str] | None = None) -> str:
     optionals as ``"X, nil"``, vectors as ``"Array<X>"``. Only the source of truth
     changes, never the output shape.
     """
+    if OVERLOAD_SEP in cpp:
+        rendered: list[str] = []
+        for part in cpp.split(OVERLOAD_SEP):
+            mapped = map_cpp_type(part, class_names)
+            if mapped not in rendered:
+                rendered.append(mapped)
+        return OVERLOAD_SEP.join(rendered)
+
     text = cpp.strip().removeprefix("const ").strip().rstrip("*&").strip()
 
     optional = re.fullmatch(r"(?:boost|std)::optional\s*<\s*(.+?)\s*>", text)
@@ -349,9 +364,23 @@ def _parse_header(path: Path) -> dict[str, dict[str, str]]:
         if cpp_type is None:
             continue
 
-        out[current].setdefault(name, cpp_type)  # overloads: first declaration wins
+        _add_overload(out[current], name, cpp_type)
 
     return {cls: methods for cls, methods in out.items() if methods}
+
+
+def _add_overload(methods: dict[str, str], name: str, cpp_type: str) -> None:
+    """Record one declaration's return type; overloads that disagree are joined.
+
+    Same-type overloads (three ``bool setX(...)`` forms) stay a single entry. Different
+    types join with ``OVERLOAD_SEP`` in declaration order; ``map_cpp_type`` renders each
+    part and dedupes anything that maps to the same Ruby-style type.
+    """
+    existing = methods.get(name)
+    if existing is None:
+        methods[name] = cpp_type
+    elif cpp_type not in existing.split(OVERLOAD_SEP):
+        methods[name] = existing + OVERLOAD_SEP + cpp_type
 
 
 def _locate_header_dir() -> Path | None:
@@ -369,6 +398,42 @@ def _locate_header_dir() -> Path | None:
 
 
 def _build(header_dir: Path) -> dict[str, dict[str, str]]:
+    """Merge ``_build_by_module`` across modules: model/ first, then first-declaration-wins.
+
+    The merged view is the fallback for classes whose bindings module has no header of
+    its own (SWIG-synthesized classes, utilities bound from several wrapper files).
+    Classes declared in more than one module (``ForwardTranslator`` in energyplus,
+    gbxml, sdd, ...) must be resolved through ``header_types_by_module`` instead: the
+    merge cannot know which module the bindings actually expose.
+    """
+    return _build_merged(_build_by_module(header_dir))
+
+
+def header_module_for(wrapper_module: str, header_modules: Iterable[str]) -> str | None:
+    """Map a SWIG wrapper file stem to the header subdir that declares its classes.
+
+    Wrapper files are ``openstudio<module><part>.py`` (``openstudioenergyplus``,
+    ``openstudiomodelcore``, ``openstudioutilitiessql``) while headers live under the
+    bare module dir (``energyplus/``, ``model/``, ``utilities/``). Longest matching
+    module prefix wins; None when nothing matches (an env-override include dir, a
+    wrapper with no headers).
+    """
+    rest = wrapper_module.removeprefix("openstudio")
+    candidates = [m for m in header_modules if m and rest.startswith(m)]
+    return max(candidates, key=len) if candidates else None
+
+
+def _build_merged(by_module: dict[str, dict[str, dict[str, str]]]) -> dict[str, dict[str, str]]:
+    result: dict[str, dict[str, str]] = {}
+    for module in sorted(by_module, key=lambda m: (m != "model", m)):
+        for cls, methods in by_module[module].items():
+            target = result.setdefault(cls, {})
+            for name, cpp_type in methods.items():
+                target.setdefault(name, cpp_type)  # first declaration wins
+    return result
+
+
+def _build_by_module(header_dir: Path) -> dict[str, dict[str, dict[str, str]]]:
     """Parse every public header under ``header_dir``, recursing into submodules.
 
     Not limited to ``model/``: ``SqlFile`` (utilities/sql), ``RunControl`` and
@@ -414,13 +479,7 @@ def _build(header_dir: Path) -> dict[str, dict[str, str]]:
         parts = path.relative_to(header_dir).parts
         by_module.setdefault(parts[0] if len(parts) > 1 else "", []).append(path)
 
-    result: dict[str, dict[str, str]] = {}
-    for module in sorted(by_module, key=lambda m: (m != "model", m)):
-        for cls, methods in _parse_module(by_module[module]).items():
-            target = result.setdefault(cls, {})
-            for name, cpp_type in methods.items():
-                target.setdefault(name, cpp_type)  # first declaration wins
-    return result
+    return {module: _parse_module(paths) for module, paths in by_module.items()}
 
 
 def _parse_renames(path: Path) -> list[tuple[str, str]]:
@@ -496,6 +555,19 @@ def header_types() -> dict[str, dict[str, str]]:
     """
     global _cache
     if _cache is None:
-        header_dir = _locate_header_dir()
-        _cache = _build(header_dir) if header_dir else {}
+        _cache = _build_merged(header_types_by_module())
     return _cache
+
+
+def header_types_by_module() -> dict[str, dict[str, dict[str, str]]]:
+    """Return ``{header_module: {class_name: {method_name: cpp_return_type}}}``, cached.
+
+    Keyed by the top-level include subdir (``model``, ``utilities``, ``energyplus``, ...)
+    so a class name declared in several modules resolves against the module the
+    bindings expose (see ``header_module_for``). Empty when no headers are installed.
+    """
+    global _cache_by_module
+    if _cache_by_module is None:
+        header_dir = _locate_header_dir()
+        _cache_by_module = _build_by_module(header_dir) if header_dir else {}
+    return _cache_by_module

--- a/mcp_server/skills/api_reference/_signatures.py
+++ b/mcp_server/skills/api_reference/_signatures.py
@@ -1,0 +1,316 @@
+"""Parse OpenStudio SWIG Python wrappers into method signatures.
+
+The Ruby bindings are compiled C with no introspectable source, and dir()/getattr()
+on the live ``openstudio.model`` module recovers method *names* only — not parameter
+names or return types. But SWIG also emits Python proxy files (``openstudio*.py``) that
+carry the full class tree and parameter names. We read those as text (never execute
+them), then ``search_api`` decorates its output with them.
+
+**The wrappers carry almost no return types.** Zero of the 57,516 class-body methods
+declare a ``->`` annotation; only module-level ``Class.method = _fn`` assignments do,
+covering ~2,876 methods across exactly four classes (``Model``, ``IdfObject``,
+``IdfExtensibleGroup``, ``GltfForwardTranslator``). Those four matter and cannot come
+from anywhere else — they are SWIG-synthesized and declared in no header — so this
+module still parses them.
+
+Every other class takes its return type from the SDK's C++ headers via ``_headers``,
+which state it exactly. See that module for why. When neither source knows, the type is
+reported as ``"?"`` rather than guessed: a wrong type is worse than an admitted unknown,
+since ``.get`` on a plain Float raises while omitting it on an Optional silently yields
+the wrapper.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ._headers import header_types, map_cpp_type
+
+# SWIG internal classes to skip
+SKIP_CLASSES = {"SwigPyIterator", "_SwigNonDynamicMeta"}
+
+_CLASS_RE = re.compile(r"^class (\w+)\((\w+(?:\.\w+)?)\):")
+_METHOD_RE = re.compile(r"^\s{4}def (\w+)\(([^)]*)\)(?:\s*->\s*([\w.]+))?\s*:")
+_MODFUNC_RE = re.compile(r"^def (_\w+)\(([^)]*)\)\s*(?:->\s*([\w.]+))?\s*:")
+_ASSIGN_RE = re.compile(r"^(?:\w+\.)*(\w+)\.(\w+)\s*=\s*(_\w+)\s*$")
+_STATIC_RE = re.compile(r"^\s+@staticmethod")
+
+_SKIP_METHODS = {"__init__", "__repr__", "__str__", "__del__"}
+
+_PRIMITIVE_TYPES = {
+    "str": "String",
+    "String": "String",
+    "bool": "Boolean",
+    "int": "Integer",
+    "float": "Float",
+    "double": "Float",
+}
+
+# Module-level cache (built once per process). PLW0603 is allowed in mcp_server.
+_cache: dict[str, dict[str, dict]] | None = None
+
+
+@dataclass
+class ParsedMethod:
+    name: str
+    params: list[str]
+    return_type: str | None
+
+
+@dataclass
+class ParsedClass:
+    name: str
+    instance_methods: dict[str, ParsedMethod] = field(default_factory=dict)
+    static_methods: dict[str, ParsedMethod] = field(default_factory=dict)
+
+
+def _clean_params(raw: str) -> list[str]:
+    """Strip self/defaults/annotations, lowercase a leading capital.
+
+    SWIG renders overloaded methods (a setter with several C++ signatures) as
+    ``(self, *args)``, losing the real names. We keep that as ``...`` rather than an
+    empty list so the rendered signature signals "takes arguments, names unavailable"
+    instead of falsely reading as a no-arg call.
+    """
+    params = []
+    for raw_part in raw.split(","):
+        part = raw_part.strip()
+        if not part or part == "self":
+            continue
+        if part.startswith("*"):
+            if "..." not in params:
+                params.append("...")
+            continue
+        name = re.split(r"[=:]", part)[0].strip().replace("[", "").replace("]", "")
+        if name and name[0].isupper():
+            name = name[0].lower() + name[1:]
+        if name:
+            params.append(name)
+    return params
+
+
+def _last_segment(type_str: str | None) -> str | None:
+    return type_str.split(".")[-1] if type_str else None
+
+
+def _parse_module_level_types(path: Path) -> dict[str, dict[str, ParsedMethod]]:
+    """Capture ``def _fn(self, x) -> Ret:`` and cross-file ``Class.method = _fn``."""
+    func_info: dict[str, ParsedMethod] = {}
+    class_methods: dict[str, dict[str, ParsedMethod]] = {}
+
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        func_match = _MODFUNC_RE.match(line)
+        if func_match:
+            func_info[func_match.group(1)] = ParsedMethod(
+                name=func_match.group(1),
+                params=_clean_params(func_match.group(2)),
+                return_type=_last_segment(func_match.group(3)),
+            )
+            continue
+        assign_match = _ASSIGN_RE.match(line)
+        if assign_match:
+            target_class, method_name, func_name = assign_match.groups()
+            info = func_info.get(func_name)
+            if info is None:
+                continue
+            class_methods.setdefault(target_class, {})[method_name] = ParsedMethod(
+                name=method_name,
+                params=info.params,
+                return_type=info.return_type,
+            )
+    return class_methods
+
+
+def _parse_python_file(path: Path) -> list[ParsedClass]:
+    """Capture ``class X(Parent):`` and its 4-space-indented method definitions."""
+    classes: list[ParsedClass] = []
+    current: ParsedClass | None = None
+    in_static = False
+
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        class_match = _CLASS_RE.match(line)
+        if class_match:
+            name, parent = class_match.group(1), class_match.group(2)
+            # Skip SWIG internals / STL container wrapper types / Python-only lowercase
+            # classes. *Vector/Optional*/*Set/*Map with parent `object` are SWIG wrappers
+            # around std::vector/optional/set/map — collection plumbing, not domain API,
+            # and their Python dict/set helper methods (add/iteritems/has_key/...) have no
+            # Ruby equivalent. Real domain classes inherit a model parent, never `object`,
+            # so this never catches them. current=None so a skipped body can't leak onto
+            # the prior class.
+            if (
+                name in SKIP_CLASSES
+                or (name.endswith(("Vector", "Set", "Map")) and parent == "object")
+                or (name.startswith("Optional") and parent == "object")
+                or name[0].islower()
+            ):
+                current = None
+                in_static = False
+                continue
+            current = ParsedClass(name=name)
+            classes.append(current)
+            in_static = False
+            continue
+
+        if current is None:
+            continue
+
+        if _STATIC_RE.match(line):
+            in_static = True
+            continue
+
+        method_match = _METHOD_RE.match(line)
+        if not method_match:
+            continue
+
+        method_name = method_match.group(1)
+        if method_name.startswith("_") or method_name in _SKIP_METHODS:
+            in_static = False
+            continue
+
+        method = ParsedMethod(
+            name=method_name,
+            params=_clean_params(method_match.group(2)),
+            return_type=_last_segment(method_match.group(3)),
+        )
+        if in_static:
+            current.static_methods[method_name] = method
+        else:
+            current.instance_methods[method_name] = method
+        in_static = False
+
+    return classes
+
+
+def _resolve_return_type(type_str: str | None, all_class_names: set[str]) -> str:
+    """Render a Python annotation as a Ruby-style return type string."""
+    if not type_str:
+        return "void"
+    type_name = type_str.split(".")[-1]
+
+    optional = re.fullmatch(r"Optional(\w+)", type_name)
+    if optional:
+        inner = optional.group(1)
+        return f"{inner}, nil" if inner in all_class_names else "Object, nil"
+
+    vector = re.fullmatch(r"(\w+)Vector", type_name)
+    if vector:
+        inner = vector.group(1)
+        return f"Array<{inner}>" if inner in all_class_names else "Array"
+
+    if type_name in _PRIMITIVE_TYPES:
+        return _PRIMITIVE_TYPES[type_name]
+
+    return type_name if type_name in all_class_names else "Object"
+
+
+UNKNOWN_TYPE = "?"
+"""Reported when neither a wrapper annotation nor a C++ header declares the return type.
+
+Deliberately not a guess. A name-based heuristic used to fill this gap and was wrong in
+ways no reader could detect: ``ThermalZone#isConditioned`` matched an ``is[A-Z] ->
+Boolean`` rule but actually returns ``boost::optional<std::string>``, so
+``next unless zone.isConditioned`` silently skipped every zone. ``?`` tells the caller to
+probe; ``Boolean`` told them to write a bug. ``operations._decorate`` already emits this
+same sentinel when ``inspect.signature`` fails.
+"""
+
+
+def _wrapper_files(wrapper_dir: Path) -> list[Path]:
+    return sorted(p for p in wrapper_dir.glob("openstudio*.py") if p.stem != "openstudio")
+
+
+def _build(wrapper_dir: Path) -> dict[str, dict[str, dict]]:
+    """Parse all wrapper files into ``{class: {method: {params, returns, static}}}``."""
+    files = _wrapper_files(wrapper_dir)
+
+    # Pass 1: cross-file module-level method assignments (carry return types).
+    module_types: dict[str, dict[str, ParsedMethod]] = {}
+    for path in files:
+        for class_name, methods in _parse_module_level_types(path).items():
+            module_types.setdefault(class_name, {}).update(methods)
+
+    # Pass 2: class definitions. Keep the first occurrence of a class name.
+    parsed: dict[str, ParsedClass] = {}
+    for path in files:
+        for cls in _parse_python_file(path):
+            parsed.setdefault(cls.name, cls)
+
+    all_class_names = set(parsed)
+
+    # Apply cross-file methods: fill missing return types, add unseen methods.
+    for class_name, methods in module_types.items():
+        cls = parsed.get(class_name)
+        if cls is None:
+            continue
+        for method_name, patched in methods.items():
+            existing = cls.instance_methods.get(method_name)
+            if existing is None:
+                cls.instance_methods[method_name] = patched
+            elif existing.return_type is None:
+                existing.return_type = patched.return_type
+
+    # C++ headers supply the return types the wrappers do not carry (i.e. nearly all of
+    # them). Empty when no SDK headers are installed — then unannotated methods report
+    # UNKNOWN_TYPE, which is honest.
+    cpp = header_types()
+
+    # Render to the public shape.
+    result: dict[str, dict[str, dict]] = {}
+    for class_name, cls in parsed.items():
+        cpp_for_class = cpp.get(class_name, {})
+        rendered: dict[str, dict] = {}
+        for method in cls.static_methods.values():
+            rendered[method.name] = _render(
+                method, all_class_names, static=True, cpp_type=cpp_for_class.get(method.name),
+            )
+        for method in cls.instance_methods.values():
+            rendered[method.name] = _render(
+                method, all_class_names, static=False, cpp_type=cpp_for_class.get(method.name),
+            )
+        result[class_name] = rendered
+    return result
+
+
+def _render(
+    method: ParsedMethod,
+    all_class_names: set[str],
+    *,
+    static: bool,
+    cpp_type: str | None = None,
+) -> dict:
+    """Resolve a return type from the best available source of truth.
+
+    Precedence: wrapper annotation (the SWIG-synthesized Model/IdfObject families, which
+    exist in no header) -> C++ header declaration (every hand-written domain class) ->
+    ``UNKNOWN_TYPE``. The two sources overlap on 4 of 2,876 pairs, so the order is very
+    nearly moot; it is stated explicitly rather than left to chance.
+    """
+    if method.return_type:
+        returns = _resolve_return_type(method.return_type, all_class_names)
+    elif cpp_type:
+        returns = map_cpp_type(cpp_type, all_class_names)
+    else:
+        returns = UNKNOWN_TYPE
+    return {"params": method.params, "returns": returns, "static": static}
+
+
+def _locate_wrapper_dir() -> Path:
+    import openstudio
+
+    return Path(openstudio.__file__).parent
+
+
+def signatures() -> dict[str, dict[str, dict]]:
+    """Return ``{class_name: {method_name: {params, returns, static}}}``.
+
+    Locates the wrapper files via the installed ``openstudio`` package
+    (``openstudio.__file__`` — the SDK shipped inside the MCP image) and caches the
+    parse for the process. Called by ``search_api`` to decorate methods with their
+    parameter names and return types.
+    """
+    global _cache
+    if _cache is None:
+        _cache = _build(_locate_wrapper_dir())
+    return _cache

--- a/mcp_server/skills/api_reference/_signatures.py
+++ b/mcp_server/skills/api_reference/_signatures.py
@@ -40,11 +40,16 @@ _SKIP_METHODS = {"__init__", "__repr__", "__str__", "__del__"}
 
 _PRIMITIVE_TYPES = {
     "str": "String",
+    "Str": "String",
     "String": "String",
     "bool": "Boolean",
+    "Bool": "Boolean",
     "int": "Integer",
+    "Int": "Integer",
     "float": "Float",
+    "Float": "Float",
     "double": "Float",
+    "Double": "Float",
 }
 
 # Module-level cache (built once per process). PLW0603 is allowed in mcp_server.
@@ -183,6 +188,16 @@ def _parse_python_file(path: Path) -> list[ParsedClass]:
     return classes
 
 
+def _resolve_inner_type(type_name: str, all_class_names: set[str]) -> tuple[str, bool]:
+    """Resolve a wrapper's inner type and whether it has a useful rendered name."""
+    rendered = _PRIMITIVE_TYPES.get(type_name)
+    if rendered is not None:
+        return rendered, True
+    if type_name in all_class_names:
+        return type_name, True
+    return "Object", False
+
+
 def _resolve_return_type(type_str: str | None, all_class_names: set[str]) -> str:
     """Render a Python annotation as a Ruby-style return type string."""
     if not type_str:
@@ -191,13 +206,13 @@ def _resolve_return_type(type_str: str | None, all_class_names: set[str]) -> str
 
     optional = re.fullmatch(r"Optional(\w+)", type_name)
     if optional:
-        inner = optional.group(1)
-        return f"{inner}, nil" if inner in all_class_names else "Object, nil"
+        rendered, _ = _resolve_inner_type(optional.group(1), all_class_names)
+        return f"{rendered}, nil"
 
     vector = re.fullmatch(r"(\w+)Vector", type_name)
     if vector:
-        inner = vector.group(1)
-        return f"Array<{inner}>" if inner in all_class_names else "Array"
+        rendered, known = _resolve_inner_type(vector.group(1), all_class_names)
+        return f"Array<{rendered}>" if known else "Array"
 
     if type_name in _PRIMITIVE_TYPES:
         return _PRIMITIVE_TYPES[type_name]

--- a/mcp_server/skills/api_reference/_signatures.py
+++ b/mcp_server/skills/api_reference/_signatures.py
@@ -25,7 +25,13 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from ._headers import header_module_for, header_types, header_types_by_module, map_cpp_type
+from ._headers import (
+    header_module_for,
+    header_typedefs,
+    header_types,
+    header_types_by_module,
+    map_cpp_type,
+)
 
 # SWIG internal classes to skip
 SKIP_CLASSES = {"SwigPyIterator", "_SwigNonDynamicMeta"}
@@ -273,6 +279,7 @@ def _build(wrapper_dir: Path) -> dict[str, dict[str, dict]]:
     # UNKNOWN_TYPE, which is honest.
     cpp = header_types()
     cpp_by_module = header_types_by_module()
+    typedefs = header_typedefs()
 
     # Render to the public shape.
     result: dict[str, dict[str, dict]] = {}
@@ -287,11 +294,13 @@ def _build(wrapper_dir: Path) -> dict[str, dict[str, dict]]:
         rendered: dict[str, dict] = {}
         for method in cls.static_methods.values():
             rendered[method.name] = _render(
-                method, all_class_names, static=True, cpp_type=cpp_for_class.get(method.name),
+                method, all_class_names, static=True,
+                cpp_type=cpp_for_class.get(method.name), typedefs=typedefs,
             )
         for method in cls.instance_methods.values():
             rendered[method.name] = _render(
-                method, all_class_names, static=False, cpp_type=cpp_for_class.get(method.name),
+                method, all_class_names, static=False,
+                cpp_type=cpp_for_class.get(method.name), typedefs=typedefs,
             )
         result[class_name] = rendered
     return result
@@ -303,6 +312,7 @@ def _render(
     *,
     static: bool,
     cpp_type: str | None = None,
+    typedefs: dict[str, str] | None = None,
 ) -> dict:
     """Resolve a return type from the best available source of truth.
 
@@ -314,7 +324,7 @@ def _render(
     if method.return_type:
         returns = _resolve_return_type(method.return_type, all_class_names)
     elif cpp_type:
-        returns = map_cpp_type(cpp_type, all_class_names)
+        returns = map_cpp_type(cpp_type, all_class_names, typedefs)
     else:
         returns = UNKNOWN_TYPE
     return {"params": method.params, "returns": returns, "static": static}

--- a/mcp_server/skills/api_reference/_signatures.py
+++ b/mcp_server/skills/api_reference/_signatures.py
@@ -25,7 +25,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from ._headers import header_types, map_cpp_type
+from ._headers import header_module_for, header_types, header_types_by_module, map_cpp_type
 
 # SWIG internal classes to skip
 SKIP_CLASSES = {"SwigPyIterator", "_SwigNonDynamicMeta"}
@@ -66,6 +66,9 @@ class ParsedMethod:
 @dataclass
 class ParsedClass:
     name: str
+    # Wrapper file stem ("openstudioenergyplus"); selects the header module whose
+    # declarations decorate this class (see _headers.header_module_for).
+    module: str = ""
     instance_methods: dict[str, ParsedMethod] = field(default_factory=dict)
     static_methods: dict[str, ParsedMethod] = field(default_factory=dict)
 
@@ -153,7 +156,7 @@ def _parse_python_file(path: Path) -> list[ParsedClass]:
                 current = None
                 in_static = False
                 continue
-            current = ParsedClass(name=name)
+            current = ParsedClass(name=name, module=path.stem)
             classes.append(current)
             in_static = False
             continue
@@ -220,16 +223,15 @@ def _resolve_return_type(type_str: str | None, all_class_names: set[str]) -> str
     return type_name if type_name in all_class_names else "Object"
 
 
+# Reported when neither a wrapper annotation nor a C++ header declares the return type.
+#
+# Deliberately not a guess. A name-based heuristic used to fill this gap and was wrong in
+# ways no reader could detect: ``ThermalZone#isConditioned`` matched an ``is[A-Z] ->
+# Boolean`` rule but actually returns ``boost::optional<std::string>``, so
+# ``next unless zone.isConditioned`` silently skipped every zone. ``?`` tells the caller to
+# probe; ``Boolean`` told them to write a bug. ``operations._decorate`` already emits this
+# same sentinel when ``inspect.signature`` fails.
 UNKNOWN_TYPE = "?"
-"""Reported when neither a wrapper annotation nor a C++ header declares the return type.
-
-Deliberately not a guess. A name-based heuristic used to fill this gap and was wrong in
-ways no reader could detect: ``ThermalZone#isConditioned`` matched an ``is[A-Z] ->
-Boolean`` rule but actually returns ``boost::optional<std::string>``, so
-``next unless zone.isConditioned`` silently skipped every zone. ``?`` tells the caller to
-probe; ``Boolean`` told them to write a bug. ``operations._decorate`` already emits this
-same sentinel when ``inspect.signature`` fails.
-"""
 
 
 def _wrapper_files(wrapper_dir: Path) -> list[Path]:
@@ -270,11 +272,18 @@ def _build(wrapper_dir: Path) -> dict[str, dict[str, dict]]:
     # them). Empty when no SDK headers are installed — then unannotated methods report
     # UNKNOWN_TYPE, which is honest.
     cpp = header_types()
+    cpp_by_module = header_types_by_module()
 
     # Render to the public shape.
     result: dict[str, dict[str, dict]] = {}
     for class_name, cls in parsed.items():
-        cpp_for_class = cpp.get(class_name, {})
+        # The bindings module's own header wins per method; the cross-module merge
+        # fills the rest. Six modules declare a ForwardTranslator and only energyplus
+        # binds it under that name; the merge alone rendered its translateModel with
+        # airflow's boost::optional<contam::IndexModel>.
+        header_module = header_module_for(cls.module, cpp_by_module)
+        own = cpp_by_module.get(header_module, {}).get(class_name, {}) if header_module else {}
+        cpp_for_class = {**cpp.get(class_name, {}), **own}
         rendered: dict[str, dict] = {}
         for method in cls.static_methods.values():
             rendered[method.name] = _render(

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -116,9 +116,17 @@ def _own_methods(
 
     ModelObject's method set is subtracted only for model-module classes: a non-model
     class (SqlFile, WorkflowStepResult) does not inherit ModelObject, and subtracting
-    it would wrongly drop same-named methods like ``name``.
+    it would wrongly drop same-named methods like ``name``. ``dir`` also exposes SWIG
+    properties, constants, and the internal ownership flag ``thisown``; only callable
+    public attributes are methods, and ``thisown`` is never part of the public API.
     """
-    all_methods = {m for m in dir(cls) if not m.startswith("_")}
+    all_methods = {
+        name
+        for name in dir(cls)
+        if not name.startswith("_")
+        and name != "thisown"
+        and callable(getattr(cls, name, None))
+    }
     if include_base or not is_model_class:
         return all_methods
     return all_methods - model_base_methods
@@ -129,8 +137,8 @@ def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[
 
     Uses the parsed wrapper signature for the class or the first matching class in its
     live MRO; falls back to ``inspect.signature`` for parameter names when a method
-    isn't in the parse (e.g. C-level), with ``-> ?`` for the unknown return; falls back
-    to the bare name if even that fails.
+    isn't in the parse (e.g. C-level), with ``-> ?`` for the unknown return. If even
+    that fails, renders an explicit unknown-parameter signature rather than a bare name.
     """
     class_sigs = sigs.get(class_name, {})
     out = []
@@ -151,7 +159,7 @@ def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[
             params = [p for p in inspect.signature(getattr(cls, name)).parameters if p != "self"]
             out.append(f"{name}({', '.join(params)}) -> ?")
         except (ValueError, TypeError):
-            out.append(name)
+            out.append(f"{name}(...) -> ?")
     return out
 
 
@@ -207,8 +215,8 @@ def search_api_op(
             continue
         modules.append((mod_label, mod))
 
-    # Parsed wrapper signatures (params + return types). Degrade to bare names if the
-    # parse is unavailable so search_api can never be broken by a SWIG/parser surprise.
+    # Parsed wrapper signatures (params + return types). Degrade to inspected or
+    # explicitly unknown signatures if the parse is unavailable, never bare names.
     try:
         sigs = signatures()
         sig_ok = True
@@ -285,10 +293,9 @@ def search_api_op(
             casts = {m for m in other_names if _CAST_RE.match(m)}
         other = sorted(other_names - casts)
 
-        if sig_ok:
-            setters = _decorate(class_name, cls, setters, sigs)
-            getters = _decorate(class_name, cls, getters, sigs)
-            other = _decorate(class_name, cls, other, sigs)
+        setters = _decorate(class_name, cls, setters, sigs)
+        getters = _decorate(class_name, cls, getters, sigs)
+        other = _decorate(class_name, cls, other, sigs)
 
         if casts:
             sample = ", ".join(sorted(casts)[:3])

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -1,12 +1,58 @@
 """Search OpenStudio SDK classes and methods by pattern.
 
-Introspects the live openstudio.model module to discover real class names
-and method signatures. Primary use case: validating that a method actually
-exists before the LLM tries to call it (catches hallucinated methods).
+Introspects the live openstudio.model module to discover real class names, then
+decorates each method with its full signature (parameter names + return type) parsed
+from the SWIG wrapper files. Primary use case: validating that a method actually exists
+AND showing the LLM how to call it before it tries (catches hallucinated methods and
+guessed argument lists).
 """
 from __future__ import annotations
 
+import inspect
 import re
+
+from ._signatures import signatures
+
+# SWIG downcast family inherited from ModelObject (to_Space, to_ThermalZone, ...).
+# Hundreds of these exist; enumerating them buries the real domain API. Requires the
+# underscore so real methods like toIdfObject/toString are NOT matched.
+_CAST_RE = re.compile(r"to_[A-Z]")
+
+
+def _is_wrapper_type(obj: type) -> bool:
+    """True for SWIG STL/optional wrapper types (collection plumbing, not domain API).
+
+    *Vector / Optional* are matched by name. *Set / *Map need a base-class check because
+    real domain classes share those suffixes (DefaultConstructionSet, IlluminanceMap):
+    SWIG container wrappers inherit `object` directly, domain classes inherit a model
+    parent — same `parent == "object"` test the wrapper parser uses.
+    """
+    name = obj.__name__
+    if name.startswith("Optional") or name.endswith(("Vector", "Optional")):
+        return True
+    return name.endswith(("Set", "Map")) and obj.__bases__ == (object,)
+
+
+def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[str]:
+    """Render each method name as ``method(params) -> ReturnType``.
+
+    Uses the parsed wrapper signatures first; falls back to ``inspect.signature`` for
+    parameter names when a method isn't in the parse (e.g. C-level), with ``-> ?`` for
+    the unknown return; falls back to the bare name if even that fails.
+    """
+    class_sigs = sigs.get(class_name, {})
+    out = []
+    for name in names:
+        info = class_sigs.get(name)
+        if info is not None:
+            out.append(f"{name}({', '.join(info['params'])}) -> {info['returns']}")
+            continue
+        try:
+            params = [p for p in inspect.signature(getattr(cls, name)).parameters if p != "self"]
+            out.append(f"{name}({', '.join(params)}) -> ?")
+        except (ValueError, TypeError):
+            out.append(name)
+    return out
 
 
 def search_api_op(
@@ -21,19 +67,22 @@ def search_api_op(
         class_pattern: Regex pattern to match class names (case-insensitive).
         method_pattern: Optional regex to filter methods (case-insensitive).
         max_classes: Max number of classes to return (default 10).
-        include_base: If True, include methods inherited from ModelObject.
+        include_base: If True, include methods inherited from ModelObject. The
+            inherited to_<Class>() downcast family is collapsed into one summary
+            line (unless method_pattern explicitly targets casts).
 
     Returns:
         {"ok": True, "classes": [{"class_name": ..., "setters": [...],
-         "getters": [...], "other": [...]}]}
+         "getters": [...], "other": [...]}]} where each setter/getter/other entry
+        is a signature string, e.g. "setSurfaceType(surfaceType) -> Boolean".
     """
     try:
-        import openstudio  # noqa: F811
+        import openstudio
         model_module = openstudio.model
     except ImportError:
         return {"ok": False, "error": "openstudio not available"}
 
-    # Find matching classes (skip Vector/Optional wrapper types)
+    # Find matching classes (skip SWIG container/optional wrapper types — see _is_wrapper_type)
     try:
         cls_re = re.compile(class_pattern, re.IGNORECASE)
     except re.error as e:
@@ -43,9 +92,7 @@ def search_api_op(
         name for name in dir(model_module)
         if not name.startswith("_")
         and isinstance(getattr(model_module, name, None), type)
-        and not name.endswith("Vector")
-        and not name.endswith("Optional")
-        and not name.startswith("Optional")
+        and not _is_wrapper_type(getattr(model_module, name))
     ]
 
     matched = [n for n in all_names if cls_re.search(n)]
@@ -71,6 +118,15 @@ def search_api_op(
         except re.error as e:
             return {"ok": False, "error": f"Invalid method_pattern regex: {e}"}
 
+    # Parsed wrapper signatures (params + return types). Degrade to bare names if the
+    # parse is unavailable so search_api can never be broken by a SWIG/parser surprise.
+    try:
+        sigs = signatures()
+        sig_ok = True
+    except Exception:
+        sigs = {}
+        sig_ok = False
+
     results = []
     for class_name in matched:
         cls = getattr(model_module, class_name)
@@ -94,7 +150,29 @@ def search_api_op(
                 getter_names.add(getter)
         getters = sorted(getter_names)
 
-        other = sorted(own_methods - set(setters) - getter_names)
+        other_names = own_methods - set(setters) - getter_names
+
+        # Collapse the to_<Class>() downcast family into one summary line so the
+        # response teaches the cast pattern without dumping ~400 inherited methods.
+        # Skip the collapse when method_pattern is set: an explicit cast search
+        # (e.g. method_pattern="to_Space") should list its matches literally.
+        casts: set[str] = set()
+        if method_re is None:
+            casts = {m for m in other_names if _CAST_RE.match(m)}
+        other = sorted(other_names - casts)
+
+        if sig_ok:
+            setters = _decorate(class_name, cls, setters, sigs)
+            getters = _decorate(class_name, cls, getters, sigs)
+            other = _decorate(class_name, cls, other, sigs)
+
+        if casts:
+            sample = ", ".join(sorted(casts)[:3])
+            other.append(
+                f"to_<TargetClass>() -> Optional  # {len(casts)} downcast methods "
+                f"(e.g. {sample}); call to_<TargetClass>() to test/cast an object "
+                f"to a concrete type",
+            )
 
         results.append({
             "class_name": class_name,

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -37,6 +37,8 @@ _MODULES = (
     ("openstudio.airflow", "airflow"),
     ("openstudio.isomodel", "isomodel"),
     ("openstudio.gltf", "gltf"),
+    ("openstudio.gbxml", "gbxml"),
+    ("openstudio.alfalfa", "alfalfa"),
     ("openstudio.radiance", "radiance"),
     ("openstudio.sdd", "sdd"),
     ("openstudio.energyplus", "energyplus"),
@@ -125,14 +127,23 @@ def _own_methods(
 def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[str]:
     """Render each method name as ``method(params) -> ReturnType``.
 
-    Uses the parsed wrapper signatures first; falls back to ``inspect.signature`` for
-    parameter names when a method isn't in the parse (e.g. C-level), with ``-> ?`` for
-    the unknown return; falls back to the bare name if even that fails.
+    Uses the parsed wrapper signature for the class or the first matching class in its
+    live MRO; falls back to ``inspect.signature`` for parameter names when a method
+    isn't in the parse (e.g. C-level), with ``-> ?`` for the unknown return; falls back
+    to the bare name if even that fails.
     """
     class_sigs = sigs.get(class_name, {})
     out = []
     for name in names:
+        # ``dir(cls)`` includes inherited methods, while ``sigs`` stores each method
+        # under the class whose wrapper declares it. Keep the explicit class-name lookup
+        # first for parsed aliases, then follow Python's normal MRO for inherited APIs.
         info = class_sigs.get(name)
+        if info is None:
+            for base in cls.__mro__:
+                info = sigs.get(base.__name__, {}).get(name)
+                if info is not None:
+                    break
         if info is not None:
             out.append(f"{name}({', '.join(info['params'])}) -> {info['returns']}")
             continue

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -1,9 +1,10 @@
 """Search OpenStudio SDK classes and methods by pattern.
 
-Introspects the live openstudio.model module to discover real class names, then
-decorates each method with its full signature (parameter names + return type) parsed
-from the SWIG wrapper files. Primary use case: validating that a method actually exists
-AND showing the LLM how to call it before it tries (catches hallucinated methods and
+Introspects the live SDK — the openstudio root namespace, openstudio.model, and the
+non-model submodules (see _MODULES) — to discover real class names, then decorates
+each method with its full signature (parameter names + return type) parsed from the
+SWIG wrapper files. Primary use case: validating that a method actually exists AND
+showing the LLM how to call it before it tries (catches hallucinated methods and
 guessed argument lists).
 """
 from __future__ import annotations
@@ -18,6 +19,31 @@ from ._signatures import signatures
 # underscore so real methods like toIdfObject/toString are NOT matched.
 _CAST_RE = re.compile(r"to_[A-Z]")
 
+_MODEL_MODULE = "openstudio.model"
+
+# Namespaces search_api surfaces, in precedence order: (module label reported to
+# callers, attribute name on the openstudio root). ``openstudio`` root and
+# ``openstudio.model`` are the domain API; the rest are the non-model modules behind
+# the plan's ~265 non-model headers (utilities classes — SqlFile, ThreeUserData, … —
+# live at the root, not in a utilities submodule). The submodules are exposed as
+# attributes of the root (SWIG sets ``model = openstudiomodel`` in __init__.py), not
+# as importable dotted paths, so they are resolved via getattr; a missing attribute
+# is skipped, so the allowlist can only shrink. Aliases
+# (``openstudio.openstudioairflow``) are deliberately not listed — _collect_classes
+# dedupes by identity.
+_MODULES = (
+    ("openstudio", None),
+    (_MODEL_MODULE, "model"),
+    ("openstudio.airflow", "airflow"),
+    ("openstudio.isomodel", "isomodel"),
+    ("openstudio.gltf", "gltf"),
+    ("openstudio.radiance", "radiance"),
+    ("openstudio.sdd", "sdd"),
+    ("openstudio.energyplus", "energyplus"),
+    ("openstudio.osversion", "osversion"),
+    ("openstudio.measure", "measure"),
+)
+
 
 def _is_wrapper_type(obj: type) -> bool:
     """True for SWIG STL/optional wrapper types (collection plumbing, not domain API).
@@ -25,12 +51,75 @@ def _is_wrapper_type(obj: type) -> bool:
     *Vector / Optional* are matched by name. *Set / *Map need a base-class check because
     real domain classes share those suffixes (DefaultConstructionSet, IlluminanceMap):
     SWIG container wrappers inherit `object` directly, domain classes inherit a model
-    parent — same `parent == "object"` test the wrapper parser uses.
+    parent — same `parent == "object"` test the wrapper parser uses. SwigPyIterator is
+    the SWIG iterator class, re-created per module — without the name skip it would be
+    listed once per surfaced namespace.
     """
     name = obj.__name__
     if name.startswith("Optional") or name.endswith(("Vector", "Optional")):
         return True
+    if name == "SwigPyIterator":
+        return True
     return name.endswith(("Set", "Map")) and obj.__bases__ == (object,)
+
+
+def _collect_classes(
+    modules: list[tuple[str, object]],
+    preferred_names: set[str] | None = None,
+) -> list[dict]:
+    """Collect ``{class_name, module, cls}`` for every real class in the modules.
+
+    Dedupes by object identity: aliased submodules (``openstudio.airflow`` vs
+    ``openstudio.openstudioairflow``) expose the same class objects under two names,
+    and identity keeps each listed once — under whichever module was enumerated first.
+    When the same object is also exposed under a second name (legacy aliases such as
+    ``DistrictHeating == DistrictHeatingWater``), a name in ``preferred_names`` (the
+    wrapper-parsed class names) wins, so the class resolves against the signature
+    parse instead of rendering untyped under its alias.
+
+    Skips underscore-private names, Python-only lowercase classes (mirrors
+    ``_signatures`` — they carry no wrapper types and are binding internals), and
+    SWIG container/optional plumbing.
+    """
+    seen: dict[int, dict] = {}
+    for mod_name, mod in modules:
+        for name in dir(mod):
+            if name.startswith("_") or name[0].islower():
+                continue
+            obj = getattr(mod, name, None)
+            if not isinstance(obj, type) or _is_wrapper_type(obj):
+                continue
+            key = id(obj)
+            existing = seen.get(key)
+            if existing is not None:
+                if (
+                    preferred_names
+                    and name in preferred_names
+                    and existing["class_name"] not in preferred_names
+                ):
+                    seen[key] = {"class_name": name, "module": mod_name, "cls": obj}
+                continue
+            seen[key] = {"class_name": name, "module": mod_name, "cls": obj}
+    return list(seen.values())
+
+
+def _own_methods(
+    cls: type,
+    *,
+    include_base: bool,
+    is_model_class: bool,
+    model_base_methods: set[str],
+) -> set[str]:
+    """The class's method names after include_base handling.
+
+    ModelObject's method set is subtracted only for model-module classes: a non-model
+    class (SqlFile, WorkflowStepResult) does not inherit ModelObject, and subtracting
+    it would wrongly drop same-named methods like ``name``.
+    """
+    all_methods = {m for m in dir(cls) if not m.startswith("_")}
+    if include_base or not is_model_class:
+        return all_methods
+    return all_methods - model_base_methods
 
 
 def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[str]:
@@ -61,20 +150,29 @@ def search_api_op(
     max_classes: int = 10,
     include_base: bool = False,
 ) -> dict:
-    """Search openstudio.model classes and their methods.
+    """Search OpenStudio SDK classes and their methods.
+
+    The class list comes from an explicit module allowlist (see _MODULES) rather than
+    ``dir(openstudio.model)`` alone: reporting measures reach SqlFile, the airflow
+    module has RunControl/IndexModel, isomodel has UserModel — none of which
+    ``dir(model)`` exposes. Aliased submodules are deduped by identity.
 
     Args:
         class_pattern: Regex pattern to match class names (case-insensitive).
         method_pattern: Optional regex to filter methods (case-insensitive).
         max_classes: Max number of classes to return (default 10).
-        include_base: If True, include methods inherited from ModelObject. The
-            inherited to_<Class>() downcast family is collapsed into one summary
-            line (unless method_pattern explicitly targets casts).
+        include_base: If True, include methods inherited from ModelObject. Only
+            model-module classes inherit it — non-model classes are unaffected. The
+            inherited to_<Class>() downcast family is collapsed into one summary line
+            (unless method_pattern explicitly targets casts).
 
     Returns:
-        {"ok": True, "classes": [{"class_name": ..., "setters": [...],
-         "getters": [...], "other": [...]}]} where each setter/getter/other entry
-        is a signature string, e.g. "setSurfaceType(surfaceType) -> Boolean".
+        {"ok": True, "classes": [{"class_name": ..., "module": ..., "setters": [...],
+         "getters": [...], "other": [...]}], "query": ...} where each
+        setter/getter/other entry is a signature string, e.g.
+        "setSurfaceType(surfaceType) -> Boolean", and module names the namespace
+        the class lives in ("openstudio", "openstudio.model", "openstudio.airflow",
+        ...).
     """
     try:
         import openstudio
@@ -88,25 +186,44 @@ def search_api_op(
     except re.error as e:
         return {"ok": False, "error": f"Invalid class_pattern regex: {e}"}
 
-    all_names = [
-        name for name in dir(model_module)
-        if not name.startswith("_")
-        and isinstance(getattr(model_module, name, None), type)
-        and not _is_wrapper_type(getattr(model_module, name))
-    ]
+    # Resolve the allowlist to module objects. The submodules are attributes of the
+    # openstudio root rather than importable dotted paths; a missing attribute
+    # (module absent from this install) is skipped — the allowlist can only shrink.
+    modules = []
+    for mod_label, attr in _MODULES:
+        mod = openstudio if attr is None else getattr(openstudio, attr, None)
+        if mod is None:
+            continue
+        modules.append((mod_label, mod))
 
-    matched = [n for n in all_names if cls_re.search(n)]
+    # Parsed wrapper signatures (params + return types). Degrade to bare names if the
+    # parse is unavailable so search_api can never be broken by a SWIG/parser surprise.
+    try:
+        sigs = signatures()
+        sig_ok = True
+    except Exception:
+        sigs = {}
+        sig_ok = False
+
+    matched = [
+        entry for entry in _collect_classes(
+            modules,
+            preferred_names=set(sigs) if sig_ok else None,
+        )
+        if cls_re.search(entry["class_name"])
+    ]
     matched = matched[:max_classes]
 
     if not matched:
         return {"ok": True, "classes": [], "query": class_pattern}
 
-    # Build base method set for exclusion
-    base_methods: set[str] = set()
+    # ModelObject's method set is subtracted only from classes that inherit it
+    # (model-module classes); non-model classes keep same-named methods.
+    model_base_methods: set[str] = set()
     if not include_base:
         base_cls = getattr(model_module, "ModelObject", None)
         if base_cls:
-            base_methods = {
+            model_base_methods = {
                 m for m in dir(base_cls) if not m.startswith("_")
             }
 
@@ -118,22 +235,18 @@ def search_api_op(
         except re.error as e:
             return {"ok": False, "error": f"Invalid method_pattern regex: {e}"}
 
-    # Parsed wrapper signatures (params + return types). Degrade to bare names if the
-    # parse is unavailable so search_api can never be broken by a SWIG/parser surprise.
-    try:
-        sigs = signatures()
-        sig_ok = True
-    except Exception:
-        sigs = {}
-        sig_ok = False
-
     results = []
-    for class_name in matched:
-        cls = getattr(model_module, class_name)
-        all_methods = {m for m in dir(cls) if not m.startswith("_")}
+    for entry in matched:
+        cls = entry["cls"]
+        class_name = entry["class_name"]
 
-        # Exclude base methods unless include_base
-        own_methods = all_methods if include_base else all_methods - base_methods
+        # Exclude base methods unless include_base (model-module classes only)
+        own_methods = _own_methods(
+            cls,
+            include_base=include_base,
+            is_model_class=entry["module"] == _MODEL_MODULE,
+            model_base_methods=model_base_methods,
+        )
 
         # Apply method filter
         if method_re:
@@ -176,6 +289,7 @@ def search_api_op(
 
         results.append({
             "class_name": class_name,
+            "module": entry["module"],
             "setters": setters,
             "getters": getters,
             "other": other,

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import inspect
 import re
+import sys
 
 from ._signatures import signatures
 
@@ -187,11 +188,13 @@ def search_api_op(
 
     Returns:
         {"ok": True, "classes": [{"class_name": ..., "module": ..., "setters": [...],
-         "getters": [...], "other": [...]}], "query": ...} where each
-        setter/getter/other entry is a signature string, e.g.
-        "setSurfaceType(surfaceType) -> Boolean", and module names the namespace
-        the class lives in ("openstudio", "openstudio.model", "openstudio.airflow",
-        ...).
+         "getters": [...], "other": [...]}], "query": ...,
+         "signatures_available": True} where each setter/getter/other entry is a
+        signature string, e.g. "setSurfaceType(surfaceType) -> Boolean", and module
+        names the namespace the class lives in ("openstudio", "openstudio.model",
+        "openstudio.airflow", ...). If signature loading fails, discovery still
+        succeeds with "signatures_available": False, a "warning", and explicit
+        fallback/unknown signature details.
     """
     try:
         import openstudio
@@ -220,9 +223,24 @@ def search_api_op(
     try:
         sigs = signatures()
         sig_ok = True
-    except Exception:
+        signature_warning = None
+    except Exception as exc:
         sigs = {}
         sig_ok = False
+        signature_warning = (
+            "SDK signatures are unavailable; method entries may use fallback "
+            "parameters and unknown return types."
+        )
+        print(
+            "search_api: failed to load SDK signatures "
+            f"while searching for {class_pattern!r}: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+
+    response_metadata = {"signatures_available": sig_ok}
+    if signature_warning is not None:
+        response_metadata["warning"] = signature_warning
 
     matched = [
         entry for entry in _collect_classes(
@@ -234,7 +252,12 @@ def search_api_op(
     matched = matched[:max_classes]
 
     if not matched:
-        return {"ok": True, "classes": [], "query": class_pattern}
+        return {
+            "ok": True,
+            "classes": [],
+            "query": class_pattern,
+            **response_metadata,
+        }
 
     # ModelObject's method set is subtracted only from classes that inherit it
     # (model-module classes); non-model classes keep same-named methods.
@@ -313,7 +336,12 @@ def search_api_op(
             "other": other,
         })
 
-    return {"ok": True, "classes": results, "query": class_pattern}
+    return {
+        "ok": True,
+        "classes": results,
+        "query": class_pattern,
+        **response_metadata,
+    }
 
 
 def search_wiring_patterns_op(

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -137,6 +137,8 @@ def _own_methods(
 def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[str]:
     """Render each method name as ``method(params) -> ReturnType``.
 
+    Static methods carry a ``[static] `` prefix.
+
     Uses the parsed wrapper signature for the class or the first matching class in its
     live MRO; falls back to ``inspect.signature`` for parameter names when a method
     isn't in the parse (e.g. C-level), with ``-> ?`` for the unknown return. If even
@@ -155,7 +157,11 @@ def _decorate(class_name: str, cls: type, names: list[str], sigs: dict) -> list[
                 if info is not None:
                     break
         if info is not None:
-            out.append(f"{name}({', '.join(info['params'])}) -> {info['returns']}")
+            # ``[static]`` marks class-level calls (``Model.load(path)``) so an agent does
+            # not invoke them on an instance. Language-neutral on purpose: Ruby renders
+            # these as ``self.load``, Python as ``@staticmethod``.
+            prefix = "[static] " if info.get("static") else ""
+            out.append(f"{prefix}{name}({', '.join(info['params'])}) -> {info['returns']}")
             continue
         try:
             params = [p for p in inspect.signature(getattr(cls, name)).parameters if p != "self"]
@@ -191,7 +197,9 @@ def search_api_op(
         {"ok": True, "classes": [{"class_name": ..., "module": ..., "setters": [...],
          "getters": [...], "other": [...]}], "query": ...,
          "signatures_available": True} where each setter/getter/other entry is a
-        signature string, e.g. "setSurfaceType(surfaceType) -> Boolean", and module
+        signature string, e.g. "setSurfaceType(surfaceType) -> Boolean" (class-level
+        methods are prefixed "[static] "; overloads with different return types
+        render "-> A | B"), and module
         names the namespace the class lives in ("openstudio", "openstudio.model",
         "openstudio.airflow", ...). If signature loading fails, discovery still
         succeeds with "signatures_available": False, a "warning", and explicit

--- a/mcp_server/skills/api_reference/tools.py
+++ b/mcp_server/skills/api_reference/tools.py
@@ -15,16 +15,19 @@ def register(mcp):
         """Look up OpenStudio SDK classes with full method signatures.
 
         IMPORTANT: call before writing measures that use SDK method calls.
-        Introspects the live openstudio.model module to verify which methods
-        actually exist on a class, AND returns each method's full signature —
-        parameter names and return type — so you can write the call correctly.
-        Prevents both hallucinated method names (e.g.
+        Introspects the live SDK (the openstudio root namespace, openstudio.model,
+        and the non-model submodules — airflow, isomodel, gltf, measure, …) to
+        verify which methods actually exist on a class, AND returns each method's
+        full signature — parameter names and return type — so you can write the
+        call correctly. Prevents both hallucinated method names (e.g.
         setRatedCoolingCoefficientOfPerformance) and guessed argument lists.
 
         Use cases:
           - "What setters does CoilCoolingFourPipeBeam have, and what args?"
           - "Does BoilerHotWater have a setEfficiency method? What does it take?"
           - "List all classes matching 'ChillerElectric'"
+          - "How do I read sql output?" — SqlFile is reachable: it lives at the
+            openstudio root, not in openstudio.model
 
         Examples:
           search_api("CoilCoolingFourPipeBeam")
@@ -37,9 +40,13 @@ def register(mcp):
             method_pattern: Optional regex to filter methods (e.g. "Rated|COP").
             max_classes: Max classes to return (default 10).
             include_base: Include inherited ModelObject methods (default False).
+                Only model-module classes inherit ModelObject — non-model classes
+                (SqlFile, WorkflowStepResult) are unaffected.
 
         Returns setters, getters, and other methods grouped per class. Each entry
-        is a signature string, e.g. "setSurfaceType(surfaceType) -> Boolean".
+        is a signature string, e.g. "setSurfaceType(surfaceType) -> Boolean", and
+        each class entry carries a "module" field naming the namespace it lives in
+        ("openstudio", "openstudio.model", "openstudio.airflow", ...).
 
         Return types are read from the SDK's C++ headers and its SWIG wrappers —
         they are sourced, never inferred from the method's name. Read them

--- a/mcp_server/skills/api_reference/tools.py
+++ b/mcp_server/skills/api_reference/tools.py
@@ -12,16 +12,18 @@ def register(mcp):
         max_classes: int = 10,
         include_base: bool = False,
     ) -> dict:
-        """Look up OpenStudio SDK classes, setter methods, and getter methods.
+        """Look up OpenStudio SDK classes with full method signatures.
 
         IMPORTANT: call before writing measures that use SDK method calls.
         Introspects the live openstudio.model module to verify which methods
-        actually exist on a class. Prevents calling nonexistent methods like
-        setRatedCoolingCoefficientOfPerformance.
+        actually exist on a class, AND returns each method's full signature —
+        parameter names and return type — so you can write the call correctly.
+        Prevents both hallucinated method names (e.g.
+        setRatedCoolingCoefficientOfPerformance) and guessed argument lists.
 
         Use cases:
-          - "What setters does CoilCoolingFourPipeBeam have?"
-          - "Does BoilerHotWater have a setEfficiency method?"
+          - "What setters does CoilCoolingFourPipeBeam have, and what args?"
+          - "Does BoilerHotWater have a setEfficiency method? What does it take?"
           - "List all classes matching 'ChillerElectric'"
 
         Examples:
@@ -36,7 +38,24 @@ def register(mcp):
             max_classes: Max classes to return (default 10).
             include_base: Include inherited ModelObject methods (default False).
 
-        Returns setters, getters, and other methods grouped per class.
+        Returns setters, getters, and other methods grouped per class. Each entry
+        is a signature string, e.g. "setSurfaceType(surfaceType) -> Boolean".
+
+        Return types are read from the SDK's C++ headers and its SWIG wrappers —
+        they are sourced, never inferred from the method's name. Read them
+        literally; the distinction matters in Ruby:
+          - "-> Float"       a plain value. Calling .get on it raises NoMethodError.
+          - "-> Float, nil"  an Optional. .get is required; check .is_initialized
+                             first. e.g. nominalCapacity() -> Float, nil while
+                             efficiency() -> Float on the same class.
+          - "-> Array<X>"    a vector; iterate it.
+          - "-> ?"           genuinely unknown — no header or annotation declares
+                             it. Probe the object (print .class) before calling
+                             .get. This is an admitted gap, not a hint.
+
+        An Optional being present is not the same as it being meaningful: e.g.
+        ThermalZone#thermostat may be initialized while carrying no setpoint
+        schedule. Check the value the behavior depends on, not just the wrapper.
         """
         return search_api_op(
             class_pattern,

--- a/mcp_server/skills/api_reference/tools.py
+++ b/mcp_server/skills/api_reference/tools.py
@@ -48,9 +48,11 @@ def register(mcp):
         each class entry carries a "module" field naming the namespace it lives in
         ("openstudio", "openstudio.model", "openstudio.airflow", ...).
 
-        Return types are read from the SDK's C++ headers and its SWIG wrappers —
-        they are sourced, never inferred from the method's name. Read them
-        literally; the distinction matters in Ruby:
+        The response includes `signatures_available`; if it is false, a warning is
+        included and entries may contain fallback parameters or `-> ?` for an
+        unknown return type. Return types are read from the SDK's C++ headers and
+        its SWIG wrappers — they are sourced, never inferred from the method's
+        name. Read them literally; the distinction matters in Ruby:
           - "-> Float"       a plain value. Calling .get on it raises NoMethodError.
           - "-> Float, nil"  an Optional. .get is required; check .is_initialized
                              first. e.g. nominalCapacity() -> Float, nil while

--- a/mcp_server/skills/api_reference/tools.py
+++ b/mcp_server/skills/api_reference/tools.py
@@ -61,6 +61,13 @@ def register(mcp):
           - "-> ?"           genuinely unknown — no header or annotation declares
                              it. Probe the object (print .class) before calling
                              .get. This is an admitted gap, not a hint.
+          - "-> A | B"       overloaded; which return you get depends on the
+                             arguments (e.g. SqlFile#timeSeries(...) ->
+                             Array<TimeSeries> | TimeSeries, nil). Handle the
+                             nil-able form defensively.
+          - "[static] name(...)"  a class-level call (Ruby `Klass.name`, Python
+                             `Klass.name`), never invoked on an instance. e.g.
+                             "[static] iddObjectType() -> IddObjectType".
 
         An Optional being present is not the same as it being meaningful: e.g.
         ThermalZone#thermostat may be initialized while carrying no setpoint

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -206,6 +206,36 @@ def test_methods_carry_signatures():
     assert setter.split("(", 1)[1].split(")", 1)[0].strip(), "setter should take an arg"
 
 
+def test_non_model_classes_exclude_swig_data_and_only_return_signatures():
+    """Regression: non-model classes must not expose SWIG data or bare entries."""
+    search = _import_search_api_op()
+    cls = search("^SqlFile$", max_classes=1)["classes"][0]
+    entries = cls["setters"] + cls["getters"] + cls["other"]
+
+    assert "thisown" not in _names(entries)
+    assert entries
+    assert all("(" in entry and ") -> " in entry for entry in entries)
+
+    constants = search(
+        "^IddFieldProperties$",
+        method_pattern="^ExclusiveBound$",
+        max_classes=1,
+    )["classes"][0]
+    assert constants["setters"] + constants["getters"] + constants["other"] == []
+
+
+def test_inherited_methods_keep_sourced_signatures():
+    """Inherited methods use the parsed signature of their declaring base class."""
+    search = _import_search_api_op()
+    result = search(
+        "^CoilCoolingFourPipeBeam$",
+        method_pattern="^addToNode$",
+        max_classes=1,
+    )
+    assert result["ok"]
+    assert result["classes"][0]["other"] == ["addToNode(node) -> Boolean"]
+
+
 # ── return types are sourced, not guessed ───────────────────────────────
 
 
@@ -273,9 +303,9 @@ def test_every_returnable_method_has_a_sourced_type():
     in the wrapper parse, and every method must resolve to a type read from a C++
     header, a SWIG %extend, or a wrapper annotation. Coverage was 98.01% before the
     parser fixes and 10.84% before the headers were used at all; the surface itself
-    grew from ``dir(openstudio.model)`` (628 classes / 21,691 methods) to 925
-    classes / 26,418 methods when non-model classes (SqlFile, RunControl,
-    UserModel, …) became reachable.
+    grew from ``dir(openstudio.model)`` (628 classes / 21,691 methods) to 936
+    classes / 26,496 methods when non-model classes (SqlFile, RunControl,
+    UserModel, GbXML translators, Alfalfa, …) became reachable.
 
     This is pinned at exactly 0 rather than a loose bound: an SDK upgrade that
     introduces a declaration shape the parser can't read should fail here loudly,
@@ -321,9 +351,9 @@ def test_every_returnable_method_has_a_sourced_type():
 def test_wrapper_parse_surface_pinned():
     """The final wrapper numbers on this 3.11.0 install: the SWIG proxy parse covers
     940 classes / 26,526 methods (measured at plan time — adjust pins only if the
-    install differs), and search_api can now return 925 of them. The remaining 15
-    (Alfalfa*, GbXML translators, Modelica/ClassDefinition/ProgressBar) live in
-    modules outside the allowlist and are deliberately not returned.
+    install differs), and search_api can now return 936 of them. The remaining 4
+    (ClassDefinition, ConnectClause, ModelicaFile, ProgressBar) live in modules
+    outside the allowlist and are deliberately not returned.
     """
     import openstudio
 
@@ -343,7 +373,7 @@ def test_wrapper_parse_surface_pinned():
         entry["class_name"]
         for entry in _collect_classes(modules, preferred_names=set(sigs))
     }
-    assert len(returnable) == 925
+    assert len(returnable) == 936
 
 
 def test_sql_file_return_types_come_from_headers():
@@ -371,12 +401,44 @@ def test_module_field_attributes_each_class():
         "AirflowPath": "openstudio.airflow",
         "UserModel": "openstudio.isomodel",
         "GltfUserData": "openstudio.gltf",
+        "GbXMLForwardTranslator": "openstudio.gbxml",
+        "GbXMLReverseTranslator": "openstudio.gbxml",
+        "AlfalfaJSON": "openstudio.alfalfa",
+        "AlfalfaPoint": "openstudio.alfalfa",
+        "AlfalfaComponentCapability": "openstudio",
+        "AlfalfaComponentType": "openstudio",
         "People": "openstudio.model",
     }
     for class_name, module in expected.items():
         result = search(class_name, max_classes=10)
         cls = next(c for c in result["classes"] if c["class_name"] == class_name)
         assert cls["module"] == module, f"{class_name}: {cls['module']}"
+
+
+def test_gbxml_and_alfalfa_namespaces_are_searchable():
+    """Public gbXML and Alfalfa classes are included in the API search surface."""
+    search = _import_search_api_op()
+
+    gbxml = search("GbXML", max_classes=10)
+    assert {c["class_name"] for c in gbxml["classes"]} == {
+        "GbXMLForwardTranslator",
+        "GbXMLReverseTranslator",
+    }
+
+    alfalfa = search("Alfalfa", max_classes=50)
+    assert {c["class_name"] for c in alfalfa["classes"]} == {
+        "AlfalfaActuator",
+        "AlfalfaComponent",
+        "AlfalfaComponentBase",
+        "AlfalfaComponentCapability",
+        "AlfalfaComponentType",
+        "AlfalfaConstant",
+        "AlfalfaGlobalVariable",
+        "AlfalfaJSON",
+        "AlfalfaMeter",
+        "AlfalfaOutputVariable",
+        "AlfalfaPoint",
+    }
 
 
 def test_classes_listed_once_across_modules():

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -267,37 +267,153 @@ def test_return_types_are_never_guessed():
 def test_every_returnable_method_has_a_sourced_type():
     """**Ratchet: 100% of what search_api can return.** No `?`, no guesses.
 
-    search_api lists `dir(openstudio.model)`; those 21,691 methods are the ones a caller
-    can actually be handed, and every one resolves to a type read from a C++ header, a
-    SWIG %extend, or a wrapper annotation. Coverage was 98.01% before the parser fixes and
-    10.84% before the headers were used at all.
+    search_api lists classes across an explicit module allowlist — the openstudio
+    root, openstudio.model, and the non-model submodules behind the plan's ~265
+    non-model headers (see operations._MODULES). Every class it can return must be
+    in the wrapper parse, and every method must resolve to a type read from a C++
+    header, a SWIG %extend, or a wrapper annotation. Coverage was 98.01% before the
+    parser fixes and 10.84% before the headers were used at all; the surface itself
+    grew from ``dir(openstudio.model)`` (628 classes / 21,691 methods) to 925
+    classes / 26,418 methods when non-model classes (SqlFile, RunControl,
+    UserModel, …) became reachable.
 
-    This is pinned at exactly 0 rather than a loose bound: an SDK upgrade that introduces a
-    declaration shape the parser can't read should fail here loudly, not degrade quietly to
-    `?`. If that happens, fix the parser or — if the shape is genuinely unreadable — change
-    this assertion deliberately and say why.
+    This is pinned at exactly 0 rather than a loose bound: an SDK upgrade that
+    introduces a declaration shape the parser can't read should fail here loudly,
+    not degrade quietly to `?`. If that happens, fix the parser or — if the shape is
+    genuinely unreadable — change this assertion deliberately and say why.
     """
     import openstudio
 
     from mcp_server.skills.api_reference import _signatures
+    from mcp_server.skills.api_reference.operations import _CAST_RE, _MODULES, _collect_classes
 
     sigs = _signatures.signatures()
+    modules = [
+        (label, openstudio if attr is None else getattr(openstudio, attr))
+        for label, attr in _MODULES
+        if attr is None or getattr(openstudio, attr, None) is not None
+    ]
     returnable = {
-        name
-        for name in dir(openstudio.model)
-        if not name.startswith("_") and isinstance(getattr(openstudio.model, name), type)
+        entry["class_name"]
+        for entry in _collect_classes(modules, preferred_names=set(sigs))
     }
+
+    # Every returned class must have a signature source — Python-only internals and
+    # legacy aliases are filtered out in _collect_classes, never returned untyped.
+    assert returnable <= set(sigs), f"untyped classes: {sorted(returnable - set(sigs))}"
 
     unknown = {
         f"{cls}#{method}"
-        for cls in returnable & set(sigs)
+        for cls in returnable
         for method, info in sigs[cls].items()
         if info["returns"] == _signatures.UNKNOWN_TYPE
+        # The to_<Class>() downcast family is SWIG-synthesized (declared in no
+        # header); search_api collapses it into one summary line, and the cast target
+        # IS the class name — its "unknown" is the family's design, not a gap.
+        and not _CAST_RE.match(method)
     }
-    total = sum(len(sigs[cls]) for cls in returnable & set(sigs))
+    total = sum(len(sigs[cls]) for cls in returnable)
 
-    assert total > 20000, f"expected the full model surface, got {total}"
+    assert total > 26000, f"expected the full SDK surface, got {total}"
     assert not unknown, f"{len(unknown)} of {total} methods have no sourced type: {sorted(unknown)[:10]}"
+
+
+def test_wrapper_parse_surface_pinned():
+    """The final wrapper numbers on this 3.11.0 install: the SWIG proxy parse covers
+    940 classes / 26,526 methods (measured at plan time — adjust pins only if the
+    install differs), and search_api can now return 925 of them. The remaining 15
+    (Alfalfa*, GbXML translators, Modelica/ClassDefinition/ProgressBar) live in
+    modules outside the allowlist and are deliberately not returned.
+    """
+    import openstudio
+
+    from mcp_server.skills.api_reference import _signatures
+    from mcp_server.skills.api_reference.operations import _MODULES, _collect_classes
+
+    sigs = _signatures.signatures()
+    assert len(sigs) == 940
+    assert sum(len(m) for m in sigs.values()) == 26526
+
+    modules = [
+        (label, openstudio if attr is None else getattr(openstudio, attr))
+        for label, attr in _MODULES
+        if attr is None or getattr(openstudio, attr, None) is not None
+    ]
+    returnable = {
+        entry["class_name"]
+        for entry in _collect_classes(modules, preferred_names=set(sigs))
+    }
+    assert len(returnable) == 925
+
+
+def test_sql_file_return_types_come_from_headers():
+    """SqlFile was unreachable before the module-allowlist change — reporting
+    measures use it constantly (execAndReturnFirstDouble, availableEnvPeriods, …).
+    Its types now come from utilities/sql/SqlFile.hpp, not from the name guesser.
+    """
+    search = _import_search_api_op()
+    assert _returns(search, "SqlFile", "execAndReturnFirstDouble") == "Float, nil"
+    assert _returns(search, "SqlFile", "execAndReturnFirstString") == "String, nil"
+    assert _returns(search, "SqlFile", "availableEnvPeriods") == "Array<String>"
+    assert _returns(search, "SqlFile", "path") == "Object"
+
+
+def test_module_field_attributes_each_class():
+    """Every class entry names the namespace it lives in, so a caller can tell
+    openstudio.model.Space from openstudio.SqlFile from openstudio.airflow.RunControl.
+    """
+    search = _import_search_api_op()
+    expected = {
+        "SqlFile": "openstudio",
+        "ThreeUserData": "openstudio",
+        "WorkflowStepResult": "openstudio",
+        "RunControl": "openstudio.airflow",
+        "AirflowPath": "openstudio.airflow",
+        "UserModel": "openstudio.isomodel",
+        "GltfUserData": "openstudio.gltf",
+        "People": "openstudio.model",
+    }
+    for class_name, module in expected.items():
+        result = search(class_name, max_classes=10)
+        cls = next(c for c in result["classes"] if c["class_name"] == class_name)
+        assert cls["module"] == module, f"{class_name}: {cls['module']}"
+
+
+def test_classes_listed_once_across_modules():
+    """Aliased submodules and cross-module re-exports must not double-list a class.
+    RunControl/AirflowPath/IndexModel live in openstudio.airflow (not in its
+    openstudioairflow alias, which is not in the allowlist) — each appears once.
+    """
+    search = _import_search_api_op()
+    result = search("RunControl|AirflowPath|IndexModel", max_classes=50)
+    names = [c["class_name"] for c in result["classes"]]
+    assert len(names) == len(set(names)), f"duplicates: {names}"
+    assert set(names) == {"RunControl", "AirflowPath", "IndexModel"}
+
+
+def test_include_base_false_keeps_non_model_methods():
+    """Regression: the old model-only logic subtracted dir(ModelObject) from every
+    class, silently dropping same-named methods on non-model classes. WorkflowStepResult
+    is not a ModelObject — include_base must be irrelevant to it.
+    """
+    search = _import_search_api_op()
+    excluded = search("WorkflowStepResult")["classes"][0]
+    included = search("WorkflowStepResult", include_base=True)["classes"][0]
+    names_excl = _names(excluded["setters"] + excluded["getters"] + excluded["other"])
+    names_incl = _names(included["setters"] + included["getters"] + included["other"])
+    assert names_excl == names_incl
+    assert "stepResult" in names_excl  # a real WorkflowStepResult method survived
+
+
+def test_loose_pattern_response_stays_bounded():
+    """A wider class list makes loose patterns match more; the default cap must keep
+    responses bounded — the module allowlist is not too wide if this stays sane.
+    """
+    search = _import_search_api_op()
+    result = search("Model", max_classes=50)
+    assert len(result["classes"]) <= 50
+    assert len(result["classes"]) > 1  # the widened surface actually matched more than one
+    assert len(search("Model")["classes"]) <= 10  # default cap still applies
 
 
 # ── Downcast collapse ────────────────────────────────────────────────────

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -19,6 +19,11 @@ def _import_search_api_op():
     return search_api_op
 
 
+def _names(entries):
+    """Method names from signature strings like 'setName(name) -> Boolean'."""
+    return {e.split("(", 1)[0] for e in entries}
+
+
 # ── Exact match ──────────────────────────────────────────────────────────
 
 def test_search_class_exact_match():
@@ -109,7 +114,7 @@ def test_exclude_base_methods():
     # Default: base methods excluded
     result = search("CoilCoolingFourPipeBeam")
     cls = result["classes"][0]
-    all_methods = cls["setters"] + cls["getters"] + cls["other"]
+    all_methods = _names(cls["setters"] + cls["getters"] + cls["other"])
     base_methods = {"clone", "remove", "name"}
     for bm in base_methods:
         assert bm not in all_methods, (
@@ -119,7 +124,7 @@ def test_exclude_base_methods():
     # With include_base=True: they appear
     result_incl = search("CoilCoolingFourPipeBeam", include_base=True)
     cls_incl = result_incl["classes"][0]
-    all_incl = cls_incl["setters"] + cls_incl["getters"] + cls_incl["other"]
+    all_incl = _names(cls_incl["setters"] + cls_incl["getters"] + cls_incl["other"])
     # At least "name" should appear (every ModelObject has it)
     assert "name" in all_incl, "'name' should appear when include_base=True"
 
@@ -147,7 +152,7 @@ def test_validates_real_methods_exist():
     search = _import_search_api_op()
     result = search("CoilCoolingFourPipeBeam", include_base=True)
     cls = result["classes"][0]
-    all_methods = set(cls["setters"] + cls["getters"] + cls["other"])
+    all_methods = _names(cls["setters"] + cls["getters"] + cls["other"])
 
     # Known GOOD methods (from Ruby/Python API)
     good_methods = {"setName", "setBeamRatedCoolingCapacityperBeamLength"}
@@ -172,7 +177,7 @@ def test_ruby_python_method_parity_spot_check():
     search = _import_search_api_op()
     result = search("CoilCoolingFourPipeBeam")
     cls = result["classes"][0]
-    setters = set(cls["setters"])
+    setters = _names(cls["setters"])
 
     # These setter names are confirmed in the Ruby API docs
     # Note: heating setters are on CoilHeatingFourPipeBeam, not Cooling
@@ -184,12 +189,168 @@ def test_ruby_python_method_parity_spot_check():
         assert m in setters, f"Expected Ruby-parity setter '{m}' not found"
 
 
+# ── Signatures (params + return types) ───────────────────────────────────
+
+def test_methods_carry_signatures():
+    """Each method entry is 'name(params) -> ReturnType', not a bare name."""
+    search = _import_search_api_op()
+    result = search("CoilCoolingFourPipeBeam")
+    cls = result["classes"][0]
+
+    setter = next(
+        s for s in cls["setters"]
+        if s.startswith("setBeamRatedCoolingCapacityperBeamLength(")
+    )
+    # Has a parameter and a rendered return type
+    assert "->" in setter
+    assert setter.split("(", 1)[1].split(")", 1)[0].strip(), "setter should take an arg"
+
+
+# ── return types are sourced, not guessed ───────────────────────────────
+
+
+def _returns(search, class_name, method):
+    """The rendered return type of one method, or None.
+
+    class_pattern is a regex `search`, so "Space" also matches SpaceType and
+    FloorspaceReverseTranslator — select the exact class rather than trusting order.
+    """
+    result = search(class_name, method_pattern=f"^{method}$", max_classes=50)
+    cls = next((c for c in result["classes"] if c["class_name"] == class_name), None)
+    if cls is None:
+        return None
+    for entry in cls["setters"] + cls["getters"] + cls["other"]:
+        if entry.split("(", 1)[0] == method:
+            return entry.split("->", 1)[1].strip() if "->" in entry else None
+    return None
+
+
+@pytest.mark.parametrize(
+    ("class_name", "method", "expected"),
+    [
+        # The pair that motivated this: identical `-> Object` under the old name-guesser,
+        # yet `.get` is mandatory on one and raises NoMethodError on the other.
+        ("ZoneHVACBaseboardConvectiveElectric", "efficiency", "Float"),
+        ("ZoneHVACBaseboardConvectiveElectric", "nominalCapacity", "Float, nil"),
+        # The guesser reported this as Boolean because the name matches `is[A-Z]`. It is
+        # really boost::optional<std::string>, empty until a sizing run — so
+        # `next unless zone.isConditioned` silently skipped every zone.
+        ("ThermalZone", "isConditioned", "String, nil"),
+        ("SpaceType", "spaces", "Array<Space>"),
+        ("Space", "thermalZone", "ThermalZone, nil"),
+    ],
+)
+def test_return_types_come_from_headers(class_name, method, expected):
+    search = _import_search_api_op()
+    assert _returns(search, class_name, method) == expected
+
+
+def test_swig_synthesized_types_still_resolve():
+    """The Model#get* family is declared in no header — it must keep its wrapper-parsed
+    type. Guards against 'simplifying' the wrapper pass away: headers cover only 4 of the
+    2,876 pairs it supplies.
+    """
+    search = _import_search_api_op()
+    assert _returns(search, "Model", "getThermalZoneByName") == "ThermalZone, nil"
+
+
+def test_return_types_are_never_guessed():
+    """A type is either sourced from a real declaration, or admitted unknown. Never
+    inferred from the method's name — that heuristic reported `isConditioned -> Boolean`
+    when it is really an empty-until-sizing `boost::optional<std::string>`.
+    """
+    from mcp_server.skills.api_reference import _signatures
+
+    assert not hasattr(_signatures, "_infer_return_type"), "the name-guesser must not return"
+
+
+def test_every_returnable_method_has_a_sourced_type():
+    """**Ratchet: 100% of what search_api can return.** No `?`, no guesses.
+
+    search_api lists `dir(openstudio.model)`; those 21,691 methods are the ones a caller
+    can actually be handed, and every one resolves to a type read from a C++ header, a
+    SWIG %extend, or a wrapper annotation. Coverage was 98.01% before the parser fixes and
+    10.84% before the headers were used at all.
+
+    This is pinned at exactly 0 rather than a loose bound: an SDK upgrade that introduces a
+    declaration shape the parser can't read should fail here loudly, not degrade quietly to
+    `?`. If that happens, fix the parser or — if the shape is genuinely unreadable — change
+    this assertion deliberately and say why.
+    """
+    import openstudio
+
+    from mcp_server.skills.api_reference import _signatures
+
+    sigs = _signatures.signatures()
+    returnable = {
+        name
+        for name in dir(openstudio.model)
+        if not name.startswith("_") and isinstance(getattr(openstudio.model, name), type)
+    }
+
+    unknown = {
+        f"{cls}#{method}"
+        for cls in returnable & set(sigs)
+        for method, info in sigs[cls].items()
+        if info["returns"] == _signatures.UNKNOWN_TYPE
+    }
+    total = sum(len(sigs[cls]) for cls in returnable & set(sigs))
+
+    assert total > 20000, f"expected the full model surface, got {total}"
+    assert not unknown, f"{len(unknown)} of {total} methods have no sourced type: {sorted(unknown)[:10]}"
+
+
+# ── Downcast collapse ────────────────────────────────────────────────────
+
+def test_casts_collapsed_with_include_base():
+    """to_<Class>() downcast family collapses to one summary line, not ~400 entries."""
+    # Regression: include_base dumped every to_<Class>() cast, bloating the response
+    search = _import_search_api_op()
+    result = search("People", include_base=True)
+    cls = next(c for c in result["classes"] if c["class_name"] == "People")
+    other = cls["other"]
+
+    # Exactly one collapsed summary entry, no individual cast entries
+    summaries = [e for e in other if e.startswith("to_<TargetClass>(")]
+    assert len(summaries) == 1, f"Expected one cast summary, got {summaries}"
+    assert "downcast methods" in summaries[0]
+    for leaked in ("to_AirGap(", "to_BoilerHotWater(", "to_Space("):
+        assert not any(e.startswith(leaked) for e in other), (
+            f"Individual cast '{leaked}' should be collapsed"
+        )
+    # The summary reports how many casts it folded; that count (hundreds) must be
+    # far larger than every remaining 'other' entry combined — proving collapse.
+    folded = int(summaries[0].split("#", 1)[1].split()[0])
+    assert folded > 100, f"Expected hundreds of casts folded, got {folded}"
+    assert len(other) < folded, (
+        f"'other' ({len(other)}) should be far smaller than folded casts ({folded})"
+    )
+
+
+def test_casts_excluded_by_default():
+    # Regression: default (include_base=False) excludes base casts entirely — no summary
+    search = _import_search_api_op()
+    cls = search("People")["classes"][0]
+    summaries = [e for e in cls["other"] if e.startswith("to_<TargetClass>(")]
+    assert summaries == [], "No cast summary expected when include_base=False"
+
+
+def test_explicit_cast_search_not_collapsed():
+    # Regression: method_pattern targeting casts lists matches literally, no collapse
+    search = _import_search_api_op()
+    cls = search("People", include_base=True, method_pattern="to_Space$")["classes"][0]
+    all_entries = cls["setters"] + cls["getters"] + cls["other"]
+    assert any(e.startswith("to_Space(") for e in all_entries)
+    assert not any(e.startswith("to_<TargetClass>(") for e in all_entries)
+
+
 # ── MCP integration ─────────────────────────────────────────────────────
 
 def test_search_api_via_mcp():
     """search_api tool works through full MCP stack."""
     # Validates: search_api works through full MCP server stack
     import asyncio
+
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
 

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -244,6 +244,24 @@ def test_overloaded_return_types_render_every_form():
     ]
 
 
+@pytest.mark.parametrize(
+    ("class_name", "method", "expected"),
+    [
+        ("TimeSeries", "intervalLength", "intervalLength() -> Time, nil"),
+        ("ThermalZone", "returnAirModelObject", "returnAirModelObject() -> ModelObject, nil"),
+        ("SqlFile", "getElecOrGasUse", "getElecOrGasUse(t_getGas) -> Float, nil"),
+        ("Polygon3d", "getOuterPath", "getOuterPath() -> Array<Point3d>"),
+    ],
+)
+def test_typedef_alias_returns_resolve_to_optional_and_array(class_name, method, expected):
+    # Regression: header aliases (OptionalTime, OptionalModelObject, OptionalDouble,
+    # Point3dVector) rendered as an opaque Object, hiding the .get / Array handling required
+    search = _import_search_api_op()
+    result = search(f"^{class_name}$", method_pattern=f"^{method}$", include_base=True)
+    cls = result["classes"][0]
+    assert cls["getters"] + cls["other"] == [expected]
+
+
 def test_non_model_classes_exclude_swig_data_and_only_return_signatures():
     # Regression: SqlFile exposed thisown and bare entries; IddFieldProperties constants leaked as methods
     """Regression: non-model classes must not expose SWIG data or bare entries."""

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -21,7 +21,7 @@ def _import_search_api_op():
 
 def _names(entries):
     """Method names from signature strings like 'setName(name) -> Boolean'."""
-    return {e.split("(", 1)[0] for e in entries}
+    return {e.removeprefix("[static] ").split("(", 1)[0] for e in entries}
 
 
 # ── Exact match ──────────────────────────────────────────────────────────
@@ -192,6 +192,7 @@ def test_ruby_python_method_parity_spot_check():
 # ── Signatures (params + return types) ───────────────────────────────────
 
 def test_methods_carry_signatures():
+    # Validates: setter entries render as 'name(params) -> Type' with a real parameter, never bare names
     """Each method entry is 'name(params) -> ReturnType', not a bare name."""
     search = _import_search_api_op()
     result = search("CoilCoolingFourPipeBeam")
@@ -206,7 +207,45 @@ def test_methods_carry_signatures():
     assert setter.split("(", 1)[1].split(")", 1)[0].strip(), "setter should take an arg"
 
 
+def test_static_methods_render_with_static_prefix():
+    # Validates: iddObjectType is a SWIG @staticmethod; rendering it as an instance call
+    # would have agents write zone.iddObjectType and hit NoMethodError in Ruby
+    search = _import_search_api_op()
+    # include_base: static class-level methods are declared on ModelObject and so are
+    # subtracted by the default base filter.
+    result = search("^ThermalZone$", method_pattern="^iddObjectType$", include_base=True)
+    assert result["ok"] is True
+    cls = result["classes"][0]
+    assert cls["class_name"] == "ThermalZone"
+    assert cls["other"] == ["[static] iddObjectType() -> IddObjectType"], cls["other"]
+
+    # Instance methods never carry the prefix
+    result = search("^Model$", method_pattern="^building$")
+    assert result["classes"][0]["other"] == ["building() -> Building, nil"]
+
+
+def test_energyplus_forward_translator_uses_its_own_header():
+    # Regression: six modules declare ForwardTranslator; the cross-module merge let airflow's
+    # win, so translateModel rendered "Object, nil" instead of the real Workspace return
+    search = _import_search_api_op()
+    result = search("^ForwardTranslator$", method_pattern="^translateModel$", max_classes=5)
+    assert result["ok"] is True
+    assert [c["module"] for c in result["classes"]] == ["openstudio.energyplus"]
+    assert result["classes"][0]["other"] == ["translateModel(model, progressBar) -> Workspace"]
+
+
+def test_overloaded_return_types_render_every_form():
+    # Regression: SqlFile#timeSeries collapsed to Array<TimeSeries>; the optional overload
+    # (envPeriod, frequency, name, keyValue) needs .get and was invisible
+    search = _import_search_api_op()
+    result = search("^SqlFile$", method_pattern="^timeSeries$")
+    assert result["classes"][0]["other"] == [
+        "timeSeries(...) -> Array<TimeSeries> | TimeSeries, nil",
+    ]
+
+
 def test_non_model_classes_exclude_swig_data_and_only_return_signatures():
+    # Regression: SqlFile exposed thisown and bare entries; IddFieldProperties constants leaked as methods
     """Regression: non-model classes must not expose SWIG data or bare entries."""
     search = _import_search_api_op()
     cls = search("^SqlFile$", max_classes=1)["classes"][0]
@@ -225,6 +264,7 @@ def test_non_model_classes_exclude_swig_data_and_only_return_signatures():
 
 
 def test_inherited_methods_keep_sourced_signatures():
+    # Regression: inherited addToNode rendered '-> ?' instead of the declaring class 'addToNode(node) -> Boolean'
     """Inherited methods use the parsed signature of their declaring base class."""
     search = _import_search_api_op()
     result = search(
@@ -250,7 +290,7 @@ def _returns(search, class_name, method):
     if cls is None:
         return None
     for entry in cls["setters"] + cls["getters"] + cls["other"]:
-        if entry.split("(", 1)[0] == method:
+        if entry.removeprefix("[static] ").split("(", 1)[0] == method:
             return entry.split("->", 1)[1].strip() if "->" in entry else None
     return None
 
@@ -271,11 +311,13 @@ def _returns(search, class_name, method):
     ],
 )
 def test_return_types_come_from_headers(class_name, method, expected):
+    # Validates: return types for known methods match their C++ header declarations exactly
     search = _import_search_api_op()
     assert _returns(search, class_name, method) == expected
 
 
 def test_swig_synthesized_types_still_resolve():
+    # Validates: Model#getThermalZoneByName (SWIG-synthesized, no header) keeps its wrapper-parsed type
     """The Model#get* family is declared in no header — it must keep its wrapper-parsed
     type. Guards against 'simplifying' the wrapper pass away: headers cover only 4 of the
     2,876 pairs it supplies.
@@ -285,6 +327,7 @@ def test_swig_synthesized_types_still_resolve():
 
 
 def test_return_types_are_never_guessed():
+    # Regression: _infer_return_type guessed isConditioned -> Boolean (really OptionalString); guesser stays deleted
     """A type is either sourced from a real declaration, or admitted unknown. Never
     inferred from the method's name — that heuristic reported `isConditioned -> Boolean`
     when it is really an empty-until-sizing `boost::optional<std::string>`.
@@ -295,6 +338,7 @@ def test_return_types_are_never_guessed():
 
 
 def test_every_returnable_method_has_a_sourced_type():
+    # Validates: ratchet at 0 unknown return types across every class search_api can return
     """**Ratchet: 100% of what search_api can return.** No `?`, no guesses.
 
     search_api lists classes across an explicit module allowlist — the openstudio
@@ -349,6 +393,7 @@ def test_every_returnable_method_has_a_sourced_type():
 
 
 def test_wrapper_parse_surface_pinned():
+    # Validates: wrapper parse covers 940 classes / 26,526 methods and 936 are returnable on 3.11.0
     """The final wrapper numbers on this 3.11.0 install: the SWIG proxy parse covers
     940 classes / 26,526 methods (measured at plan time — adjust pins only if the
     install differs), and search_api can now return 936 of them. The remaining 4
@@ -377,6 +422,7 @@ def test_wrapper_parse_surface_pinned():
 
 
 def test_sql_file_return_types_come_from_headers():
+    # Validates: SqlFile exec/availableEnvPeriods types come from SqlFile.hpp (Float, nil / Array<String>)
     """SqlFile was unreachable before the module-allowlist change — reporting
     measures use it constantly (execAndReturnFirstDouble, availableEnvPeriods, …).
     Its types now come from utilities/sql/SqlFile.hpp, not from the name guesser.
@@ -389,6 +435,7 @@ def test_sql_file_return_types_come_from_headers():
 
 
 def test_module_field_attributes_each_class():
+    # Validates: module field names the exact namespace for root, model, airflow, isomodel, gltf, gbxml, alfalfa
     """Every class entry names the namespace it lives in, so a caller can tell
     openstudio.model.Space from openstudio.SqlFile from openstudio.airflow.RunControl.
     """
@@ -416,6 +463,7 @@ def test_module_field_attributes_each_class():
 
 
 def test_gbxml_and_alfalfa_namespaces_are_searchable():
+    # Regression: openstudio.gbxml and openstudio.alfalfa were missing from _MODULES; exact class sets pinned
     """Public gbXML and Alfalfa classes are included in the API search surface."""
     search = _import_search_api_op()
 
@@ -442,6 +490,7 @@ def test_gbxml_and_alfalfa_namespaces_are_searchable():
 
 
 def test_classes_listed_once_across_modules():
+    # Validates: RunControl/AirflowPath/IndexModel each appear once despite aliased submodule re-exports
     """Aliased submodules and cross-module re-exports must not double-list a class.
     RunControl/AirflowPath/IndexModel live in openstudio.airflow (not in its
     openstudioairflow alias, which is not in the allowlist) — each appears once.
@@ -454,6 +503,7 @@ def test_classes_listed_once_across_modules():
 
 
 def test_include_base_false_keeps_non_model_methods():
+    # Regression: WorkflowStepResult#stepResult was dropped by ModelObject base subtraction on a non-model class
     """Regression: the old model-only logic subtracted dir(ModelObject) from every
     class, silently dropping same-named methods on non-model classes. WorkflowStepResult
     is not a ModelObject — include_base must be irrelevant to it.
@@ -468,6 +518,7 @@ def test_include_base_false_keeps_non_model_methods():
 
 
 def test_loose_pattern_response_stays_bounded():
+    # Validates: max_classes cap (default 10) still bounds responses after widening to 10 namespaces
     """A wider class list makes loose patterns match more; the default cap must keep
     responses bounded — the module allowlist is not too wide if this stays sane.
     """

--- a/tests/test_api_reference_unit.py
+++ b/tests/test_api_reference_unit.py
@@ -1,0 +1,223 @@
+"""Unit tests for search_api's class collection (no OpenStudio SDK needed).
+
+The class-collection logic in operations.py was factored out of search_api_op so it
+can be exercised with fake module objects: identity dedupe of aliased submodules,
+per-module attribution, the wrapper-type filter, and the per-module include_base
+semantics. Integration behavior against the live SDK lives in test_api_reference.py.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from mcp_server.skills.api_reference.operations import (
+    _collect_classes,
+    _is_wrapper_type,
+    _own_methods,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _mod(**classes) -> object:
+    return types.SimpleNamespace(**classes)
+
+
+# --------------------------------------------------------------------------------------
+# _collect_classes — allowlist -> {class_name, module, cls}, deduped by identity
+# --------------------------------------------------------------------------------------
+
+
+def test_collect_classes_dedupes_aliased_modules_by_identity():
+    """openstudio.airflow and openstudio.openstudioairflow expose the SAME class
+    objects. Identity dedupe must list each class once — under the first module
+    enumerated (the canonical short name).
+    """
+    run_control = type("RunControl", (), {})
+    airflow = _mod(RunControl=run_control, IndexModel=type("IndexModel", (), {}))
+    airflow_alias = _mod(RunControl=run_control)  # alias module, same objects
+
+    out = _collect_classes([
+        ("openstudio.airflow", airflow),
+        ("openstudio.openstudioairflow", airflow_alias),
+    ])
+
+    assert len(out) == 2
+    by_name = {e["class_name"]: e for e in out}
+    assert set(by_name) == {"RunControl", "IndexModel"}
+    assert by_name["RunControl"]["module"] == "openstudio.airflow"
+    assert by_name["IndexModel"]["module"] == "openstudio.airflow"
+
+
+def test_collect_classes_module_attribution():
+    """Each class carries the module it was found in; a class present only in a later
+    module keeps that module's label.
+    """
+    space = type("Space", (), {})
+    sql_file = type("SqlFile", (), {})
+    out = _collect_classes([
+        ("openstudio", _mod(Space=space)),
+        ("openstudio.model", _mod(Space=space)),
+        ("openstudio.airflow", _mod(SqlFile=sql_file)),
+    ])
+    by_name = {e["class_name"]: e for e in out}
+    assert by_name["Space"]["module"] == "openstudio"  # first module wins for dup ids
+    assert by_name["SqlFile"]["module"] == "openstudio.airflow"
+
+
+def test_collect_classes_skips_wrapper_private_and_iterator_types():
+    """Container/optional plumbing must never leak: Optional*, *Vector, *Set/*Map with
+    an `object` base, the per-module SwigPyIterator, and underscore-private names.
+    Real domain classes sharing a suffix (inheriting a non-object base) are kept.
+    """
+    class MapBase:
+        pass
+
+    class DefaultConstructionSet(MapBase):
+        pass
+
+    class GoodMap(MapBase):
+        pass
+
+    mod = _mod(
+        _Private=type("_Private", (), {}),
+        OptionalString=type("OptionalString", (), {}),
+        StringVector=type("StringVector", (), {}),
+        DefaultConstructionSet=DefaultConstructionSet,
+        GoodMap=GoodMap,
+        BadSet=type("BadSet", (), {}),          # object base -> wrapper
+        BadMap=type("BadMap", (), {}),          # object base -> wrapper
+        SwigPyIterator=type("SwigPyIterator", (), {}),
+    )
+    out = _collect_classes([("openstudio", mod)])
+    assert {e["class_name"] for e in out} == {"DefaultConstructionSet", "GoodMap"}
+
+
+def test_collect_classes_ignores_non_class_attributes():
+    """Module-level functions/constants are not classes and must be skipped."""
+    mod = _mod(
+        the_answer=42,
+        helper=lambda: None,
+        RunControl=type("RunControl", (), {}),
+    )
+    out = _collect_classes([("openstudio.airflow", mod)])
+    assert [e["class_name"] for e in out] == ["RunControl"]
+
+
+def test_collect_classes_skips_python_only_lowercase_classes():
+    """path / xml_document / xml_node / baseUnitConversionFactor are Python-binding
+    internals at the openstudio root. _signatures excludes lowercase names from the
+    wrapper parse (no types exist for them); the class list must mirror that rule so
+    search_api never returns an untyped class.
+    """
+    mod = _mod(
+        path=type("path", (), {}),
+        xml_document=type("xml_document", (), {}),
+        RunControl=type("RunControl", (), {}),
+    )
+    out = _collect_classes([("openstudio", mod)])
+    assert [e["class_name"] for e in out] == ["RunControl"]
+
+
+def test_collect_classes_prefers_wrapper_parsed_name_for_aliases():
+    """Legacy aliases: model.DistrictHeating IS model.DistrictHeatingWater (same
+    object). Identity dedupe keeps whichever name dir() lists first, but the wrapper
+    parse knows only the proxy name — so the preferred (parsed) name must win,
+    otherwise the class renders untyped under its alias.
+    """
+    cls = type("DistrictHeatingWater", (), {})
+    mod = _mod(DistrictHeating=cls, DistrictHeatingWater=cls)  # alias, same object
+    out = _collect_classes(
+        [("openstudio.model", mod)],
+        preferred_names={"DistrictHeatingWater"},
+    )
+    assert len(out) == 1
+    assert out[0]["class_name"] == "DistrictHeatingWater"
+    assert out[0]["module"] == "openstudio.model"
+
+    # Without preferences, the first-seen name wins (pre-existing behavior).
+    out2 = _collect_classes([("openstudio.model", mod)])
+    assert out2[0]["class_name"] == "DistrictHeating"
+
+
+# --------------------------------------------------------------------------------------
+# _own_methods — include_base semantics, scoped to model-module classes
+# --------------------------------------------------------------------------------------
+
+
+class _FakeModelObject:
+    def name(self):
+        return None
+
+    def handle(self):
+        return None
+
+
+class _FakeSpace(_FakeModelObject):
+    def name(self):  # overrides the base — must be kept, not subtracted
+        return None
+
+    def surfaceArea(self):
+        return None
+
+
+class _FakeSqlFile:  # non-model: does NOT inherit ModelObject
+    def name(self):
+        return None
+
+    def path(self):
+        return None
+
+
+_BASE_METHODS = {m for m in dir(_FakeModelObject) if not m.startswith("_")}
+
+
+def test_own_methods_model_class_subtracts_base_unless_include_base():
+    """Model-module classes get ModelObject's method set subtracted (default), by
+    name — pre-existing search_api behavior, so an override of a base method is
+    excluded too. include_base=True keeps everything.
+    """
+    own = _own_methods(
+        _FakeSpace,
+        include_base=False,
+        is_model_class=True,
+        model_base_methods=_BASE_METHODS,
+    )
+    assert own == {"surfaceArea"}  # `name` (override) and `handle` both subtracted
+
+    with_base = _own_methods(
+        _FakeSpace,
+        include_base=True,
+        is_model_class=True,
+        model_base_methods=_BASE_METHODS,
+    )
+    assert with_base == {"name", "surfaceArea", "handle"}
+
+
+def test_own_methods_non_model_class_never_subtracts_base():
+    """Regression: SqlFile has its own `name` method. Under the old model-only logic it
+    would be subtracted as if it were inherited from ModelObject, silently dropping a
+    real method from the response.
+    """
+    own = _own_methods(
+        _FakeSqlFile, include_base=False, is_model_class=False, model_base_methods=_BASE_METHODS,
+    )
+    assert own == {"name", "path"}  # nothing subtracted
+
+
+# --------------------------------------------------------------------------------------
+# _is_wrapper_type — SwigPyIterator skip (added for the multi-module surface)
+# --------------------------------------------------------------------------------------
+
+
+def test_is_wrapper_type_skips_swig_py_iterator():
+    """SwigPyIterator is re-created per module — without the name skip, a pattern like
+    "Iterator" would list it once per surfaced namespace (10 times after widening).
+    A real *Set domain class (non-object base) is unaffected.
+    """
+    class ModelParent:
+        pass
+
+    assert _is_wrapper_type(type("SwigPyIterator", (), {}))
+    assert not _is_wrapper_type(type("DefaultConstructionSet", (ModelParent,), {}))

--- a/tests/test_api_reference_unit.py
+++ b/tests/test_api_reference_unit.py
@@ -13,6 +13,7 @@ import pytest
 
 from mcp_server.skills.api_reference.operations import (
     _collect_classes,
+    _decorate,
     _is_wrapper_type,
     _own_methods,
 )
@@ -204,6 +205,75 @@ def test_own_methods_non_model_class_never_subtracts_base():
         _FakeSqlFile, include_base=False, is_model_class=False, model_base_methods=_BASE_METHODS,
     )
     assert own == {"name", "path"}  # nothing subtracted
+
+
+def test_own_methods_excludes_swig_data_and_thisown_unconditionally():
+    """``dir`` includes SWIG properties/constants and the internal ownership flag.
+
+    ``thisown`` is excluded by name even if a binding version exposes it as callable;
+    all other non-callable attributes are excluded from the method buckets.
+    """
+    class _FakeSwigClass:
+        def thisown(self):
+            return None
+
+        ExclusiveBound = 1
+
+        @property
+        def swig_property(self):
+            return "value"
+
+        def realMethod(self):
+            return None
+
+    own = _own_methods(
+        _FakeSwigClass,
+        include_base=False,
+        is_model_class=False,
+        model_base_methods=set(),
+    )
+    assert own == {"realMethod"}
+
+
+def test_decorate_walks_mro_for_inherited_signatures_and_respects_precedence():
+    """Parsed signatures come from the first matching class in the live MRO."""
+    class _SignatureBase:
+        def inherited(self, base_value):
+            return None
+
+    class _SignatureMiddle(_SignatureBase):
+        def inherited(self, middle_value):
+            return None
+
+    class _SignatureLeaf(_SignatureMiddle):
+        pass
+
+    sigs = {
+        "_SignatureBase": {
+            "inherited": {"params": ["baseValue"], "returns": "BaseResult"},
+        },
+        "_SignatureMiddle": {
+            "inherited": {"params": ["middleValue"], "returns": "MiddleResult"},
+        },
+    }
+
+    assert _decorate("_SignatureLeaf", _SignatureLeaf, ["inherited"], sigs) == [
+        "inherited(middleValue) -> MiddleResult",
+    ]
+
+
+def test_decorate_never_returns_a_bare_method_name():
+    """Opaque C/SWIG callables still render as an explicit unknown signature."""
+    class _OpaqueCallable:
+        __signature__ = "unavailable"
+
+        def __call__(self):
+            return None
+
+    class _Opaque:
+        method = _OpaqueCallable()
+
+    assert _decorate("_Opaque", _Opaque, ["method"], {}) == ["method(...) -> ?"]
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_api_reference_unit.py
+++ b/tests/test_api_reference_unit.py
@@ -7,10 +7,12 @@ semantics. Integration behavior against the live SDK lives in test_api_reference
 """
 from __future__ import annotations
 
+import sys
 import types
 
 import pytest
 
+from mcp_server.skills.api_reference import operations
 from mcp_server.skills.api_reference.operations import (
     _collect_classes,
     _decorate,
@@ -274,6 +276,42 @@ def test_decorate_never_returns_a_bare_method_name():
         method = _OpaqueCallable()
 
     assert _decorate("_Opaque", _Opaque, ["method"], {}) == ["method(...) -> ?"]
+
+
+def test_search_api_reports_degraded_signature_loading(monkeypatch, capsys):
+    """Class/method discovery survives a signature parser failure visibly."""
+    class ModelObject:
+        def name(self):
+            return None
+
+    class FakeWidget(ModelObject):
+        def setName(self, name):
+            return True
+
+    fake_model = types.ModuleType("openstudio.model")
+    fake_model.ModelObject = ModelObject
+    fake_model.FakeWidget = FakeWidget
+    fake_openstudio = types.ModuleType("openstudio")
+    fake_openstudio.model = fake_model
+    monkeypatch.setitem(sys.modules, "openstudio", fake_openstudio)
+
+    def fail_signatures():
+        raise OSError("signature files unavailable")
+
+    monkeypatch.setattr(operations, "signatures", fail_signatures)
+
+    result = operations.search_api_op("^FakeWidget$")
+
+    assert result["ok"] is True
+    assert result["signatures_available"] is False
+    assert "signatures are unavailable" in result["warning"]
+    assert result["classes"][0]["class_name"] == "FakeWidget"
+    assert result["classes"][0]["setters"] == ["setName(name) -> ?"]
+
+    stderr = capsys.readouterr().err
+    assert "search_api: failed to load SDK signatures" in stderr
+    assert "^FakeWidget$" in stderr
+    assert "OSError: signature files unavailable" in stderr
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_api_reference_unit.py
+++ b/tests/test_api_reference_unit.py
@@ -33,6 +33,7 @@ def _mod(**classes) -> object:
 
 
 def test_collect_classes_dedupes_aliased_modules_by_identity():
+    # Validates: aliased submodules (airflow/openstudioairflow) list each class once under the canonical module
     """openstudio.airflow and openstudio.openstudioairflow expose the SAME class
     objects. Identity dedupe must list each class once — under the first module
     enumerated (the canonical short name).
@@ -54,6 +55,7 @@ def test_collect_classes_dedupes_aliased_modules_by_identity():
 
 
 def test_collect_classes_module_attribution():
+    # Validates: class entries carry the first module they were found in; later-only classes keep their own
     """Each class carries the module it was found in; a class present only in a later
     module keeps that module's label.
     """
@@ -70,6 +72,7 @@ def test_collect_classes_module_attribution():
 
 
 def test_collect_classes_skips_wrapper_private_and_iterator_types():
+    # Validates: Optional*/Vector/object-based Set/Map, SwigPyIterator and _private names never leak as classes
     """Container/optional plumbing must never leak: Optional*, *Vector, *Set/*Map with
     an `object` base, the per-module SwigPyIterator, and underscore-private names.
     Real domain classes sharing a suffix (inheriting a non-object base) are kept.
@@ -98,6 +101,7 @@ def test_collect_classes_skips_wrapper_private_and_iterator_types():
 
 
 def test_collect_classes_ignores_non_class_attributes():
+    # Validates: module-level functions/constants are not returned as classes
     """Module-level functions/constants are not classes and must be skipped."""
     mod = _mod(
         the_answer=42,
@@ -109,6 +113,7 @@ def test_collect_classes_ignores_non_class_attributes():
 
 
 def test_collect_classes_skips_python_only_lowercase_classes():
+    # Validates: lowercase Python-binding internals (path, xml_document) never return as untyped classes
     """path / xml_document / xml_node / baseUnitConversionFactor are Python-binding
     internals at the openstudio root. _signatures excludes lowercase names from the
     wrapper parse (no types exist for them); the class list must mirror that rule so
@@ -124,6 +129,7 @@ def test_collect_classes_skips_python_only_lowercase_classes():
 
 
 def test_collect_classes_prefers_wrapper_parsed_name_for_aliases():
+    # Regression: legacy alias DistrictHeating rendered untyped because parsed name DistrictHeatingWater lost
     """Legacy aliases: model.DistrictHeating IS model.DistrictHeatingWater (same
     object). Identity dedupe keeps whichever name dir() lists first, but the wrapper
     parse knows only the proxy name — so the preferred (parsed) name must win,
@@ -177,6 +183,7 @@ _BASE_METHODS = {m for m in dir(_FakeModelObject) if not m.startswith("_")}
 
 
 def test_own_methods_model_class_subtracts_base_unless_include_base():
+    # Validates: model classes subtract ModelObject methods by name unless include_base=True
     """Model-module classes get ModelObject's method set subtracted (default), by
     name — pre-existing search_api behavior, so an override of a base method is
     excluded too. include_base=True keeps everything.
@@ -199,6 +206,7 @@ def test_own_methods_model_class_subtracts_base_unless_include_base():
 
 
 def test_own_methods_non_model_class_never_subtracts_base():
+    # Regression: SqlFile#name was dropped by model-only base subtraction applied to non-model classes
     """Regression: SqlFile has its own `name` method. Under the old model-only logic it
     would be subtracted as if it were inherited from ModelObject, silently dropping a
     real method from the response.
@@ -210,6 +218,7 @@ def test_own_methods_non_model_class_never_subtracts_base():
 
 
 def test_own_methods_excludes_swig_data_and_thisown_unconditionally():
+    # Regression: thisown and SWIG properties/constants leaked into method buckets as bare entries
     """``dir`` includes SWIG properties/constants and the internal ownership flag.
 
     ``thisown`` is excluded by name even if a binding version exposes it as callable;
@@ -238,6 +247,7 @@ def test_own_methods_excludes_swig_data_and_thisown_unconditionally():
 
 
 def test_decorate_walks_mro_for_inherited_signatures_and_respects_precedence():
+    # Regression: inherited methods rendered '-> ?' (24/45 on coil) because only the leaf class parse was used
     """Parsed signatures come from the first matching class in the live MRO."""
     class _SignatureBase:
         def inherited(self, base_value):
@@ -264,7 +274,31 @@ def test_decorate_walks_mro_for_inherited_signatures_and_respects_precedence():
     ]
 
 
+def test_decorate_prefixes_static_methods():
+    # Validates: parsed static flag renders as "[static] " so agents call Klass.m(), not obj.m()
+    class _WithStatic:
+        @staticmethod
+        def load(_path):
+            return None
+
+        def name(self):
+            return None
+
+    sigs = {
+        "_WithStatic": {
+            "load": {"params": ["path"], "returns": "Model, nil", "static": True},
+            "name": {"params": [], "returns": "String", "static": False},
+        },
+    }
+
+    assert _decorate("_WithStatic", _WithStatic, ["load", "name"], sigs) == [
+        "[static] load(path) -> Model, nil",
+        "name() -> String",
+    ]
+
+
 def test_decorate_never_returns_a_bare_method_name():
+    # Regression: opaque C callables rendered as bare names; must be 'name(...) -> ?'
     """Opaque C/SWIG callables still render as an explicit unknown signature."""
     class _OpaqueCallable:
         __signature__ = "unavailable"
@@ -279,6 +313,7 @@ def test_decorate_never_returns_a_bare_method_name():
 
 
 def test_search_api_reports_degraded_signature_loading(monkeypatch, capsys):
+    # Regression: signature-load failure silently returned ok:true with bare names; needs signatures_available:False
     """Class/method discovery survives a signature parser failure visibly."""
     class ModelObject:
         def name(self):
@@ -320,6 +355,7 @@ def test_search_api_reports_degraded_signature_loading(monkeypatch, capsys):
 
 
 def test_is_wrapper_type_skips_swig_py_iterator():
+    # Validates: per-module SwigPyIterator is skipped so it is not listed once per surfaced namespace
     """SwigPyIterator is re-created per module — without the name skip, a pattern like
     "Iterator" would list it once per surfaced namespace (10 times after widening).
     A real *Set domain class (non-object base) is unaffected.

--- a/tests/test_api_signatures_unit.py
+++ b/tests/test_api_signatures_unit.py
@@ -20,6 +20,7 @@ from mcp_server.skills.api_reference._headers import (
     _parse_header,
     map_cpp_type,
 )
+from mcp_server.skills.api_reference._signatures import _resolve_return_type
 
 pytestmark = pytest.mark.unit
 
@@ -36,6 +37,39 @@ def _write_tree(base: Path, rel: str, body: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
     return path
+
+
+# --------------------------------------------------------------------------------------
+# _resolve_return_type — wrapper annotation rendering
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("annotation", "known_classes", "expected"),
+    [
+        ("OptionalString", set(), "String, nil"),
+        ("StringVector", set(), "Array<String>"),
+        ("OptionalStr", set(), "String, nil"),
+        ("StrVector", set(), "Array<String>"),
+        ("OptionalDouble", set(), "Float, nil"),
+        ("DoubleVector", set(), "Array<Float>"),
+        ("OptionalFloat", set(), "Float, nil"),
+        ("FloatVector", set(), "Array<Float>"),
+        ("OptionalInt", set(), "Integer, nil"),
+        ("IntVector", set(), "Array<Integer>"),
+        ("OptionalBool", set(), "Boolean, nil"),
+        ("BoolVector", set(), "Array<Boolean>"),
+        ("OptionalThermalZone", {"ThermalZone"}, "ThermalZone, nil"),
+        ("ThermalZoneVector", {"ThermalZone"}, "Array<ThermalZone>"),
+        ("OptionalUnknown", set(), "Object, nil"),
+        ("UnknownVector", set(), "Array"),
+    ],
+)
+def test_wrapper_return_types_resolve_primitives_before_classes(
+    annotation, known_classes, expected,
+):
+    """Primitive wrapper names must not be mistaken for unknown bound classes."""
+    assert _resolve_return_type(annotation, known_classes) == expected
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_api_signatures_unit.py
+++ b/tests/test_api_signatures_unit.py
@@ -1,0 +1,467 @@
+"""Unit tests for the C++ header parser behind ``search_api`` return types.
+
+These run without the OpenStudio SDK: every fixture is synthetic header text, so they
+execute in the fast ``-m "not integration"`` shard. Each hazard case below is drawn from a
+real construct found in the shipped 3.11.0 headers, not invented — the comment on each
+says which.
+
+The counterpart integration assertions (real SDK, real values) live in
+``test_api_reference.py``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.skills.api_reference._headers import (
+    _build,
+    _locate_header_dir,
+    _parse_header,
+    map_cpp_type,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write(tmp_path, name: str, body: str):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------------------
+# map_cpp_type — the C++ -> Ruby rendering table
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cpp", "expected"),
+    [
+        # The case that motivated the whole change: identical `-> Object` under the old
+        # name-guesser, opposite handling in Ruby.
+        ("double", "Float"),
+        ("boost::optional<double>", "Float, nil"),
+        # ThermalZone#isConditioned — the guesser called this Boolean. It is not.
+        ("boost::optional<std::string>", "String, nil"),
+        ("void", "void"),
+        ("bool", "Boolean"),
+        ("int", "Integer"),
+        ("unsigned", "Integer"),
+        ("size_t", "Integer"),
+        ("std::string", "String"),
+        ("float", "Float"),
+        # SDK object returns
+        ("Schedule", "Schedule"),
+        ("boost::optional<ThermalZone>", "ThermalZone, nil"),
+        ("std::vector<Space>", "Array<Space>"),
+        ("std::vector<std::string>", "Array<String>"),
+        # const / ref / ptr decoration must not change the rendered type
+        ("const std::string", "String"),
+        ("double&", "Float"),
+        # Types with no useful Ruby rendering degrade to Object, never to a guess.
+        ("std::map<UUID, UUID>", "Object"),
+        # A vector of un-renderable elements is plain `Array` — `Array<Object>` would add
+        # noise without adding information.
+        ("std::vector<std::pair<std::string, std::string>>", "Array"),
+        ("boost::optional<std::pair<ConstructionBase, int>>", "Object, nil"),
+    ],
+)
+def test_map_cpp_type(cpp, expected):
+    assert map_cpp_type(cpp) == expected
+
+
+def test_map_cpp_type_gates_unknown_classes():
+    """Header-only classes absent from the bindings must not render a name Ruby lacks.
+
+    `Connection`, `ComponentWatcher` and `DesignSpecificationZoneAirDistribution` are
+    declared in headers but confirmed absent from `OpenStudio::Model` in Ruby.
+    """
+    known = {"ThermalZone", "Space"}
+    assert map_cpp_type("ThermalZone", known) == "ThermalZone"
+    assert map_cpp_type("ComponentWatcher", known) == "Object"
+    assert map_cpp_type("boost::optional<ComponentWatcher>", known) == "Object, nil"
+    assert map_cpp_type("std::vector<Space>", known) == "Array<Space>"
+
+
+# --------------------------------------------------------------------------------------
+# _parse_header — declaration extraction and its hazards
+# --------------------------------------------------------------------------------------
+
+
+def test_parses_public_declarations(tmp_path):
+    src = """
+class MODEL_API ZoneHVACBaseboardConvectiveElectric : public ZoneHVACComponent {
+ public:
+    double efficiency() const;
+    boost::optional<double> nominalCapacity() const;
+    bool setEfficiency(double efficiency);
+    void autosizeNominalCapacity();
+    bool isNominalCapacityAutosized() const;
+    static IddObjectType iddObjectType();
+};
+"""
+    parsed = _parse_header(_write(tmp_path, "X.hpp", src))
+    methods = parsed["ZoneHVACBaseboardConvectiveElectric"]
+    assert methods["efficiency"] == "double"
+    assert methods["nominalCapacity"] == "boost::optional<double>"
+    assert methods["setEfficiency"] == "bool"
+    assert methods["autosizeNominalCapacity"] == "void"
+    assert methods["isNominalCapacityAutosized"] == "bool"
+    assert methods["iddObjectType"] == "IddObjectType"  # `static` stripped
+
+
+def test_ignores_declarations_inside_comments(tmp_path):
+    """Real hazard: CoilCoolingWater.hpp:29 has `*  <li> bool addToNode(Node & node);</li>`."""
+    src = """
+class MODEL_API CoilCoolingWater : public WaterToAirComponent {
+ /** Doxygen block:
+  *  <li> bool addToNode(Node & node);</li>
+  *  You can then call the helper method `bool assignHistoricalEffectivenessCurves()`
+  */
+ public:
+    // bool commentedOut() const;
+    double realMethod() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "C.hpp", src))["CoilCoolingWater"]
+    assert "realMethod" in methods
+    assert "addToNode" not in methods
+    assert "assignHistoricalEffectivenessCurves" not in methods
+    assert "commentedOut" not in methods
+
+
+def test_ignores_macros(tmp_path):
+    """REGISTER_LOGGER appears 621 times, OS_DEPRECATED 295 times inside class bodies."""
+    src = """
+class MODEL_API ThermalZone : public HVACComponent {
+ public:
+    REGISTER_LOGGER("openstudio.model.ThermalZone");
+    OS_DEPRECATED(3, 1, 0)
+    double realMethod() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "T.hpp", src))["ThermalZone"]
+    assert set(methods) == {"realMethod"}
+
+
+def test_access_specifiers_do_not_filter_methods(tmp_path):
+    """Access level is deliberately ignored — this map only answers "what does X return".
+
+    search_api lists methods from `dir()` on the live bindings, which expose some protected
+    members (`Model#addVersionObject` sits under `protected:` in Model.hpp yet is callable).
+    Filtering to `public:` dropped their types without hiding the methods — it cost coverage
+    and hid nothing. The `public:`/`protected:` lines themselves must still not parse as
+    declarations.
+    """
+    src = """
+class MODEL_API ThermalZone : public HVACComponent {
+ public:
+    double publicMethod() const;
+ protected:
+    double protectedMethod() const;
+ private:
+    double privateMethod() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "T.hpp", src))["ThermalZone"]
+    assert methods == {
+        "publicMethod": "double",
+        "protectedMethod": "double",
+        "privateMethod": "double",
+    }
+
+
+def test_data_members_are_not_mistaken_for_methods(tmp_path):
+    """Access level is unfiltered, so private *data* must still be excluded — it is, by
+    having no `(`. Real line from PlanarSurface.hpp: `std::map<UUID, UUID> m_handleMapping;`
+    """
+    src = """
+class MODEL_API Sneaky : public Base {
+ private:
+    std::map<UUID, UUID> m_handleMapping;
+    double m_someValue;
+ public:
+    double realMethod() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "S.hpp", src))["Sneaky"]
+    assert set(methods) == {"realMethod"}
+
+
+def test_skips_constructors_and_destructors(tmp_path):
+    src = """
+class MODEL_API ThermalZone : public HVACComponent {
+ public:
+    explicit ThermalZone(const Model& model);
+    virtual ~ThermalZone() override = default;
+    double realMethod() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "T.hpp", src))["ThermalZone"]
+    assert "ThermalZone" not in methods
+    assert set(methods) == {"realMethod"}
+
+
+def test_class_declared_with_macro_taking_arguments(tmp_path):
+    """Real: TableMultiVariableLookup.hpp:51. Allowing only one *bare* macro before the
+    name meant the class never opened and all 99 of its methods were dropped.
+    """
+    src = """
+class OS_DEPRECATED(3, 5, 0) MODEL_API TableMultiVariableLookup : public Curve {
+ public:
+    static IddObjectType iddObjectType();
+    static std::vector<std::string> interpolationMethodValues();
+};
+"""
+    parsed = _parse_header(_write(tmp_path, "T.hpp", src))
+    assert "TableMultiVariableLookup" in parsed
+    assert parsed["TableMultiVariableLookup"]["iddObjectType"] == "IddObjectType"
+    assert parsed["TableMultiVariableLookup"]["interpolationMethodValues"] == "std::vector<std::string>"
+
+
+def test_all_caps_class_name_still_parses(tmp_path):
+    """The macro run is greedy; backtracking must still yield an ALL-CAPS class name."""
+    src = "class MODEL_API AVM : public Base {\n public:\n    double x() const;\n};\n"
+    assert "AVM" in _parse_header(_write(tmp_path, "A.hpp", src))
+
+
+def test_forward_declaration_is_not_a_class(tmp_path):
+    src = "class ThermalZone_Impl;\nclass MODEL_API ThermalZone : public Base {\n public:\n    double x() const;\n};\n"
+    parsed = _parse_header(_write(tmp_path, "F.hpp", src))
+    assert "ThermalZone_Impl" not in parsed
+    assert parsed["ThermalZone"] == {"x": "double"}
+
+
+def test_inline_deprecated_prefix_keeps_the_declaration(tmp_path):
+    """Real: AirLoopHVACUnitarySystem.hpp. 294 declarations carry this prefix; skipping the
+    whole line because it *starts* with a macro discarded every one of them. The methods are
+    deprecated, not absent — the bindings still expose them.
+    """
+    src = """
+class MODEL_API AirLoopHVACUnitarySystem : public ZoneHVACComponent {
+ public:
+    REGISTER_LOGGER("openstudio.model.AirLoopHVACUnitarySystem");
+    OS_DEPRECATED(3, 7, 0) double maximumCyclingRate() const;
+    OS_DEPRECATED(3, 7, 0) bool isMaximumCyclingRateDefaulted() const;
+    OS_DEPRECATED(3, 3, 0) static std::vector<std::string> validHumidityIndicatingTypeValues();
+};
+"""
+    methods = _parse_header(_write(tmp_path, "A.hpp", src))["AirLoopHVACUnitarySystem"]
+    assert methods["maximumCyclingRate"] == "double"
+    assert methods["isMaximumCyclingRateDefaulted"] == "bool"
+    assert methods["validHumidityIndicatingTypeValues"] == "std::vector<std::string>"
+    assert "REGISTER_LOGGER" not in methods
+
+
+def test_uppercase_method_names(tmp_path):
+    """Real: UtilityBill.hpp:250 `boost::optional<double> CVRMSE() const;`"""
+    src = """
+class MODEL_API UtilityBill : public ModelObject {
+ public:
+    boost::optional<double> CVRMSE() const;
+    boost::optional<double> NMBE() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "U.hpp", src))["UtilityBill"]
+    assert methods["CVRMSE"] == "boost::optional<double>"
+    assert map_cpp_type(methods["NMBE"]) == "Float, nil"
+
+
+def test_method_may_return_its_own_class(tmp_path):
+    """`Construction reverseConstruction() const;` — rejecting return-type == class name
+    also killed these. Constructors are excluded by name == class, which is sufficient.
+    """
+    src = """
+class MODEL_API Construction : public LayeredConstruction {
+ public:
+    explicit Construction(const Model& model);
+    Construction(const Construction& other) = default;
+    Construction reverseConstruction() const;
+    static GeneratorPhotovoltaic simple(const Model& model);
+};
+"""
+    methods = _parse_header(_write(tmp_path, "C.hpp", src))["Construction"]
+    assert methods["reverseConstruction"] == "Construction"
+    assert methods["simple"] == "GeneratorPhotovoltaic"
+    assert "Construction" not in methods  # the ctor, not a method
+
+
+def test_return_type_on_its_own_line(tmp_path):
+    """clang-format wraps a long declaration by putting the return type on its own line.
+
+    Real: HeatExchangerDesiccantBalancedFlowPerformanceDataType1.hpp:209-210. The name is
+    long enough to trigger the wrap, and long enough that reproducing it inline would blow
+    the 120-char limit — hence the constant.
+    """
+    setter = "setMinimumRegenerationInletAirRelativeHumidityforTemperatureEquation"
+    cls = "HeatExchangerDesiccantBalancedFlowPerformanceDataType1"
+    src = (
+        f"class MODEL_API {cls} : public ModelObject {{\n"
+        " public:\n"
+        "    bool\n"
+        f"      {setter}(double {setter[3:4].lower() + setter[4:]});\n"
+        "    double realMethod() const;\n"
+        "};\n"
+    )
+    methods = _parse_header(_write(tmp_path, "H.hpp", src))[cls]
+    assert methods[setter] == "bool"
+    assert methods["realMethod"] == "double"
+
+
+def test_doc_comment_continuation_without_a_star(tmp_path):
+    """Real: ExteriorLoadInstance.hpp:50-52. The middle line of this doxygen block starts
+    with neither `*` nor `//`, and carries a `(` — a line-at-a-time stripper feeds it into
+    the continuation buffer and eats the declaration behind it. Block state must be tracked.
+    """
+    src = """
+class MODEL_API ExteriorLoadInstance : public ModelObject {
+ public:
+    /** Returns the number of instances this space load instance represents.
+  This just forwards to multiplier() here but is included for consistency with SpaceLoadInstance**/
+    int quantity() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "E.hpp", src))["ExteriorLoadInstance"]
+    assert methods["quantity"] == "int"
+    assert "multiplier" not in methods  # mentioned only inside the comment
+
+
+def test_openstudio_enum_members(tmp_path):
+    """`OPENSTUDIO_ENUM(DefaultScheduleType, ...)` declares a class by macro expansion —
+    no `class` line, no member declarations. The generated set is uniform; every row was
+    confirmed against live Ruby. Note the macro sits in DefaultScheduleSet.hpp, a file
+    named for a different class.
+    """
+    src = """
+class MODEL_API DefaultScheduleSet : public ResourceObject {
+ public:
+    double realMethod() const;
+};
+  OPENSTUDIO_ENUM(DefaultScheduleType,
+    ((HoursofOperationSchedule)(Hours of Operation Schedule)(1))
+    ((NumberofPeopleSchedule)(Number of People Schedule)(2))
+  );
+"""
+    parsed = _parse_header(_write(tmp_path, "D.hpp", src))
+    assert parsed["DefaultScheduleSet"] == {"realMethod": "double"}
+    enum = parsed["DefaultScheduleType"]
+    assert map_cpp_type(enum["enumName"]) == "String"
+    assert map_cpp_type(enum["value"]) == "Integer"
+    assert map_cpp_type(enum["getValues"]) == "Array<Integer>"
+
+
+def test_swig_extend_block(tmp_path):
+    """`toIdfObject` exists in no .hpp — it is a SWIG %extend in ModelCore.i:
+    `IdfObject toIdfObject() const { return *self; }`. The .i body is plain C++.
+    """
+    src = """
+%extend openstudio::model::ModelObject{
+  // This really should not be necessary
+  IdfObject toIdfObject() const {
+    return *self;
+  }
+};
+"""
+    methods = _parse_header(_write(tmp_path, "ModelCore.i", src))["ModelObject"]
+    assert methods["toIdfObject"] == "IdfObject"
+
+
+def test_balances_nested_templates(tmp_path):
+    """`<[^>]*>` would truncate these; real examples from PlanarSurface / CoilHeating*."""
+    src = """
+class MODEL_API PlanarSurface : public ParentObject {
+ public:
+    boost::optional<std::pair<ConstructionBase, int>> constructionWithSearchDistance() const;
+    boost::optional<std::tuple<int, CoilCoolingDXMultiSpeed>> stageIndexAndParentCoil() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "P.hpp", src))["PlanarSurface"]
+    assert methods["constructionWithSearchDistance"] == "boost::optional<std::pair<ConstructionBase, int>>"
+    assert map_cpp_type(methods["constructionWithSearchDistance"]) == "Object, nil"
+
+
+def test_joins_multiline_declarations(tmp_path):
+    """Real: Space.hpp `findSurfaces(boost::optional<double> minDegreesFromNorth,` wraps."""
+    src = """
+class MODEL_API Space : public PlanarSurfaceGroup {
+ public:
+    std::vector<Surface> findSurfaces(boost::optional<double> minDegreesFromNorth,
+                                      boost::optional<double> maxDegreesFromNorth);
+    double realMethod() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "S.hpp", src))["Space"]
+    assert methods["findSurfaces"] == "std::vector<Surface>"
+    assert methods["realMethod"] == "double"
+
+
+def test_overload_first_declaration_wins(tmp_path):
+    """Matches _signatures' existing `setdefault` first-occurrence-wins convention."""
+    src = """
+class MODEL_API Model : public Workspace {
+ public:
+    bool addObject(const IdfObject& idf);
+    boost::optional<double> addObject(int index);
+};
+"""
+    methods = _parse_header(_write(tmp_path, "M.hpp", src))["Model"]
+    assert methods["addObject"] == "bool"
+
+
+def test_default_arguments_do_not_break_parsing(tmp_path):
+    src = """
+class MODEL_API AdditionalProperties : public ModelObject {
+ public:
+    void merge(const AdditionalProperties& other, bool overwrite = false);
+    std::vector<ModelObject> modelObjects(bool sorted = false) const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "A.hpp", src))["AdditionalProperties"]
+    assert methods["merge"] == "void"
+    assert methods["modelObjects"] == "std::vector<ModelObject>"
+
+
+# --------------------------------------------------------------------------------------
+# _build / _locate_header_dir — wiring and graceful degradation
+# --------------------------------------------------------------------------------------
+
+
+def test_build_skips_impl_headers(tmp_path):
+    """*_Impl.hpp are detail:: internals, never the public Ruby API."""
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "ThermalZone.hpp").write_text(
+        "class MODEL_API ThermalZone : public HVACComponent {\n public:\n"
+        "    double publicApi() const;\n};\n",
+        encoding="utf-8",
+    )
+    (model / "ThermalZone_Impl.hpp").write_text(
+        "class MODEL_API ThermalZone_Impl : public HVACComponent_Impl {\n public:\n"
+        "    double implDetail() const;\n};\n",
+        encoding="utf-8",
+    )
+    built = _build(tmp_path)
+    assert built["ThermalZone"] == {"publicApi": "double"}
+    assert "ThermalZone_Impl" not in built
+
+
+def test_locate_header_dir_honours_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("OSMCP_OPENSTUDIO_INCLUDE", str(tmp_path))
+    assert _locate_header_dir() == tmp_path
+
+
+def test_locate_header_dir_returns_none_when_missing(tmp_path, monkeypatch):
+    """No headers is not an error — a wheel-only box simply has no type source."""
+    monkeypatch.setenv("OSMCP_OPENSTUDIO_INCLUDE", str(tmp_path / "does-not-exist"))
+    assert _locate_header_dir() is None
+
+
+def test_no_name_based_guessing_remains():
+    """Guard the core invariant: types are sourced, never inferred from the method name.
+
+    `_infer_return_type` guessed `ThermalZone#isConditioned -> Boolean` (really an
+    OptionalString) and rendered `efficiency`/`nominalCapacity` identically despite
+    opposite handling. If it ever returns, this fails.
+    """
+    from mcp_server.skills.api_reference import _signatures
+
+    assert not hasattr(_signatures, "_infer_return_type")

--- a/tests/test_api_signatures_unit.py
+++ b/tests/test_api_signatures_unit.py
@@ -10,6 +10,8 @@ The counterpart integration assertions (real SDK, real values) live in
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from mcp_server.skills.api_reference._headers import (
@@ -24,6 +26,14 @@ pytestmark = pytest.mark.unit
 
 def _write(tmp_path, name: str, body: str):
     path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _write_tree(base: Path, rel: str, body: str) -> Path:
+    """Write a header at a nested relative path, creating parent dirs (for _build)."""
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
     return path
 
@@ -130,7 +140,13 @@ class MODEL_API CoilCoolingWater : public WaterToAirComponent {
 
 
 def test_ignores_macros(tmp_path):
-    """REGISTER_LOGGER appears 621 times, OS_DEPRECATED 295 times inside class bodies."""
+    """REGISTER_LOGGER appears 621 times, OS_DEPRECATED 295 times inside class bodies.
+
+    OS_DEPRECATED is stripped and the declaration kept; REGISTER_LOGGER expands to
+    ``static Logger logChannel();`` — a real static accessor, so it is registered
+    literally (deliberate: the utilities classes expose logChannel and it must
+    resolve to a type, not `?`).
+    """
     src = """
 class MODEL_API ThermalZone : public HVACComponent {
  public:
@@ -140,7 +156,8 @@ class MODEL_API ThermalZone : public HVACComponent {
 };
 """
     methods = _parse_header(_write(tmp_path, "T.hpp", src))["ThermalZone"]
-    assert set(methods) == {"realMethod"}
+    assert methods["logChannel"] == "Logger"
+    assert methods["realMethod"] == "double"
 
 
 def test_access_specifiers_do_not_filter_methods(tmp_path):
@@ -442,6 +459,273 @@ def test_build_skips_impl_headers(tmp_path):
     built = _build(tmp_path)
     assert built["ThermalZone"] == {"publicApi": "double"}
     assert "ThermalZone_Impl" not in built
+
+
+def test_build_discovers_nested_submodule_headers(tmp_path):
+    """Real: ``RunControl`` and ``AirflowPath`` are both declared in
+    ``airflow/contam/PrjObjects.hpp`` — a nested subdir, and a filename matching
+    neither class. The old ``glob("model/*.hpp")`` never saw them.
+    """
+    src = """
+class OS_AIRFLOW_API RunControl : public AirflowObject {
+ public:
+    int iterationCount() const;
+    double convergenceLimit() const;
+};
+class OS_AIRFLOW_API AirflowPath : public AirflowObject {
+ public:
+    int nodeCount() const;
+};
+"""
+    _write_tree(tmp_path, "airflow/contam/PrjObjects.hpp", src)
+    built = _build(tmp_path)
+    assert built["RunControl"] == {"iterationCount": "int", "convergenceLimit": "double"}
+    assert built["AirflowPath"] == {"nodeCount": "int"}
+
+
+def test_build_skips_impl_headers_in_nested_subdirs(tmp_path):
+    """The *_Impl.hpp skip applies everywhere, not just model/."""
+    _write_tree(
+        tmp_path, "model/ThermalZone.hpp",
+        "class MODEL_API ThermalZone {\n public:\n    double publicApi() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "utilities/sql/SqlFile.hpp",
+        "class OS_UTILITIES_API SqlFile {\n public:\n    std::string path() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "utilities/sql/SqlFile_Impl.hpp",
+        "class OS_UTILITIES_API SqlFile_Impl {\n public:\n    double implDetail() const;\n};\n",
+    )
+    built = _build(tmp_path)
+    assert built["ThermalZone"] == {"publicApi": "double"}
+    assert built["SqlFile"] == {"path": "std::string"}
+    assert "SqlFile_Impl" not in built
+
+
+def test_build_model_precedence_over_submodule(tmp_path):
+    """First-declaration-wins with model/ parsed first: a method declared in both
+    model/ and a submodule keeps the model declaration.
+    """
+    _write_tree(
+        tmp_path, "model/Space.hpp",
+        "class MODEL_API Space {\n public:\n    double surfaceArea() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "utilities/Space.hpp",
+        "class OS_UTILITIES_API Space {\n public:\n    int surfaceArea() const;\n};\n",
+    )
+    built = _build(tmp_path)
+    assert built["Space"] == {"surfaceArea": "double"}
+
+
+def test_build_parses_extend_in_nested_subdir(tmp_path):
+    """SWIG %extend blocks live in .i files outside model/ too; recursion must find
+    them so those methods get types (headers alone don't declare them).
+    """
+    _write_tree(
+        tmp_path, "utilities/sql/SqlFile.i",
+        "%extend openstudio::utilities::SqlFile{\n"
+        "    bool isOpen() const { return *self; }\n"
+        "};\n",
+    )
+    built = _build(tmp_path)
+    assert built["SqlFile"] == {"isOpen": "bool"}
+
+
+def test_build_hpp_declaration_wins_over_extend(tmp_path):
+    """A real .hpp declaration beats a %extend of the same method even when the
+    %extend sits in model/ — the .hpp-before-.i ordering is global, not per-module.
+    """
+    _write_tree(
+        tmp_path, "model/Space.hpp",
+        "class MODEL_API Space {\n public:\n    double surfaceArea() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "model/ModelCore.i",
+        "%extend openstudio::model::Space{\n"
+        "    int surfaceArea() const { return *self; }\n"
+        "};\n",
+    )
+    built = _build(tmp_path)
+    assert built["Space"] == {"surfaceArea": "double"}
+
+
+def test_parses_struct_classes(tmp_path):
+    """Real: `struct UTILITIES_API IstringFind` (Compare.hpp) and
+    `struct ISOMODEL_API ISOResults` (SimModel.hpp) — the class regex only matched
+    `class` and silently dropped every struct.
+    """
+    src = """
+struct UTILITIES_API IstringFind
+{
+ public:
+    void addTarget(const std::string& target);
+    std::string string() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "Compare.hpp", src))["IstringFind"]
+    assert methods == {"addTarget": "void", "string": "std::string"}
+
+
+def test_nested_struct_does_not_hijack_enclosing_class(tmp_path):
+    """Real: Calendar.hpp — `struct CalendarDay` sits inside `class Calendar`; without
+    nesting tracking, the struct stole every method that followed it and Calendar got
+    none (its logChannel and accessors rendered unknown).
+    """
+    src = """
+class UTILITIES_API Calendar
+{
+ public:
+    REGISTER_LOGGER("utilities.time.Calendar");
+    struct CalendarDay
+    {
+        int dayOfWeek() const;
+    };
+    void addHoliday(const Date& date, const std::string& name);
+    std::string getName(const Date& date) const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "Calendar.hpp", src))["Calendar"]
+    assert methods["logChannel"] == "Logger"
+    assert methods["addHoliday"] == "void"
+    assert methods["getName"] == "std::string"
+    assert "dayOfWeek" not in methods  # belongs to CalendarDay, not Calendar
+
+
+def test_getters_ending_in_close_brace_do_not_close_the_class(tmp_path):
+    """Real: EpwFile.hpp — getters are written `std::string x() const {` / `return …;` /
+    `};` — each getter's closing line looks exactly like a class close. Brace-depth
+    tracking must keep the class open (the getter close stays at the class depth, the
+    class's own `};` drops below it).
+    """
+    src = """
+class UTILITIES_API EpwHoliday
+{
+ public:
+    std::string holidayName() const {
+        return m_holidayName;
+    };
+    std::string holidayDateString() const {
+        return m_holidayDateString;
+    };
+ private:
+    std::string m_holidayName;
+    std::string m_holidayDateString;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "EpwFile.hpp", src))["EpwHoliday"]
+    assert methods == {
+        "holidayName": "std::string",
+        "holidayDateString": "std::string",
+    }
+
+
+def test_constructor_initializer_list_is_not_a_declaration(tmp_path):
+    """Real: EpwFile.hpp — `EpwHoliday(const std::string& a, const std::string& b)` is
+    followed by `: m_holidayName(holidayName), m_holidayDateString(holidayDateString){};`.
+    The ctor line ends with `)` so it is flushed as a (skipped) candidate, and the
+    initializer list used to parse as a bogus `m_holidayName` method with type `:`.
+    """
+    src = """
+class UTILITIES_API EpwHoliday
+{
+ public:
+    EpwHoliday(const std::string& holidayName, const std::string& holidayDateString)
+        : m_holidayName(holidayName), m_holidayDateString(holidayDateString){};
+    std::string holidayName() const;
+};
+"""
+    methods = _parse_header(_write(tmp_path, "EpwFile.hpp", src))["EpwHoliday"]
+    assert methods == {"holidayName": "std::string"}
+
+
+def test_build_reads_hxx_declarations(tmp_path):
+    """Real: IddFactory is declared in utilities/idd/IddFactory.hxx — a .hxx, which
+    the old glob never read, so IddFactory rendered unknown.
+    """
+    _write_tree(
+        tmp_path, "utilities/idd/IddFactory.hxx",
+        "class IddFactory {\n public:\n    static IddFactory& instance();\n};\n",
+    )
+    built = _build(tmp_path)
+    assert built["IddFactory"] == {"instance": "IddFactory"}
+
+
+def test_build_applies_module_scoped_class_rename(tmp_path):
+    """Real: `%rename(ZUnit) openstudio::Unit;` — the exposed name differs from the
+    declared one. The %extend on openstudio::Unit must also surface as ZUnit.
+    """
+    _write_tree(
+        tmp_path, "utilities/units/Unit.hpp",
+        "class UTILITIES_API Unit {\n public:\n    double baseUnits() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "utilities/UtilitiesUnits.i",
+        "%rename(ZUnit) openstudio::Unit;\n",
+    )
+    built = _build(tmp_path)
+    assert built["Unit"]["baseUnits"] == "double"
+    assert built["ZUnit"]["baseUnits"] == "double"  # alias carries the methods
+
+
+def test_build_rename_does_not_cross_modules(tmp_path):
+    """Real: six modules declare a `ForwardTranslator`; each is renamed to its own
+    XForwardTranslator. The rename must apply per module — sdd's rename must not
+    alias airflow's class, or SddForwardTranslator would inherit Contam's methods.
+    """
+    _write_tree(
+        tmp_path, "airflow/contam/ForwardTranslator.hpp",
+        "class AIRFLOW_API ForwardTranslator {\n public:\n    int modelToPrj() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "airflow/Airflow.i",
+        "%rename(ContamForwardTranslator) openstudio::contam::ForwardTranslator;\n",
+    )
+    _write_tree(
+        tmp_path, "sdd/ForwardTranslator.hpp",
+        "class SDD_API ForwardTranslator {\n public:\n    int modelToSDD() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "sdd/SDD.i",
+        "%rename(SddForwardTranslator) openstudio::sdd::ForwardTranslator;\n",
+    )
+    built = _build(tmp_path)
+    assert built["ContamForwardTranslator"] == {"modelToPrj": "int"}
+    assert built["SddForwardTranslator"] == {"modelToSDD": "int"}
+
+
+def test_build_applies_method_rename(tmp_path):
+    """Real: `%rename(toString) openstudio::measure::OSArgument::print;` — a method
+    rename: the header declares print, the exposed name is toString.
+    """
+    _write_tree(
+        tmp_path, "measure/OSArgument.hpp",
+        "class OS_MEASURE_API OSArgument {\n public:\n    std::string print() const;\n};\n",
+    )
+    _write_tree(
+        tmp_path, "measure/Measure.i",
+        "%rename(toString) openstudio::measure::OSArgument::print;\n",
+    )
+    built = _build(tmp_path)
+    assert built["OSArgument"]["print"] == "std::string"
+    assert built["OSArgument"]["toString"] == "std::string"
+
+
+def test_build_applies_inline_swig_class_rename(tmp_path):
+    """Real: CommonImport.i defines `class any { ... }` inline and renames it:
+    `%rename(Any) boost::any;` — the inline class's methods must surface as Any.
+    """
+    _write_tree(
+        tmp_path, "utilities/core/CommonImport.i",
+        "%rename(Any) boost::any;\n"
+        "class any {\n"
+        " public:\n"
+        "    std::string toString();\n"
+        "};\n",
+    )
+    built = _build(tmp_path)
+    assert built["Any"] == {"toString": "std::string"}
 
 
 def test_locate_header_dir_honours_env_override(tmp_path, monkeypatch):

--- a/tests/test_api_signatures_unit.py
+++ b/tests/test_api_signatures_unit.py
@@ -16,8 +16,10 @@ import pytest
 
 from mcp_server.skills.api_reference._headers import (
     _build,
+    _build_by_module,
     _locate_header_dir,
     _parse_header,
+    header_module_for,
     map_cpp_type,
 )
 from mcp_server.skills.api_reference._signatures import _resolve_return_type
@@ -68,6 +70,7 @@ def _write_tree(base: Path, rel: str, body: str) -> Path:
 def test_wrapper_return_types_resolve_primitives_before_classes(
     annotation, known_classes, expected,
 ):
+    # Regression: OptionalString/StringVector were treated as unknown bound classes instead of String primitives
     """Primitive wrapper names must not be mistaken for unknown bound classes."""
     assert _resolve_return_type(annotation, known_classes) == expected
 
@@ -110,10 +113,12 @@ def test_wrapper_return_types_resolve_primitives_before_classes(
     ],
 )
 def test_map_cpp_type(cpp, expected):
+    # Validates: C++ types map to exact Ruby-style renderings (Float, String, nil, Array<X>, Object)
     assert map_cpp_type(cpp) == expected
 
 
 def test_map_cpp_type_gates_unknown_classes():
+    # Validates: header-only classes absent from bindings render as Object, never a name Ruby lacks
     """Header-only classes absent from the bindings must not render a name Ruby lacks.
 
     `Connection`, `ComponentWatcher` and `DesignSpecificationZoneAirDistribution` are
@@ -132,6 +137,7 @@ def test_map_cpp_type_gates_unknown_classes():
 
 
 def test_parses_public_declarations(tmp_path):
+    # Validates: plain, optional, bool, void and static declarations parse with exact C++ return types
     src = """
 class MODEL_API ZoneHVACBaseboardConvectiveElectric : public ZoneHVACComponent {
  public:
@@ -154,6 +160,7 @@ class MODEL_API ZoneHVACBaseboardConvectiveElectric : public ZoneHVACComponent {
 
 
 def test_ignores_declarations_inside_comments(tmp_path):
+    # Regression: CoilCoolingWater.hpp doc comment '<li> bool addToNode(...)' parsed as a real method
     """Real hazard: CoilCoolingWater.hpp:29 has `*  <li> bool addToNode(Node & node);</li>`."""
     src = """
 class MODEL_API CoilCoolingWater : public WaterToAirComponent {
@@ -174,6 +181,7 @@ class MODEL_API CoilCoolingWater : public WaterToAirComponent {
 
 
 def test_ignores_macros(tmp_path):
+    # Validates: OS_DEPRECATED is stripped, REGISTER_LOGGER registers logChannel -> Logger, no macro leaks
     """REGISTER_LOGGER appears 621 times, OS_DEPRECATED 295 times inside class bodies.
 
     OS_DEPRECATED is stripped and the declaration kept; REGISTER_LOGGER expands to
@@ -195,6 +203,7 @@ class MODEL_API ThermalZone : public HVACComponent {
 
 
 def test_access_specifiers_do_not_filter_methods(tmp_path):
+    # Regression: filtering to public: dropped protected Model#addVersionObject type while dir() still lists it
     """Access level is deliberately ignored — this map only answers "what does X return".
 
     search_api lists methods from `dir()` on the live bindings, which expose some protected
@@ -222,6 +231,7 @@ class MODEL_API ThermalZone : public HVACComponent {
 
 
 def test_data_members_are_not_mistaken_for_methods(tmp_path):
+    # Validates: private data members (no parens) like m_handleMapping are never parsed as methods
     """Access level is unfiltered, so private *data* must still be excluded — it is, by
     having no `(`. Real line from PlanarSurface.hpp: `std::map<UUID, UUID> m_handleMapping;`
     """
@@ -239,6 +249,7 @@ class MODEL_API Sneaky : public Base {
 
 
 def test_skips_constructors_and_destructors(tmp_path):
+    # Validates: constructors and destructors are excluded; only real methods remain
     src = """
 class MODEL_API ThermalZone : public HVACComponent {
  public:
@@ -253,6 +264,7 @@ class MODEL_API ThermalZone : public HVACComponent {
 
 
 def test_class_declared_with_macro_taking_arguments(tmp_path):
+    # Regression: TableMultiVariableLookup macro-with-args class line never opened, dropping all 99 methods
     """Real: TableMultiVariableLookup.hpp:51. Allowing only one *bare* macro before the
     name meant the class never opened and all 99 of its methods were dropped.
     """
@@ -270,12 +282,14 @@ class OS_DEPRECATED(3, 5, 0) MODEL_API TableMultiVariableLookup : public Curve {
 
 
 def test_all_caps_class_name_still_parses(tmp_path):
+    # Validates: greedy macro run backtracks so an ALL-CAPS class name (AVM) still parses
     """The macro run is greedy; backtracking must still yield an ALL-CAPS class name."""
     src = "class MODEL_API AVM : public Base {\n public:\n    double x() const;\n};\n"
     assert "AVM" in _parse_header(_write(tmp_path, "A.hpp", src))
 
 
 def test_forward_declaration_is_not_a_class(tmp_path):
+    # Validates: 'class X_Impl;' forward declarations do not create a class entry
     src = "class ThermalZone_Impl;\nclass MODEL_API ThermalZone : public Base {\n public:\n    double x() const;\n};\n"
     parsed = _parse_header(_write(tmp_path, "F.hpp", src))
     assert "ThermalZone_Impl" not in parsed
@@ -283,6 +297,7 @@ def test_forward_declaration_is_not_a_class(tmp_path):
 
 
 def test_inline_deprecated_prefix_keeps_the_declaration(tmp_path):
+    # Regression: 294 OS_DEPRECATED-prefixed declarations were skipped entirely though bindings expose them
     """Real: AirLoopHVACUnitarySystem.hpp. 294 declarations carry this prefix; skipping the
     whole line because it *starts* with a macro discarded every one of them. The methods are
     deprecated, not absent — the bindings still expose them.
@@ -304,6 +319,7 @@ class MODEL_API AirLoopHVACUnitarySystem : public ZoneHVACComponent {
 
 
 def test_uppercase_method_names(tmp_path):
+    # Regression: UtilityBill CVRMSE/NMBE (uppercase names) failed to parse
     """Real: UtilityBill.hpp:250 `boost::optional<double> CVRMSE() const;`"""
     src = """
 class MODEL_API UtilityBill : public ModelObject {
@@ -318,6 +334,7 @@ class MODEL_API UtilityBill : public ModelObject {
 
 
 def test_method_may_return_its_own_class(tmp_path):
+    # Regression: Construction#reverseConstruction was rejected because return type equalled class name
     """`Construction reverseConstruction() const;` — rejecting return-type == class name
     also killed these. Constructors are excluded by name == class, which is sufficient.
     """
@@ -337,6 +354,7 @@ class MODEL_API Construction : public LayeredConstruction {
 
 
 def test_return_type_on_its_own_line(tmp_path):
+    # Regression: clang-format wrapped return type on its own line lost the desiccant setter type
     """clang-format wraps a long declaration by putting the return type on its own line.
 
     Real: HeatExchangerDesiccantBalancedFlowPerformanceDataType1.hpp:209-210. The name is
@@ -359,6 +377,7 @@ def test_return_type_on_its_own_line(tmp_path):
 
 
 def test_doc_comment_continuation_without_a_star(tmp_path):
+    # Regression: ExteriorLoadInstance.hpp doxygen line without '*' ate the quantity() declaration behind it
     """Real: ExteriorLoadInstance.hpp:50-52. The middle line of this doxygen block starts
     with neither `*` nor `//`, and carries a `(` — a line-at-a-time stripper feeds it into
     the continuation buffer and eats the declaration behind it. Block state must be tracked.
@@ -377,6 +396,7 @@ class MODEL_API ExteriorLoadInstance : public ModelObject {
 
 
 def test_openstudio_enum_members(tmp_path):
+    # Validates: OPENSTUDIO_ENUM macro expands to enumName/value/getValues with exact types
     """`OPENSTUDIO_ENUM(DefaultScheduleType, ...)` declares a class by macro expansion —
     no `class` line, no member declarations. The generated set is uniform; every row was
     confirmed against live Ruby. Note the macro sits in DefaultScheduleSet.hpp, a file
@@ -401,6 +421,7 @@ class MODEL_API DefaultScheduleSet : public ResourceObject {
 
 
 def test_swig_extend_block(tmp_path):
+    # Validates: SWIG %extend methods (toIdfObject in ModelCore.i) parse with their return type
     """`toIdfObject` exists in no .hpp — it is a SWIG %extend in ModelCore.i:
     `IdfObject toIdfObject() const { return *self; }`. The .i body is plain C++.
     """
@@ -417,6 +438,7 @@ def test_swig_extend_block(tmp_path):
 
 
 def test_balances_nested_templates(tmp_path):
+    # Regression: '<[^>]*>' truncated nested templates like boost::optional<std::pair<...>>
     """`<[^>]*>` would truncate these; real examples from PlanarSurface / CoilHeating*."""
     src = """
 class MODEL_API PlanarSurface : public ParentObject {
@@ -431,6 +453,7 @@ class MODEL_API PlanarSurface : public ParentObject {
 
 
 def test_joins_multiline_declarations(tmp_path):
+    # Regression: Space#findSurfaces wrapped across lines lost its std::vector<Surface> type
     """Real: Space.hpp `findSurfaces(boost::optional<double> minDegreesFromNorth,` wraps."""
     src = """
 class MODEL_API Space : public PlanarSurfaceGroup {
@@ -445,20 +468,38 @@ class MODEL_API Space : public PlanarSurfaceGroup {
     assert methods["realMethod"] == "double"
 
 
-def test_overload_first_declaration_wins(tmp_path):
-    """Matches _signatures' existing `setdefault` first-occurrence-wins convention."""
+def test_overloads_with_different_returns_are_joined(tmp_path):
+    # Regression: SqlFile#timeSeries rendered only the first overload (Array<TimeSeries>),
+    # hiding the boost::optional<TimeSeries> form that needs .get in Ruby
     src = """
 class MODEL_API Model : public Workspace {
  public:
     bool addObject(const IdfObject& idf);
     boost::optional<double> addObject(int index);
+    bool addObject(const std::string& text);
 };
 """
     methods = _parse_header(_write(tmp_path, "M.hpp", src))["Model"]
-    assert methods["addObject"] == "bool"
+    # Declaration order, same raw type recorded once
+    assert methods["addObject"] == "bool | boost::optional<double>"
+    assert map_cpp_type(methods["addObject"]) == "Boolean | Float, nil"
+
+
+def test_overloads_with_same_rendered_return_stay_single(tmp_path):
+    # Validates: const Foo& vs Foo overloads render one type, not "Foo | Foo"
+    src = """
+class MODEL_API Surface : public PlanarSurface {
+ public:
+    std::vector<Surface> splitSurfaceForSubSurfaces();
+    const std::vector<Surface>& splitSurfaceForSubSurfaces(double offset);
+};
+"""
+    methods = _parse_header(_write(tmp_path, "S.hpp", src))["Surface"]
+    assert map_cpp_type(methods["splitSurfaceForSubSurfaces"]) == "Array<Surface>"
 
 
 def test_default_arguments_do_not_break_parsing(tmp_path):
+    # Validates: default arguments (overwrite = false) do not break parameter parsing
     src = """
 class MODEL_API AdditionalProperties : public ModelObject {
  public:
@@ -477,6 +518,7 @@ class MODEL_API AdditionalProperties : public ModelObject {
 
 
 def test_build_skips_impl_headers(tmp_path):
+    # Validates: *_Impl.hpp detail headers are never parsed into the public type map
     """*_Impl.hpp are detail:: internals, never the public Ruby API."""
     model = tmp_path / "model"
     model.mkdir()
@@ -496,6 +538,7 @@ def test_build_skips_impl_headers(tmp_path):
 
 
 def test_build_discovers_nested_submodule_headers(tmp_path):
+    # Regression: RunControl/AirflowPath in airflow/contam/PrjObjects.hpp missed by glob('model/*.hpp')
     """Real: ``RunControl`` and ``AirflowPath`` are both declared in
     ``airflow/contam/PrjObjects.hpp`` — a nested subdir, and a filename matching
     neither class. The old ``glob("model/*.hpp")`` never saw them.
@@ -518,6 +561,7 @@ class OS_AIRFLOW_API AirflowPath : public AirflowObject {
 
 
 def test_build_skips_impl_headers_in_nested_subdirs(tmp_path):
+    # Validates: the *_Impl.hpp skip applies in nested subdirs (utilities/sql), not just model/
     """The *_Impl.hpp skip applies everywhere, not just model/."""
     _write_tree(
         tmp_path, "model/ThermalZone.hpp",
@@ -538,6 +582,7 @@ def test_build_skips_impl_headers_in_nested_subdirs(tmp_path):
 
 
 def test_build_model_precedence_over_submodule(tmp_path):
+    # Validates: model/ declaration wins over a same-named submodule declaration
     """First-declaration-wins with model/ parsed first: a method declared in both
     model/ and a submodule keeps the model declaration.
     """
@@ -554,6 +599,7 @@ def test_build_model_precedence_over_submodule(tmp_path):
 
 
 def test_build_parses_extend_in_nested_subdir(tmp_path):
+    # Validates: %extend blocks in .i files outside model/ are found by recursion
     """SWIG %extend blocks live in .i files outside model/ too; recursion must find
     them so those methods get types (headers alone don't declare them).
     """
@@ -568,6 +614,7 @@ def test_build_parses_extend_in_nested_subdir(tmp_path):
 
 
 def test_build_hpp_declaration_wins_over_extend(tmp_path):
+    # Validates: .hpp declaration beats a same-method %extend regardless of directory
     """A real .hpp declaration beats a %extend of the same method even when the
     %extend sits in model/ — the .hpp-before-.i ordering is global, not per-module.
     """
@@ -586,6 +633,7 @@ def test_build_hpp_declaration_wins_over_extend(tmp_path):
 
 
 def test_parses_struct_classes(tmp_path):
+    # Regression: 'struct UTILITIES_API IstringFind' was dropped because only 'class' matched
     """Real: `struct UTILITIES_API IstringFind` (Compare.hpp) and
     `struct ISOMODEL_API ISOResults` (SimModel.hpp) — the class regex only matched
     `class` and silently dropped every struct.
@@ -603,6 +651,7 @@ struct UTILITIES_API IstringFind
 
 
 def test_nested_struct_does_not_hijack_enclosing_class(tmp_path):
+    # Regression: nested struct CalendarDay stole every following Calendar method
     """Real: Calendar.hpp — `struct CalendarDay` sits inside `class Calendar`; without
     nesting tracking, the struct stole every method that followed it and Calendar got
     none (its logChannel and accessors rendered unknown).
@@ -628,6 +677,7 @@ class UTILITIES_API Calendar
 
 
 def test_getters_ending_in_close_brace_do_not_close_the_class(tmp_path):
+    # Regression: EpwFile.hpp inline getters ending '};' closed the class early
     """Real: EpwFile.hpp — getters are written `std::string x() const {` / `return …;` /
     `};` — each getter's closing line looks exactly like a class close. Brace-depth
     tracking must keep the class open (the getter close stays at the class depth, the
@@ -656,6 +706,7 @@ class UTILITIES_API EpwHoliday
 
 
 def test_constructor_initializer_list_is_not_a_declaration(tmp_path):
+    # Regression: EpwHoliday initializer list parsed as bogus m_holidayName method with type ':'
     """Real: EpwFile.hpp — `EpwHoliday(const std::string& a, const std::string& b)` is
     followed by `: m_holidayName(holidayName), m_holidayDateString(holidayDateString){};`.
     The ctor line ends with `)` so it is flushed as a (skipped) candidate, and the
@@ -675,6 +726,7 @@ class UTILITIES_API EpwHoliday
 
 
 def test_build_reads_hxx_declarations(tmp_path):
+    # Regression: IddFactory.hxx was never read so IddFactory rendered unknown
     """Real: IddFactory is declared in utilities/idd/IddFactory.hxx — a .hxx, which
     the old glob never read, so IddFactory rendered unknown.
     """
@@ -687,6 +739,7 @@ def test_build_reads_hxx_declarations(tmp_path):
 
 
 def test_build_applies_module_scoped_class_rename(tmp_path):
+    # Regression: %rename(ZUnit) openstudio::Unit left ZUnit without Unit methods
     """Real: `%rename(ZUnit) openstudio::Unit;` — the exposed name differs from the
     declared one. The %extend on openstudio::Unit must also surface as ZUnit.
     """
@@ -704,6 +757,7 @@ def test_build_applies_module_scoped_class_rename(tmp_path):
 
 
 def test_build_rename_does_not_cross_modules(tmp_path):
+    # Regression: six ForwardTranslator renames bled across modules (Sdd inherited Contam methods)
     """Real: six modules declare a `ForwardTranslator`; each is renamed to its own
     XForwardTranslator. The rename must apply per module — sdd's rename must not
     alias airflow's class, or SddForwardTranslator would inherit Contam's methods.
@@ -730,6 +784,7 @@ def test_build_rename_does_not_cross_modules(tmp_path):
 
 
 def test_build_applies_method_rename(tmp_path):
+    # Regression: %rename(toString) OSArgument::print left toString untyped
     """Real: `%rename(toString) openstudio::measure::OSArgument::print;` — a method
     rename: the header declares print, the exposed name is toString.
     """
@@ -747,6 +802,7 @@ def test_build_applies_method_rename(tmp_path):
 
 
 def test_build_applies_inline_swig_class_rename(tmp_path):
+    # Regression: inline 'class any' in CommonImport.i renamed to Any surfaced with no methods
     """Real: CommonImport.i defines `class any { ... }` inline and renames it:
     `%rename(Any) boost::any;` — the inline class's methods must surface as Any.
     """
@@ -763,17 +819,20 @@ def test_build_applies_inline_swig_class_rename(tmp_path):
 
 
 def test_locate_header_dir_honours_env_override(tmp_path, monkeypatch):
+    # Validates: OSMCP_OPENSTUDIO_INCLUDE overrides header directory discovery
     monkeypatch.setenv("OSMCP_OPENSTUDIO_INCLUDE", str(tmp_path))
     assert _locate_header_dir() == tmp_path
 
 
 def test_locate_header_dir_returns_none_when_missing(tmp_path, monkeypatch):
+    # Validates: missing header dir returns None (wheel-only install), not an error
     """No headers is not an error — a wheel-only box simply has no type source."""
     monkeypatch.setenv("OSMCP_OPENSTUDIO_INCLUDE", str(tmp_path / "does-not-exist"))
     assert _locate_header_dir() is None
 
 
 def test_no_name_based_guessing_remains():
+    # Regression: _infer_return_type guessed isConditioned -> Boolean; the name-guesser must stay deleted
     """Guard the core invariant: types are sourced, never inferred from the method name.
 
     `_infer_return_type` guessed `ThermalZone#isConditioned -> Boolean` (really an
@@ -783,3 +842,51 @@ def test_no_name_based_guessing_remains():
     from mcp_server.skills.api_reference import _signatures
 
     assert not hasattr(_signatures, "_infer_return_type")
+
+
+# --------------------------------------------------------------------------------------
+# per-module header precedence (class names reused across modules)
+# --------------------------------------------------------------------------------------
+
+
+def test_build_by_module_keeps_same_named_classes_apart(tmp_path):
+    # Regression: airflow's ForwardTranslator (alphabetically first) shadowed energyplus's in
+    # the merge, so openstudio.energyplus.ForwardTranslator#translateModel rendered Object, nil
+    _write_tree(
+        tmp_path, "airflow/contam/ForwardTranslator.hpp",
+        "class AIRFLOW_API ForwardTranslator {\n public:\n"
+        "    boost::optional<IndexModel> translateModel(const Model& model);\n};\n",
+    )
+    _write_tree(
+        tmp_path, "energyplus/ForwardTranslator.hpp",
+        "class ENERGYPLUS_API ForwardTranslator {\n public:\n"
+        "    Workspace translateModel(const Model& model, ProgressBar* progressBar = nullptr);\n"
+        "};\n",
+    )
+    by_module = _build_by_module(tmp_path)
+    assert by_module["energyplus"]["ForwardTranslator"]["translateModel"] == "Workspace"
+    assert by_module["airflow"]["ForwardTranslator"]["translateModel"] == (
+        "boost::optional<IndexModel>"
+    )
+    # The merged view still picks airflow (first declaration wins) — which is exactly why
+    # _signatures resolves through the bindings module first.
+    assert _build(tmp_path)["ForwardTranslator"]["translateModel"] == "boost::optional<IndexModel>"
+
+
+@pytest.mark.parametrize(
+    ("wrapper_stem", "expected"),
+    [
+        ("openstudioenergyplus", "energyplus"),
+        ("openstudiomodelcore", "model"),
+        ("openstudiomodelgeometry", "model"),
+        ("openstudioutilitiessql", "utilities"),
+        ("openstudioairflow", "airflow"),
+        ("openstudiogbxml", "gbxml"),
+        ("openstudiomeasure", "measure"),
+        ("openstudioopenstudio", None),
+    ],
+)
+def test_header_module_for_maps_wrapper_stems(wrapper_stem, expected):
+    # Validates: every shipped wrapper stem resolves to its include subdir by longest prefix
+    modules = ["model", "utilities", "energyplus", "airflow", "gbxml", "measure", "isomodel"]
+    assert header_module_for(wrapper_stem, modules) == expected

--- a/tests/test_api_signatures_unit.py
+++ b/tests/test_api_signatures_unit.py
@@ -17,8 +17,10 @@ import pytest
 from mcp_server.skills.api_reference._headers import (
     _build,
     _build_by_module,
+    _build_typedefs,
     _locate_header_dir,
     _parse_header,
+    _parse_typedefs,
     header_module_for,
     map_cpp_type,
 )
@@ -890,3 +892,85 @@ def test_header_module_for_maps_wrapper_stems(wrapper_stem, expected):
     # Validates: every shipped wrapper stem resolves to its include subdir by longest prefix
     modules = ["model", "utilities", "energyplus", "airflow", "gbxml", "measure", "isomodel"]
     assert header_module_for(wrapper_stem, modules) == expected
+
+
+# --------------------------------------------------------------------------------------
+# typedef / using aliases (OptionalTime, Point3dVector, ...)
+# --------------------------------------------------------------------------------------
+
+
+def test_parse_typedefs_collects_using_and_typedef_forms(tmp_path):
+    # Regression: TimeSeries#intervalLength returns the alias OptionalTime, which rendered as
+    # Object because no source resolved the alias to boost::optional<Time>
+    src = """
+namespace openstudio {
+using OptionalTime = boost::optional<Time>;
+typedef std::vector<Point3d> Point3dVector;
+// using OptionalDouble = boost::optional<double>;
+/* typedef std::vector<int> IntVector; */
+template <class T> using Wrapped = std::vector<T>;
+class UTILITIES_API TimeSeries {
+ public:
+  using OptionalUnsigned = boost::optional<unsigned int>;
+};
+}
+"""
+    assert _parse_typedefs(_write(tmp_path, "T.hpp", src)) == {
+        "OptionalTime": "boost::optional<Time>",
+        "Point3dVector": "std::vector<Point3d>",
+        "OptionalUnsigned": "boost::optional<unsigned int>",
+    }
+
+
+_TYPEDEFS = {
+    "OptionalTime": "boost::optional<Time>",
+    "OptionalUnsigned": "boost::optional<unsigned int>",
+    "Point3dVector": "std::vector<Point3d>",
+    "Point3dVectorVector": "std::vector<Point3dVector>",
+    "OptionalIddObjectTypeVector": "boost::optional<std::vector<IddObjectType>>",
+    "Loop": "Loop",
+    "string": "std::wstring",
+}
+
+
+@pytest.mark.parametrize(
+    ("cpp", "expected"),
+    [
+        ("OptionalTime", "Time, nil"),
+        ("const OptionalTime&", "Time, nil"),
+        ("OptionalUnsigned", "Integer, nil"),
+        ("Point3dVector", "Array<Point3d>"),
+        ("Point3dVectorVector", "Array<Array<Point3d>>"),
+        ("OptionalIddObjectTypeVector", "Array<IddObjectType>, nil"),
+        ("std::vector<Point3dVector>", "Array<Array<Point3d>>"),
+        ("openstudio::OptionalTime", "Time, nil"),  # TimeSeries::intervalLength declares it qualified
+        ("openstudio::model::Point3d", "Point3d"),
+        ("std::map<std::string, Point3dVector>", "Object"),
+        ("std::string", "String"),  # a header aliases `string` to std::wstring; primitives win
+        ("boost::optional<std::string>", "String, nil"),
+        ("Loop", "Object"),  # self-referential alias must terminate, not recurse forever
+        ("NotAnAlias", "Object"),
+    ],
+)
+def test_map_cpp_type_resolves_typedef_aliases(cpp, expected):
+    # Regression: OptionalModelObject / Point3dVector / StringVector returns rendered Object
+    # (10 bound methods on 3.11.0), hiding the Optional and Array shapes agents must handle
+    classes = {"Time", "Point3d", "IddObjectType"}
+    assert map_cpp_type(cpp, classes, _TYPEDEFS) == expected
+
+
+def test_map_cpp_type_without_typedefs_is_unchanged():
+    # Validates: callers that pass no alias table keep the pre-alias behaviour (Object)
+    assert map_cpp_type("OptionalTime", {"Time"}) == "Object"
+
+
+def test_build_typedefs_walks_nested_dirs_model_first(tmp_path):
+    # Validates: aliases are gathered from every module dir, model/ declaration winning a clash
+    _write_tree(tmp_path, "model/ModelObject.hpp", "using OptionalX = boost::optional<ModelX>;\n")
+    _write_tree(tmp_path, "utilities/core/Optional.hpp",
+                "using OptionalX = boost::optional<UtilX>;\nusing OptionalDouble = boost::optional<double>;\n")
+    _write_tree(tmp_path, "utilities/core/Optional_Impl.hpp", "using OptionalHidden = boost::optional<int>;\n")
+    assert _build_typedefs(tmp_path) == {
+        "OptionalX": "boost::optional<ModelX>",
+        "OptionalDouble": "boost::optional<double>",
+    }


### PR DESCRIPTION
## Summary

Fixes #137 

`search_api` now searches the public OpenStudio namespaces instead of only `openstudio.model`, and its method entries carry signatures sourced from the SDK headers and SWIG wrapper declarations.

This makes the result useful at the point where a measure author needs it. A caller can now see that `SqlFile` lives in the root `openstudio` namespace and that `execAndReturnFirstDouble` takes a statement and returns an optional `Float`, rather than guessing either fact.

## What changed

- Search the root `openstudio` namespace, `openstudio.model`, and the supported non-model modules (`airflow`, `isomodel`, `gltf`, `radiance`, `sdd`, `energyplus`, `osversion`, and `measure`).
- Report the namespace in a new `module` field.
- Deduplicate classes exposed through SWIG aliases and omit container plumbing such as `Optional*`, `*Vector`, and `SwigPyIterator`.
- Parse parameter names and return types from the SDK headers and wrapper declarations. Optional returns are rendered explicitly, for example `Float, nil`; types are not inferred from method names.
- Preserve the existing class cap, method filtering, method grouping, and `include_base` behavior. ModelObject methods are excluded only for model classes when requested; non-model classes such as `SqlFile` are unaffected.

The implementation is in `mcp_server/skills/api_reference/operations.py`, with signature parsing in `_headers.py` and `_signatures.py`. The API-reference test suite covers namespace discovery, alias deduplication, signature rendering, optional types, and the response-size boundary.

## Reproducible before/after check

The comparison uses the same OpenStudio SDK and the same MCP request against two pinned, locally built `linux/amd64` images.
Both images report:

```text
OpenStudio Python: 3.11.0
OpenStudio CLI:    3.11.0+241b8abb4d
MCP server:        1.2.1
```

The images were built with separate, immutable comparison tags, a baseline and a modified. To test the responses, use your existing MCP image and compare it with the image modified with the changes in this PR.

### Request

The exact MCP request was:

```json
{
  "class_pattern": "SqlFile",
  "method_pattern": "availableEnvPeriods|execAndReturnFirstDouble",
  "max_classes": 10,
  "include_base": true
}
```

Because this comparison is about the server contract, the response was obtained with a direct MCP stdio client (`mcp.ClientSession` and `stdio_client`), not by asking an LLM to paraphrase it. The client starts each image independently and calls the MCP protocol's `search_api` tool. Re-run it with:

```Python
import asyncio
import json
from pathlib import Path

from mcp import ClientSession, StdioServerParameters
from mcp.client.stdio import stdio_client

ROOT = Path.cwd()
COMMON_ARGS = [
    "run",
    "--rm",
    "-i",
    "--platform",
    "linux/amd64",
    "-v",
    f"{ROOT / 'tests/assets'}:/inputs:ro",
    "-v",
    f"{ROOT / 'runs'}:/runs",
    "-v",
    f"{ROOT / 'measures'}:/measures",
    "-v",
    f"{ROOT / '.claude/skills'}:/skills:ro",
    "-e",
    "OPENSTUDIO_MCP_MODE=prod",
    "-e",
    "OSMCP_SANDBOX=posix", # This is only needed on Mac
]
# Change the TAG names to whatever you decided to name them
TAGS = [
    "openstudio-mcp:baseline-0e11fd1-amd64",
    "openstudio-mcp:modified-7c17545-amd64",
]
ARGS = {
    "class_pattern": "SqlFile",
    "method_pattern": "availableEnvPeriods|execAndReturnFirstDouble",
    "max_classes": 10,
    "include_base": True,
}
OUTPUT = ROOT / "runs/direct-mcp-compare.json"


async def call(tag: str) -> dict:
    params = StdioServerParameters(
        command="docker",
        args=[*COMMON_ARGS, tag, "openstudio-mcp"],
    )
    async with stdio_client(params) as (read, write):
        async with ClientSession(read, write) as session:
            await session.initialize()
            result = await session.call_tool("search_api", ARGS)
            text = result.content[0].text
            return {"image": tag, "args": ARGS, "response": json.loads(text)}


async def main() -> None:
    records = []
    for tag in TAGS:
        records.append(await call(tag))
    OUTPUT.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8")
    print(json.dumps(records))


asyncio.run(main())
```
### Before: baseline response

```json
{
  "ok": true,
  "classes": [],
  "query": "SqlFile"
}
```

The class exists in the SDK, but the baseline search scope cannot see it.

### After: modified response

```json
{
  "ok": true,
  "classes": [
    {
      "class_name": "SqlFile",
      "module": "openstudio",
      "setters": [],
      "getters": [],
      "other": [
        "availableEnvPeriods() -> Array<String>",
        "execAndReturnFirstDouble(statement) -> Float, nil"
      ]
    },
    {
      "class_name": "SqlFileTimeSeriesQuery",
      "module": "openstudio",
      "setters": [],
      "getters": [],
      "other": []
    }
  ],
  "query": "SqlFile"
}
```

The modified response exposes both the root namespace and the actionable method signatures. In particular, `Float, nil` tells the caller to handle a no-result query instead of an assumed value.

This is a deterministic MCP regression check; it is deliberately not presented as a stochastic LLM-quality score.

## Verification

Fast unit coverage:

```text
$ uv run --no-project pytest -q tests/test_api_reference_unit.py tests/test_api_signatures_unit.py
67 passed in 0.15s
```

The full API-reference integration file passes inside the modified amd64 image:

```text
$ docker run --rm --platform linux/amd64 \
    -e OPENSTUDIO_MCP_MODE=prod \
    openstudio-mcp:modified-7c17545-amd64 \
    bash -lc 'cd /repo && pytest -q tests/test_api_reference.py'
30 passed in 4.62s
```
I have anecdotally verified that, for the same prompt, using local LLM models (or small online-hosted ones), it takes fewer turns to write a measure that uses the new return values for search_api.

## Compatibility

The response retains the existing top-level `ok`, `classes`, and `query` keys, as well as method grouping, filtering, and class limit. New responses add `module` and replace bare method names with signature strings. Consumers that treated method entries as display-only names should strip the signature at the first `(`; the additional information is intentional and is the point of this change.
