### PR TITLE
Validate served skill docs against real tool signatures, and fix the mismatches

### DIFF
--- a/.claude/skills/add-hvac/SKILL.md
+++ b/.claude/skills/add-hvac/SKILL.md
@@ -73,7 +73,7 @@ create_typical_building(system_type="PVAV with gas boiler reheat",
     template="90.1-2019", climate_zone="ASHRAE 169-2013-5A", hvac_only=True)
 save_osm_model(...); run_simulation(...)   # then next candidate
 
-compare_runs(run_id_a, run_id_b)           # EUI + unmet-hours deltas
+compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-hours deltas
 ```
 
 ## Notes

--- a/.claude/skills/add-hvac/eval.md
+++ b/.claude/skills/add-hvac/eval.md
@@ -4,11 +4,11 @@
 | "Add HVAC to the model" | add_baseline_system | system_type, thermal_zone_names |
 | "Set up heating and cooling" | add_baseline_system OR add_vrf_system | — |
 | "What HVAC system should I use?" | list_baseline_systems, get_baseline_system_info | — |
-| "Add a VAV system" | add_baseline_system | system_type=7 |
+| "Add a VAV reheat system with a chiller and boiler plant" | add_baseline_system | system_type=7 |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "Change the coil efficiency" | Component property — use set_component_properties |
-| "Add a boiler to the loop" | Loop surgery — use add_supply_equipment |
-| "What air loops exist?" | Query — use list_air_loops |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Change the coil efficiency" | add_baseline_system, add_doas_system, add_vrf_system, add_radiant_system | set_component_properties, get_component_properties, list_model_objects |
+| "Add a boiler to the loop" | add_baseline_system, add_doas_system | add_supply_equipment, list_plant_loops |
+| "What air loops exist?" | add_baseline_system, add_doas_system, add_vrf_system | list_air_loops |

--- a/.claude/skills/energy-report/eval.md
+++ b/.claude/skills/energy-report/eval.md
@@ -2,12 +2,12 @@
 | Query | Expected tools | Critical params |
 |---|---|---|
 | "Give me a full energy report" | extract_summary_metrics, extract_end_use_breakdown, extract_envelope_summary, extract_hvac_sizing, extract_zone_summary | run_id |
-| "Detailed analysis of results" | extract_* tools | run_id |
-| "What are the full simulation results?" | extract_* tools | run_id |
+| "Detailed analysis of results" | extract_summary_metrics, extract_end_use_breakdown, extract_envelope_summary, extract_hvac_sizing, extract_zone_summary | run_id |
+| "What are the full simulation results?" | extract_summary_metrics, extract_end_use_breakdown, extract_envelope_summary, extract_hvac_sizing, extract_zone_summary | run_id |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "What's the EUI?" | Single metric — use extract_summary_metrics directly |
-| "Run the simulation" | Simulation — use simulate skill |
-| "Show me monthly electricity" | Timeseries — use query_timeseries |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "What's the EUI?" | extract_end_use_breakdown, extract_envelope_summary, extract_hvac_sizing, extract_zone_summary | extract_summary_metrics |
+| "Run the simulation" | generate_results_report | run_simulation, save_osm_model |
+| "Show me monthly electricity" | extract_end_use_breakdown, generate_results_report | query_timeseries, list_output_variables |

--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -7,7 +7,7 @@ description: Translate a Revit-exported gbXML file into an OpenStudio model, the
 
 ## Workflow
 
-1. `import_gbxml(gbxml_path, epw_path[, osm_path, run_name])` — needs four files under
+1. `import_gbxml(gbxml_path=..., epw_path=..., ...)` (optional `osm_path`, `run_name`) — needs four files under
    `/inputs`: the gbXML file, its project EPW, and the EPW's companion `.stat`/`.ddy` files
    (same directory, same filename stem as the EPW). Result auto-loads the model and always
    returns a `climate_zone` (+ `climate_zone_source`) unless truly unresolvable — if

--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -49,21 +49,21 @@ apply_measure(measure_dir="/measures/<user>/custom/set_lights_8w")
 ### 4. Verify Results (Before/After Comparison)
 For rigorous validation, run a baseline simulation BEFORE applying the measure:
 ```
-save_osm_model(save_path="/runs/baseline.osm")
+save_osm_model(osm_path="/runs/baseline.osm")
 run_simulation(osm_path="/runs/baseline.osm", epw_path="<epw>")
 extract_summary_metrics(run_id=<baseline_id>)   # record baseline EUI
 
 # reload, apply measure, re-simulate
 load_osm_model(osm_path="<original>")
 apply_measure(measure_dir="/measures/<user>/custom/set_lights_8w")
-save_osm_model(save_path="/runs/retrofit.osm")
+save_osm_model(osm_path="/runs/retrofit.osm")
 run_simulation(osm_path="/runs/retrofit.osm", epw_path="<epw>")
 extract_summary_metrics(run_id=<retrofit_id>)   # compare to baseline
 ```
 
 ## Language Choice
 
-Both are **fully supported** — `create_measure(language="Ruby"|"Python")` scaffolds, tests
+Both are **fully supported** — `create_measure(language="Ruby"|"Python", ...)` scaffolds, tests
 (minitest for Ruby, pytest for Python), and applies either. Pick per the user's request or
 project convention:
 

--- a/.claude/skills/new-building/SKILL.md
+++ b/.claude/skills/new-building/SKILL.md
@@ -86,7 +86,7 @@ For fully custom buildings not matching DOE prototypes:
 
 After any workflow:
 ```
-save_osm_model(save_path="/runs/<name>.osm")
+save_osm_model(osm_path="/runs/<name>.osm")
 run_simulation(osm_path="/runs/<name>.osm", epw_path="/inputs/<city>.epw")
 get_run_status(run_id=<id>)
 extract_summary_metrics(run_id=<id>)

--- a/.claude/skills/new-building/eval.md
+++ b/.claude/skills/new-building/eval.md
@@ -16,4 +16,4 @@
 | "What spaces are in the model?" | create_new_building, create_bar_building | list_spaces, get_model_summary |
 | "Add a boiler to the hot water loop" | create_new_building, create_bar_building | add_supply_equipment, list_plant_loops |
 | "Run the simulation" | create_new_building, create_bar_building | run_simulation, load_osm_model, list_files |
-| "Add HVAC to the building" | create_new_building, create_bar_building | add_baseline_system, list_thermal_zones, list_baseline_systems |
+| "Add HVAC to the building" | create_new_building, create_bar_building | add_baseline_system, list_thermal_zones, list_baseline_systems, get_model_summary, load_osm_model |

--- a/.claude/skills/new-building/eval.md
+++ b/.claude/skills/new-building/eval.md
@@ -11,9 +11,9 @@
 | "Create a complete building with weather" | create_new_building | weather_file present |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "What spaces are in the model?" | Query — use list_spaces |
-| "Add a boiler to the hot water loop" | Modification — use add_supply_equipment |
-| "Run the simulation" | Simulation — use simulate skill |
-| "Add HVAC to the building" | HVAC — use add-hvac skill |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "What spaces are in the model?" | create_new_building, create_bar_building | list_spaces, get_model_summary |
+| "Add a boiler to the hot water loop" | create_new_building, create_bar_building | add_supply_equipment, list_plant_loops |
+| "Run the simulation" | create_new_building, create_bar_building | run_simulation, load_osm_model, list_files |
+| "Add HVAC to the building" | create_new_building, create_bar_building | add_baseline_system, list_thermal_zones, list_baseline_systems |

--- a/.claude/skills/openstudio-patterns/SKILL.md
+++ b/.claude/skills/openstudio-patterns/SKILL.md
@@ -13,7 +13,7 @@ Objects must be created in dependency order. Arrows mean "must exist before."
 ```
 Materials
   └─> Constructions
-        └─> assign_construction_to_surface (needs Surface + Construction)
+        └─> assign_construction_to_surface(...) — needs Surface + Construction
 
 Spaces (geometry)
   ├─> Surfaces (auto-created by create_space_from_floor_print)

--- a/.claude/skills/python-ems/SKILL.md
+++ b/.claude/skills/python-ems/SKILL.md
@@ -31,11 +31,11 @@ template fits.
                         rules=[{"days": "weekdays", "start_hour": 5, "end_hour": 19, "value": 21.0}])
    ```
 4. `save_osm_model()` — the script lives in the model's companion `files/` dir and travels with it.
-5. `run_simulation(...)`, then verify the plugin loaded: `extract_simulation_errors(run_id)`
+5. `run_simulation(...)`, then verify the plugin loaded: `extract_simulation_errors(run_id=<run_id>)`
    should show no severe messages; the .err file logs `PythonPlugin: Class X imported`.
 6. Read the plugin's outputs:
    ```
-   query_timeseries(run_id, variable_name="PythonPlugin:OutputVariable",
+   query_timeseries(run_id=<run_id>, variable_name="PythonPlugin:OutputVariable",
                     key_value="Night Setback Applied Value")
    ```
 
@@ -97,7 +97,7 @@ first for valid actuator triples.
   For third-party packages (numpy etc.): `install_plugin_packages(["numpy"])`
   first — wheels-only, quota-capped, wired in automatically. `pkg==version`
   pins allowed; URLs/paths are not.
-- To revise a plugin: `edit_python_plugin(name, code)` (validated; the class
+- To revise a plugin: `edit_python_plugin(name=..., code=...)` (validated; the class
   name must stay unchanged). `delete_object` on the instance removes it.
 - `trend_timesteps=N` on create logs the plugin global as a
   PythonPlugin:TrendVariable for `get_trend_average/min/max` history access.

--- a/.claude/skills/qaqc/SKILL.md
+++ b/.claude/skills/qaqc/SKILL.md
@@ -31,19 +31,21 @@ Inspect the current model for common issues before running a simulation.
 
 4. Run ASHRAE QA/QC checks (if model has been simulated):
    ```
-   run_qaqc_checks(template="90.1-2019")
+   run_qaqc_checks(run_id=<completed run_id>, template="90.1-2019")
    ```
 
-5. Report findings organized by severity:
+5. Report findings organized by severity (same buckets `validate_model` uses):
 
    **Errors** (will cause simulation failure):
-   - Missing weather file
+   - Missing design days (HVAC sizing fails)
+   - Air loops serving no thermal zones (EnergyPlus fatal)
+   - Single-zone setpoint managers without a control zone (EnergyPlus fatal)
+
+   **Warnings** (may fail later or produce bad results):
+   - No weather file on the model (can still pass epw_path to run_simulation)
    - Zones with no HVAC and no ideal air loads
    - Surfaces with no construction
-
-   **Warnings** (may produce bad results):
    - Zones with no loads (people, lights, equipment)
-   - Missing design days (HVAC won't autosize)
    - No run period set (only sizing runs)
    - Unmet hours above threshold
 

--- a/.claude/skills/qaqc/eval.md
+++ b/.claude/skills/qaqc/eval.md
@@ -1,14 +1,14 @@
 ## Should trigger
 | Query | Expected tools | Critical params |
 |---|---|---|
-| "Check the model for issues" | run_qaqc_checks, inspect_osm_summary | — |
-| "Validate before simulation" | run_qaqc_checks | — |
-| "QA/QC the model" | run_qaqc_checks | template |
-| "Is my model ready to simulate?" | inspect_osm_summary, run_qaqc_checks | — |
+| "Check the model for issues" | run_qaqc_checks, inspect_osm_summary, validate_model | — |
+| "Validate before simulation" | validate_model OR run_qaqc_checks | — |
+| "QA/QC the model against ASHRAE 90.1-2019" | run_qaqc_checks | template=90.1-2019 |
+| "Is my model ready to simulate?" | validate_model, inspect_osm_summary, run_qaqc_checks | — |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "Run the simulation" | Simulation — use simulate skill |
-| "What's wrong with my results?" | Post-sim — use troubleshoot skill |
-| "List the spaces" | Query — use list_spaces |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Run the simulation" | run_qaqc_checks, validate_osw | run_simulation, save_osm_model |
+| "What's wrong with my results?" | inspect_osm_summary | extract_summary_metrics, get_run_logs, extract_simulation_errors |
+| "List the spaces" | run_qaqc_checks, inspect_osm_summary | list_spaces |

--- a/.claude/skills/retrofit/SKILL.md
+++ b/.claude/skills/retrofit/SKILL.md
@@ -13,7 +13,7 @@ Apply energy conservation measures to an existing model and compare before/after
 ### 1. Establish Baseline
 Ensure a simulation has been run on the current model. If not:
 ```
-save_osm_model(save_path="/runs/baseline.osm")
+save_osm_model(osm_path="/runs/baseline.osm")
 run_simulation(osm_path="/runs/baseline.osm", epw_path="<epw>")
 get_run_status(run_id=<id>)
 extract_summary_metrics(run_id=<baseline_id>)
@@ -39,10 +39,10 @@ Ask the user which upgrades to apply. Available ECM tools:
 **HVAC/Controls:**
 - `adjust_thermostat_setpoints(cooling_offset_f=2.0, heating_offset_f=-2.0)` — widen deadband
 - `replace_thermostat_schedules(...)` — new thermostat schedules
-- `shift_schedule_time(shift_value_hours=1)` — shift occupancy/HVAC schedules
+- `shift_schedule_time(schedule_name="<schedule>", shift_hours=1)` — shift occupancy/HVAC schedules
 
 **Renewables:**
-- `add_rooftop_pv(fraction_of_roof=0.5)` — rooftop solar
+- `add_rooftop_pv(fraction_of_surface=0.5)` — rooftop solar
 - `add_pv_to_shading(...)` — PV on shading surfaces
 
 **Loads:**
@@ -57,7 +57,7 @@ See [ecm-catalog.md](ecm-catalog.md) for typical savings ranges.
 
 ### 4. Re-Simulate
 ```
-save_osm_model(save_path="/runs/retrofit.osm")
+save_osm_model(osm_path="/runs/retrofit.osm")
 run_simulation(osm_path="/runs/retrofit.osm", epw_path="<epw>")
 get_run_status(run_id=<id>)
 extract_summary_metrics(run_id=<retrofit_id>)

--- a/.claude/skills/retrofit/eval.md
+++ b/.claude/skills/retrofit/eval.md
@@ -9,6 +9,6 @@
 ## Should NOT trigger
 | Query | Forbidden tools | Expected alternatives |
 |---|---|---|
-| "Change wall insulation" | compare_runs | create_standard_opaque_material, add_layer_to_construction, assign_construction_to_surface |
+| "Change wall insulation" | compare_runs | create_standard_opaque_material, add_layer_to_construction, assign_construction_to_surface, get_construction_details, list_model_objects |
 | "Run a simulation" | compare_runs | run_simulation, save_osm_model |
 | "Create a new building" | compare_runs, replace_window_constructions | create_new_building, create_bar_building, create_baseline_osm |

--- a/.claude/skills/retrofit/eval.md
+++ b/.claude/skills/retrofit/eval.md
@@ -3,12 +3,12 @@
 |---|---|---|
 | "Compare before and after adding insulation" | save_osm_model, run_simulation, extract_summary_metrics (x2) | — |
 | "What energy savings from better windows?" | replace_window_constructions, run_simulation | — |
-| "Evaluate an ECM" | save baseline, apply measure, run, compare | — |
+| "Evaluate an ECM" | save_osm_model, apply_measure, run_simulation, compare_runs | — |
 | "Do a retrofit analysis" | save_osm_model, run_simulation x2, extract_summary_metrics x2 | — |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "Change wall insulation" | Single modification — use tool-workflows |
-| "Run a simulation" | Simulation only — use simulate skill |
-| "Create a new building" | Creation — use new-building skill |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Change wall insulation" | compare_runs | create_standard_opaque_material, add_layer_to_construction, assign_construction_to_surface |
+| "Run a simulation" | compare_runs | run_simulation, save_osm_model |
+| "Create a new building" | compare_runs, replace_window_constructions | create_new_building, create_bar_building, create_baseline_osm |

--- a/.claude/skills/simulate/SKILL.md
+++ b/.claude/skills/simulate/SKILL.md
@@ -12,12 +12,12 @@ Run a simulation on the currently loaded model and present results.
 
 1. Save the model to a unique path under `/runs/`:
    ```
-   save_osm_model(save_path="/runs/<descriptive_name>.osm")
+   save_osm_model(osm_path="/runs/<descriptive_name>.osm")
    ```
 
-2. Ask the user which weather file to use. They must provide an EPW file path in the docker-mounted input directory. List available files if needed:
+2. Ask the user which weather file to use. They must provide an EPW file path in the docker-mounted input directory. List available weather files if needed:
    ```
-   list_files()
+   list_weather_files()
    ```
 
 3. Run the simulation:
@@ -25,10 +25,13 @@ Run a simulation on the currently loaded model and present results.
    run_simulation(osm_path="<saved_path>", epw_path="<user_epw_path>")
    ```
 
-4. Poll until complete (check every 3-5 seconds):
+4. Poll until complete — first status check ~60 seconds after submitting, then
+   no more than once per minute (every 2-3 minutes for long simulations):
    ```
    get_run_status(run_id=<id>)
    ```
+   Each status check costs a full LLM turn. If your client can wait (e.g. a
+   shell sleep), wait before checking rather than polling back-to-back.
 
 5. Extract key results:
    ```

--- a/.claude/skills/simulate/eval.md
+++ b/.claude/skills/simulate/eval.md
@@ -1,13 +1,13 @@
 ## Should trigger
 | Query | Expected tools | Critical params |
 |---|---|---|
-| "Run a simulation" | save_osm_model, run_simulation, get_run_status | epw_path |
+| "Run a simulation with the Boston weather file" | save_osm_model, run_simulation, get_run_status | epw_path |
 | "Simulate the model" | save_osm_model, run_simulation | — |
 | "Run EnergyPlus" | run_simulation | — |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "Create a new building" | Creation — use new-building skill |
-| "Show me the results" | Results — use energy-report skill |
-| "What's the EUI?" | Query — use extract_summary_metrics directly |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Create a new building" | run_simulation | create_new_building, create_bar_building, create_baseline_osm |
+| "A simulation already completed. Show me the results" | run_simulation | extract_summary_metrics, extract_end_use_breakdown, generate_results_report, list_files |
+| "A simulation already completed. What's the EUI?" | run_simulation | extract_summary_metrics, list_files |

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -41,7 +41,7 @@ assign_construction_to_surface(
 
 Repeat `assign_construction_to_surface` for each target surface, or use
 `replace_window_constructions` for bulk window replacement. Reserve
-`create_construction(material_names=[...])` for building NEW assemblies from
+`create_construction(name=..., material_names=[...])` for building NEW assemblies from
 scratch, where you specify every layer deliberately.
 
 ## Add Internal Loads to a Space
@@ -64,7 +64,7 @@ User must provide an EPW file in the docker-mounted input directory.
 The EPW must have companion `.stat` and `.ddy` files alongside it (same directory, same base filename).
 
 ```
-list_files()                              # find available weather files
+list_weather_files()                      # find available weather files
 change_building_location(weather_file="/inputs/Chicago.epw")
 ```
 
@@ -87,7 +87,7 @@ save_osm_model(osm_path="/runs/sweep_pvav.osm"); run_simulation(...)
 create_typical_building(system_type="PSZ-HP", ..., hvac_only=True)
 save_osm_model(osm_path="/runs/sweep_pszhp.osm"); run_simulation(...)
 
-compare_runs(run_id_a, run_id_b)          # EUI + unmet-hours deltas
+compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-hours deltas
 ```
 
 Do NOT use add_baseline_system/add_doas_system for comparative studies — they
@@ -105,14 +105,13 @@ set_component_properties(component_name="Heating Coil 1",
 ### Economizer
 ```
 set_economizer_properties(air_loop_name="VAV System",
-    economizer_type="DifferentialEnthalpy")
+    properties='{"economizer_control_type": "DifferentialEnthalpy"}')
 ```
 
 ### Plant Loop Sizing
 ```
-set_sizing_properties(component_name="Chilled Water Loop",
-    design_loop_exit_temperature_c=6.67,
-    loop_design_temperature_difference_c=5.56)
+set_sizing_properties(loop_name="Chilled Water Loop",
+    properties='{"design_loop_exit_temperature_c": 6.67, "loop_design_temperature_difference_c": 5.56}')
 ```
 
 ## Apply External Measure
@@ -131,19 +130,19 @@ Full chain: create → test → apply → simulate → compare results.
 
 ```
 # 1. Baseline simulation
-save_osm_model(save_path="/runs/baseline.osm")
+save_osm_model(osm_path="/runs/baseline.osm")
 run_simulation(osm_path="/runs/baseline.osm", epw_path="<epw>")
 extract_summary_metrics(run_id=<baseline_id>)
 
 # 2. Create custom measure
 create_measure(name="my_measure", description="...",
     language="Ruby", run_body="    model.get...each { |x| ... }")
-test_measure(measure_dir="/runs/custom_measures/my_measure")
+test_measure(measure_dir="/measures/<user>/custom/my_measure")  # use the measure_dir returned by create_measure
 
 # 3. Reload original model, apply measure, re-simulate
 load_osm_model(osm_path="<original>")
-apply_measure(measure_dir="/runs/custom_measures/my_measure")
-save_osm_model(save_path="/runs/retrofit.osm")
+apply_measure(measure_dir="/measures/<user>/custom/my_measure")
+save_osm_model(osm_path="/runs/retrofit.osm")
 run_simulation(osm_path="/runs/retrofit.osm", epw_path="<epw>")
 extract_summary_metrics(run_id=<retrofit_id>)
 
@@ -172,10 +171,10 @@ create_measure(name="custom_report", description="...",
     run_body="    val = sql.execAndReturnFirstDouble('SELECT ...')\n    runner.registerValue('metric', val.get) if val.is_initialized")
 
 # 3. Test against completed simulation
-test_measure(measure_dir="/runs/custom_measures/custom_report", run_id="<run_id>")
+test_measure(measure_dir="/measures/<user>/custom/custom_report", run_id="<run_id>")
 
 # 4. Apply to completed simulation
-apply_measure(measure_dir="/runs/custom_measures/custom_report", run_id="<run_id>")
+apply_measure(measure_dir="/measures/<user>/custom/custom_report", run_id="<run_id>")
 ```
 
 ## Object Cleanup

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -12,7 +12,7 @@ disable-model-invocation: true
 1. Check status and logs:
 ```
 get_run_status(run_id=...)
-get_run_logs(run_id=..., log_type="stderr")
+get_run_logs(run_id=..., stream="energyplus")   # stream="openstudio" (default) or "energyplus"
 ```
 
 2. Common fatal errors and fixes:

--- a/.claude/skills/troubleshoot/eval.md
+++ b/.claude/skills/troubleshoot/eval.md
@@ -2,13 +2,13 @@
 | Query | Expected tools | Critical params |
 |---|---|---|
 | "My simulation failed" | get_run_status, get_run_logs | run_id |
-| "EUI looks way too high" | extract_summary_metrics, list_infiltration | run_id |
+| "EUI looks way too high" | extract_summary_metrics, list_model_objects | run_id |
 | "Too many unmet hours" | extract_summary_metrics, extract_component_sizing | run_id |
-| "Why did EnergyPlus crash?" | get_run_logs | run_id, log_type="stderr" |
+| "Why did EnergyPlus crash? Check the EnergyPlus error log" | get_run_logs | run_id, stream=energyplus |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "Run the simulation" | Simulation — use simulate skill |
-| "Check the model before simulating" | Pre-sim QA — use qaqc skill |
-| "Create a new building" | Creation — use new-building skill |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Run the simulation" | get_run_logs, extract_simulation_errors | run_simulation, save_osm_model |
+| "Check the model before simulating" | get_run_logs | validate_model, run_qaqc_checks, inspect_osm_summary, get_model_summary |
+| "Create a new building" | get_run_logs, extract_simulation_errors | create_new_building, create_bar_building, create_baseline_osm |

--- a/.claude/skills/view/SKILL.md
+++ b/.claude/skills/view/SKILL.md
@@ -2,7 +2,7 @@
 name: view
 description: Generate 3D visualization of the current model. Use when user says "show me the model", "visualize", or "view".
 disable-model-invocation: true
-argument-hint: [format]
+argument-hint: [geometry_diagnostics]
 ---
 
 # View Model

--- a/.claude/skills/view/eval.md
+++ b/.claude/skills/view/eval.md
@@ -3,10 +3,10 @@
 |---|---|---|
 | "Show me the model" | view_model | — |
 | "Visualize the building" | view_model | — |
-| "3D view" | view_model | format |
+| "Show me a 3D view highlighting geometry problems" | view_model | geometry_diagnostics=true |
 
 ## Should NOT trigger
-| Query | Why |
-|---|---|
-| "Show me the results" | Results — use energy-report skill |
-| "What does the model contain?" | Query — use get_model_summary |
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "A simulation already completed. Show me the results" | view_model | extract_summary_metrics, view_simulation_data, generate_results_report, list_files |
+| "What does the model contain?" | view_model | get_model_summary, list_spaces |

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -89,7 +89,8 @@ mcp = FastMCP(
         "List tools default to 10 results — use filters to narrow, or "
         "max_results=0 for all. Prefer list tools before detail tools to "
         "find the right name. "
-        "When polling get_run_status, wait at least 1-2 minutes between calls. "
+        "Poll get_run_status no more than once per minute — first check "
+        "~60 s after submitting, every 2-3 minutes for long simulations. "
         "For multi-step workflows, call list_skills() first."
     ),
     auth=_build_auth(),

--- a/mcp_server/skills/prompts_resources/tools.py
+++ b/mcp_server/skills/prompts_resources/tools.py
@@ -46,12 +46,15 @@ def register(mcp):
             f'weather_file="/inputs/{climate_city}.epw")  # builds typical model\n'
             f'2. create_typical_building(system_type="{system_a}", '
             'hvac_only=True)  # standards-tuned swap, loads untouched\n'
-            '3. save_osm_model() and run_simulation()\n'
-            "4. get_run_status() until complete\n"
+            '3. save_osm_model(osm_path="/runs/sweep_a.osm") and '
+            'run_simulation(osm_path="/runs/sweep_a.osm")\n'
+            "4. get_run_status(run_id=<id from run_simulation>) until complete\n"
             f'5. create_typical_building(system_type="{system_b}", '
             'hvac_only=True)  # swap to candidate B on the SAME model\n'
-            "6. save_osm_model() and run_simulation()\n"
-            "7. compare_runs(run_id_a, run_id_b) — EUI, end uses, unmet hours\n\n"
+            '6. save_osm_model(osm_path="/runs/sweep_b.osm") and '
+            'run_simulation(osm_path="/runs/sweep_b.osm")\n'
+            "7. compare_runs(baseline_run_id=<run A id>, "
+            "retrofit_run_id=<run B id>) — EUI, end uses, unmet hours\n\n"
             "Note: system_type takes openstudio-standards names — call "
             "create_typical_building's docs or list them via the tool schema. "
             "Do NOT use add_baseline_system for comparisons; it is a generic "
@@ -86,9 +89,10 @@ def register(mcp):
             "5. add_layer_to_construction(construction_name=<current "
             'construction>, material_name="New_Insulation") — keeps all '
             "existing layers; verify assembly_r_si_after > before\n"
-            "6. assign_construction_to_surface() with the new construction "
-            "for each target surface\n"
-            "7. save_osm_model()"
+            "6. assign_construction_to_surface(surface_name=<target surface>, "
+            "construction_name=<new construction>) for each target surface\n"
+            '7. save_osm_model(osm_path="/runs/retrofit.osm") — save to a '
+            "new path, never over a read-only input"
         )
 
     @mcp.prompt(
@@ -99,19 +103,25 @@ def register(mcp):
         ),
     )
     def full_building_simulation_prompt(
-        system_type: str = "05",
+        system_type: str = "Inferred",
         climate_city: str = "Chicago",
     ) -> str:
+        # system_type takes openstudio-standards names ("VAV chiller with gas
+        # boiler reheat", ...); "Inferred" auto-selects by building type
         return (
-            f"Create a full building model with ASHRAE System {system_type} "
+            f"Create a full building model with HVAC system '{system_type}' "
             f"in {climate_city}, add loads, and simulate.\n\n"
             "Steps:\n"
             f'1. create_new_building(building_type="SmallOffice", '
-            f'weather_file="/inputs/{climate_city}.epw")\n'
+            f'weather_file="/inputs/{climate_city}.epw", '
+            f'system_type="{system_type}")\n'
             "2. list_spaces() — verify geometry and loads\n"
-            "3. save_osm_model() and run_simulation()\n"
-            "4. Poll get_run_status() until complete\n"
-            "5. extract_summary_metrics() — review EUI and unmet hours"
+            '3. save_osm_model(osm_path="/runs/full_building.osm") and '
+            'run_simulation(osm_path="/runs/full_building.osm")\n'
+            "4. Poll get_run_status(run_id=<id from run_simulation>) "
+            "until complete\n"
+            "5. extract_summary_metrics(run_id=<id>) — review EUI and "
+            "unmet hours"
         )
 
     @mcp.prompt(
@@ -162,7 +172,8 @@ def register(mcp):
             "4. get_model_summary() — verify what was added\n"
             "5. list_air_loops() — inspect HVAC\n"
             '6. list_model_objects(object_type="Construction") — inspect envelope\n'
-            "7. save_osm_model()"
+            '7. save_osm_model(osm_path="/runs/typical.osm") — save to a new '
+            "path, never over a read-only input"
         )
 
     @mcp.prompt(
@@ -183,7 +194,8 @@ def register(mcp):
             "5. get_weather_info() — verify weather file is set\n"
             "6. get_run_period() — verify simulation period\n"
             "7. get_simulation_control() — check sizing flags\n"
-            "8. run_qaqc_checks() — automated diagnostics\n"
+            "8. validate_model() — automated pre-flight diagnostics "
+            "(run_qaqc_checks needs a completed simulation)\n"
             "9. Report any issues found before proceeding"
         )
 

--- a/tests/doc_contract_lib.py
+++ b/tests/doc_contract_lib.py
@@ -1,0 +1,340 @@
+"""AST-derived MCP tool contracts + served-doc call extraction/validation.
+
+Pure stdlib (ast/re/pathlib) — never imports mcp_server, so unit tests built
+on this module cannot transitively import OpenStudio (plan finding E2).
+
+Three capabilities:
+  1. load_tool_registry() — AST-parse every mcp_server/skills/*/tools.py and
+     return {mcp_name: ToolSig} with param names, required params, and tags.
+  2. extract_calls(text) — find tool-style calls in served markdown/prompt
+     text (fenced blocks included; ruby/python measure-body fences skipped;
+     quoted strings never fabricate kwargs).
+  3. validate_doc_calls(calls, registry) — flag unknown tools, unknown
+     kwargs, bare-identifier positional args, and missing required args.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_SRC = REPO_ROOT / "mcp_server" / "skills"
+SERVED_SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+
+
+# ---------------------------------------------------------------------------
+# 1. Tool registry from AST
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ToolSig:
+    name: str                  # MCP-visible name from @mcp.tool(name=...)
+    package: str               # owning mcp_server/skills/<package>
+    params: tuple[str, ...]    # all parameter names, in order
+    required: frozenset[str]   # parameters without defaults
+    tags: frozenset[str]
+
+
+def parse_tools_source(src: str, package: str) -> list[ToolSig]:
+    """Extract ToolSigs from one tools.py source string (no import)."""
+    sigs: list[ToolSig] = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            if not (
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Attribute)
+                and dec.func.attr == "tool"
+            ):
+                continue
+            name = None
+            tags: set[str] = set()
+            for kw in dec.keywords:
+                if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                    name = kw.value.value
+                if kw.arg == "tags" and isinstance(kw.value, ast.Set):
+                    tags = {
+                        e.value for e in kw.value.elts
+                        if isinstance(e, ast.Constant)
+                    }
+            if name is None:
+                raise ValueError(
+                    f"{package}/tools.py: @mcp.tool on {node.name} has no "
+                    f"literal name= kwarg — MCP name must be explicit",
+                )
+            args = node.args
+            params = [a.arg for a in (*args.posonlyargs, *args.args)]
+            required = set(params[: len(params) - len(args.defaults)])
+            for a, default in zip(args.kwonlyargs, args.kw_defaults):
+                params.append(a.arg)
+                if default is None:
+                    required.add(a.arg)
+            sigs.append(
+                ToolSig(name, package, tuple(params),
+                        frozenset(required), frozenset(tags)),
+            )
+    return sigs
+
+
+def load_tool_registry() -> dict[str, ToolSig]:
+    """Registry of every MCP tool, AST-parsed from mcp_server/skills."""
+    registry: dict[str, ToolSig] = {}
+    for tools_py in sorted(SKILLS_SRC.glob("*/tools.py")):
+        for sig in parse_tools_source(
+            tools_py.read_text(encoding="utf-8"), tools_py.parent.name,
+        ):
+            if sig.name in registry:
+                raise ValueError(
+                    f"duplicate MCP tool name '{sig.name}' "
+                    f"({registry[sig.name].package} and {sig.package})",
+                )
+            registry[sig.name] = sig
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# 2. Call extraction from served text
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DocCall:
+    name: str
+    kwargs: dict[str, str]     # kwarg name -> raw value text
+    positional: list[str]      # raw positional arg texts
+    elided: bool               # a bare `...` appears among top-level args
+    line: int
+    context: str               # doc label, e.g. "simulate/SKILL.md"
+
+
+# Fenced blocks whose language is a measure-body sample, not tool calls
+_FENCE_RE = re.compile(r"```([^\n`]*)\n.*?```", re.DOTALL)
+_SKIP_LANGS = {"ruby", "rb", "python", "py"}
+# snake_case-with-underscore callee not preceded by `.` (excludes method calls)
+_CALL_START = re.compile(r"(?<![\w.])([a-z][a-z0-9_]*_[a-z0-9_]*)\s*\(")
+_BARE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_KWARG_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*=(?!=)\s*(.*)$", re.DOTALL)
+
+_OPEN = {"(": ")", "[": "]", "{": "}"}
+_CLOSE = set(_OPEN.values())
+_MAX_CALL_CHARS = 4000
+
+
+def _scan_call_args(text: str, open_paren: int) -> tuple[str, int] | None:
+    """Parse a call starting at `open_paren` -> (args_text, end_index), or None.
+
+    Quote-aware ('...' and "..."), nesting-aware, and drops unquoted
+    `#`-to-EOL comments from the returned args so Ruby interpolation inside
+    strings survives while trailing code comments cannot corrupt the parse.
+    """
+    depth = 0
+    quote: str | None = None
+    buf: list[str] = []
+    i = open_paren
+    end = min(len(text), open_paren + _MAX_CALL_CHARS)
+    while i < end:
+        ch = text[i]
+        if quote:
+            if ch == "\\":
+                buf.append(text[i : i + 2])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == "#":
+            eol = text.find("\n", i)
+            i = end if eol == -1 else eol
+            continue
+        elif ch in _OPEN:
+            depth += 1
+        elif ch in _CLOSE:
+            depth -= 1
+            if depth == 0:
+                return "".join(buf[1:]), i + 1  # drop the opening paren
+        buf.append(ch)
+        i += 1
+    return None  # unbalanced within budget — not a call
+
+
+def _split_top_level_args(args_text: str) -> list[str]:
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    quote: str | None = None
+    i = 0
+    while i < len(args_text):
+        ch = args_text[i]
+        if quote:
+            if ch == "\\" and i + 1 < len(args_text):
+                buf.append(args_text[i : i + 2])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch in _OPEN:
+            depth += 1
+        elif ch in _CLOSE:
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def extract_calls(text: str, context: str) -> list[DocCall]:
+    """All tool-style calls in `text`, skipping ruby/python fenced blocks."""
+    skip_spans = [
+        (m.start(), m.end())
+        for m in _FENCE_RE.finditer(text)
+        if m.group(1).strip().lower() in _SKIP_LANGS
+    ]
+    calls: list[DocCall] = []
+    consumed_until = -1  # matches inside an already-parsed call are string
+    # content or nested values, never independent doc examples
+    for m in _CALL_START.finditer(text):
+        if m.start() < consumed_until:
+            continue
+        if any(s <= m.start() < e for s, e in skip_spans):
+            continue
+        parsed = _scan_call_args(text, m.end() - 1)
+        if parsed is None:
+            continue
+        args_text, consumed_until = parsed
+        kwargs: dict[str, str] = {}
+        positional: list[str] = []
+        elided = False
+        for part in _split_top_level_args(args_text):
+            if part == "...":
+                elided = True
+                continue
+            kw = _KWARG_RE.match(part)
+            if kw:
+                kwargs[kw.group(1)] = kw.group(2).strip()
+            else:
+                positional.append(part)
+        calls.append(DocCall(
+            name=m.group(1),
+            kwargs=kwargs,
+            positional=positional,
+            elided=elided,
+            line=text.count("\n", 0, m.start()) + 1,
+            context=context,
+        ))
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# 3. Validation
+# ---------------------------------------------------------------------------
+
+def validate_doc_calls(
+    calls: list[DocCall],
+    registry: dict[str, ToolSig],
+    known_exceptions: frozenset[tuple[str, str, str]] = frozenset(),
+    ignore_names: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Contract-check extracted calls against the AST registry.
+
+    known_exceptions: (context, tool, kwarg) triples temporarily tolerated —
+    each entry must cite the PR that removes it.
+    ignore_names: snake_case callees that are legitimately not MCP tools
+    (e.g. CLI commands quoted in prose).
+    """
+    errors: list[str] = []
+    for c in calls:
+        where = f"{c.context}:{c.line}"
+        sig = registry.get(c.name)
+        if sig is None:
+            if c.name not in ignore_names:
+                errors.append(f"{where}: unknown tool '{c.name}(...)'")
+            continue
+        for k in c.kwargs:
+            if k not in sig.params:
+                if (c.context, c.name, k) in known_exceptions:
+                    continue
+                errors.append(
+                    f"{where}: {c.name}() has no parameter '{k}' "
+                    f"(params: {', '.join(sig.params)})",
+                )
+        bare = [a for a in c.positional if _BARE_IDENT.match(a)]
+        if bare:
+            errors.append(
+                f"{where}: {c.name}() passes bare identifier(s) "
+                f"{bare} positionally — use keyword arguments so agents "
+                f"see real parameter names",
+            )
+        if len(c.positional) > len(sig.params):
+            errors.append(
+                f"{where}: {c.name}() has {len(c.positional)} positional "
+                f"args but only {len(sig.params)} parameters",
+            )
+        if not c.elided:
+            satisfied = set(sig.params[: len(c.positional)]) | set(c.kwargs)
+            missing = sorted(sig.required - satisfied)
+            if missing:
+                errors.append(
+                    f"{where}: {c.name}() missing required argument(s) "
+                    f"{missing}",
+                )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# 4. MCP prompt template extraction (from prompts_resources/tools.py AST)
+# ---------------------------------------------------------------------------
+
+def _render_str(node: ast.expr) -> str:
+    """Render a string expression; f-string fields become __PARAM_<name>__."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        out = []
+        for part in node.values:
+            if isinstance(part, ast.Constant):
+                out.append(str(part.value))
+            elif isinstance(part, ast.FormattedValue):
+                expr = ast.unparse(part.value)
+                token = expr if _BARE_IDENT.match(expr) else "expr"
+                out.append(f"__PARAM_{token}__")
+        return "".join(out)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _render_str(node.left) + _render_str(node.right)
+    return ""
+
+
+def extract_prompt_templates(path: Path) -> dict[str, str]:
+    """MCP prompt name -> rendered template text with __PARAM_x__ markers."""
+    templates: dict[str, str] = {}
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for dec in node.decorator_list:
+            if not (
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Attribute)
+                and dec.func.attr == "prompt"
+            ):
+                continue
+            name = next(
+                (kw.value.value for kw in dec.keywords
+                 if kw.arg == "name" and isinstance(kw.value, ast.Constant)),
+                node.name,
+            )
+            rendered = "".join(
+                _render_str(stmt.value)
+                for stmt in ast.walk(node)
+                if isinstance(stmt, ast.Return) and stmt.value is not None
+            )
+            templates[name] = rendered
+    return templates

--- a/tests/llm/eval_parser.py
+++ b/tests/llm/eval_parser.py
@@ -304,6 +304,8 @@ def normalize_calls(result_or_calls) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 def _values_equal(actual, expected: str) -> bool:
+    if isinstance(actual, bool) and expected.lower() in ("true", "false"):
+        return actual == (expected.lower() == "true")
     try:
         return float(actual) == float(expected)
     except (TypeError, ValueError):

--- a/tests/llm/eval_parser.py
+++ b/tests/llm/eval_parser.py
@@ -1,122 +1,357 @@
-"""Parse eval.md files into Tier 1 test cases.
+"""Parse eval.md files into machine-checkable Tier 1 test cases.
 
 Each eval.md has two tables:
-  - "Should trigger" → tool selection cases (prompt → expected tools)
-  - "Should NOT trigger" → negative cases (prompt should NOT call these tools)
 
-Format:
+  ## Should trigger
   | Query | Expected tools | Critical params |
-  |---|---|---|
-  | "Create a 5-zone office" | create_baseline_osm, load_osm_model | ... |
+    Expected tools: comma- or OR-separated MCP registry names. Annotations
+    "(x2)" / "x2" are stripped. Wildcards and prose are format errors.
+    Critical params grammar (one comma-separated item each):
+      —  or empty        no assertion
+      name               param must be present on a matched call
+      name present       same as bare name
+      name=value         param must equal value (quotes optional; numeric
+                         values compare numerically)
+    A critical assertion applies to called tools that are BOTH in the row's
+    expected list AND have that parameter in their schema.
+
+  ## Should NOT trigger
+  | Query | Forbidden tools | Expected alternatives |
+    Forbidden tools: registry names the agent must NOT call.
+    Expected alternatives: registry names; at least one must be called.
+    (The old "| Query | Why |" format is prose-only and unassertable — it is
+    reported as a format error.)
+
+parse_eval_files() returns cases plus format errors; the unit validator in
+tests/test_skill_docs.py asserts there are no format errors, so eval content
+that drifts from this grammar fails CI instead of being silently skipped.
 """
 from __future__ import annotations
 
+import ast as _ast
+import contextlib
+import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 SKILLS_DIR = Path(__file__).resolve().parent.parent.parent / ".claude" / "skills"
 
+_TOOL_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_NO_ASSERT = {"", "—", "-", "–"}  # noqa: RUF001 — em/en dash cells mean "no assertion"
 
-def _parse_table_rows(text: str) -> list[list[str]]:
-    """Extract rows from a markdown table (skip header + separator)."""
-    rows = []
-    for line in text.strip().splitlines():
-        line = line.strip()
+NEGATIVE_HEADER = ["query", "forbidden tools", "expected alternatives"]
+
+
+@dataclass(frozen=True)
+class CriticalParam:
+    param: str
+    op: str            # "present" | "equals"
+    value: str | None  # only for "equals"
+
+
+# ---------------------------------------------------------------------------
+# Markdown table parsing
+# ---------------------------------------------------------------------------
+
+def _parse_table(text: str) -> tuple[list[str], list[list[str]]]:
+    """First markdown table in `text` -> (header_cells, data_rows)."""
+    header: list[str] = []
+    rows: list[list[str]] = []
+    for raw_line in text.strip().splitlines():
+        line = raw_line.strip()
         if not line.startswith("|"):
             continue
         cells = [c.strip() for c in line.split("|")[1:-1]]
-        # Skip separator rows (all dashes)
-        if cells and all(re.match(r"^-+$", c) for c in cells):
-            continue
-        # Skip header row
-        if cells and cells[0].lower() in ("query", ""):
+        if cells and all(re.match(r"^:?-+:?$", c) for c in cells):
+            continue  # separator row
+        if not header:
+            header = cells
             continue
         if cells:
             rows.append(cells)
-    return rows
+    return header, rows
+
+
+def _section(text: str, title_re: str) -> str | None:
+    m = re.search(
+        rf"##\s*{title_re}\s*\n(.*?)(?=\n##|\Z)", text,
+        re.DOTALL | re.IGNORECASE,
+    )
+    return m.group(1) if m else None
 
 
 def _strip_quotes(s: str) -> str:
-    """Remove surrounding quotes from a string."""
     s = s.strip()
-    if (s.startswith('"') and s.endswith('"')) or \
-       (s.startswith("'") and s.endswith("'")):
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in "\"'":
         return s[1:-1]
     return s
 
 
-def load_should_trigger() -> list[dict]:
-    """Parse "Should trigger" tables from all eval.md files.
-
-    Returns list of:
-        {"prompt": str, "expected_tools": list[str], "skill": str}
-    """
-    cases = []
-    for eval_md in sorted(SKILLS_DIR.rglob("eval.md")):
-        skill_name = eval_md.parent.name
-        text = eval_md.read_text()
-
-        # Extract "Should trigger" section
-        match = re.search(
-            r"##\s*Should\s+trigger\s*\n(.*?)(?=\n##|\Z)",
-            text, re.DOTALL | re.IGNORECASE,
-        )
-        if not match:
+def _parse_tool_list(cell: str, where: str, errors: list[str]) -> list[str]:
+    cell = re.sub(r"\(x\d+\)", "", cell)
+    cell = re.sub(r"\bx\d+\b", "", cell)
+    tools: list[str] = []
+    for part in re.split(r",|\bOR\b", cell):
+        t = part.strip()
+        if not t:
             continue
+        if not _TOOL_NAME_RE.match(t) or "_" not in t:
+            errors.append(f"{where}: unparseable tool name '{t}' — use exact "
+                          f"MCP registry names (no wildcards, no prose)")
+            continue
+        tools.append(t)
+    return tools
 
-        for row in _parse_table_rows(match.group(1)):
-            if len(row) < 2:
+
+def parse_critical_params(
+    cell: str, where: str = "", errors: list[str] | None = None,
+) -> list[CriticalParam]:
+    """Parse one Critical params cell under the documented grammar."""
+    errors = errors if errors is not None else []
+    cell = cell.strip()
+    if cell in _NO_ASSERT:
+        return []
+    out: list[CriticalParam] = []
+    for raw_item in cell.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        m = re.match(r"^([a-z_][a-z0-9_]*)\s*=\s*(.+)$", item)
+        if m:
+            out.append(CriticalParam(m.group(1), "equals",
+                                     _strip_quotes(m.group(2))))
+            continue
+        m = re.match(r"^([a-z_][a-z0-9_]*)(\s+present)?$", item)
+        if m:
+            out.append(CriticalParam(m.group(1), "present", None))
+            continue
+        errors.append(f"{where}: unparseable critical param '{item}' — "
+                      f"grammar is 'name', 'name present', or 'name=value'")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# eval.md loading
+# ---------------------------------------------------------------------------
+
+def parse_eval_files(skills_dir: Path | None = None) -> dict:
+    """Parse every eval.md -> {"cases": [...], "negative_cases": [...],
+    "errors": [...]}.
+
+    Rows with format errors are excluded from cases and reported in errors.
+    """
+    skills_dir = skills_dir or SKILLS_DIR
+    cases: list[dict] = []
+    negative: list[dict] = []
+    errors: list[str] = []
+
+    for eval_md in sorted(skills_dir.rglob("eval.md")):
+        skill = eval_md.parent.name
+        text = eval_md.read_text(encoding="utf-8")
+
+        pos = _section(text, r"Should\s+trigger")
+        if pos:
+            _header, rows = _parse_table(pos)
+            for i, row in enumerate(rows, 1):
+                where = f"{skill}/eval.md should-trigger row {i}"
+                if len(row) < 3:
+                    errors.append(f"{where}: expected 3 columns "
+                                  f"(Query | Expected tools | Critical params)")
+                    continue
+                row_errors: list[str] = []
+                tools = _parse_tool_list(row[1], where, row_errors)
+                criticals = parse_critical_params(row[2], where, row_errors)
+                errors.extend(row_errors)
+                prompt = _strip_quotes(row[0])
+                if prompt and tools and not row_errors:
+                    cases.append({
+                        "prompt": prompt,
+                        "expected_tools": tools,
+                        "critical_params": criticals,
+                        "skill": skill,
+                    })
+
+        neg = _section(text, r"Should\s+NOT\s+trigger")
+        if neg is None:
+            continue
+        header, rows = _parse_table(neg)
+        if [h.lower() for h in header] != NEGATIVE_HEADER:
+            errors.append(
+                f"{skill}/eval.md: 'Should NOT trigger' table header is "
+                f"{header} — prose-only negatives are unassertable; use "
+                f"| Query | Forbidden tools | Expected alternatives |",
+            )
+            continue
+        for i, row in enumerate(rows, 1):
+            where = f"{skill}/eval.md should-NOT-trigger row {i}"
+            if len(row) < 3:
+                errors.append(f"{where}: expected 3 columns")
                 continue
+            row_errors = []
+            forbidden = _parse_tool_list(row[1], where, row_errors)
+            alternatives = _parse_tool_list(row[2], where, row_errors)
+            errors.extend(row_errors)
+            if not forbidden:
+                errors.append(f"{where}: no forbidden tools declared")
+            if not alternatives:
+                errors.append(f"{where}: no expected alternatives declared")
             prompt = _strip_quotes(row[0])
-            # Parse comma-separated tool names, handle "x2" and "OR" variants
-            raw_tools = row[1]
-            # Remove annotations like "(x2)", "x2"
-            raw_tools = re.sub(r"\(x\d+\)", "", raw_tools)
-            raw_tools = re.sub(r"\bx\d+\b", "", raw_tools)
-            # Split on comma or "OR"
-            tools = []
-            for part in re.split(r",|\bOR\b", raw_tools):
-                t = part.strip()
-                # Skip vague entries like "save baseline, apply measure, run, compare"
-                if t and "_" in t:
-                    tools.append(t)
-
-            if prompt and tools:
-                cases.append({
+            if prompt and forbidden and alternatives and not row_errors:
+                negative.append({
                     "prompt": prompt,
-                    "expected_tools": tools,
-                    "skill": skill_name,
+                    "forbidden_tools": forbidden,
+                    "alternatives": alternatives,
+                    "skill": skill,
                 })
-    return cases
+
+    return {"cases": cases, "negative_cases": negative, "errors": errors}
+
+
+def load_should_trigger() -> list[dict]:
+    """Positive cases: {"prompt", "expected_tools", "critical_params", "skill"}."""
+    return parse_eval_files()["cases"]
 
 
 def load_should_not_trigger() -> list[dict]:
-    """Parse "Should NOT trigger" tables from all eval.md files.
+    """Negative cases: {"prompt", "forbidden_tools", "alternatives", "skill"}."""
+    return parse_eval_files()["negative_cases"]
 
-    Returns list of:
-        {"prompt": str, "reason": str, "skill": str}
-    """
-    cases = []
-    for eval_md in sorted(SKILLS_DIR.rglob("eval.md")):
-        skill_name = eval_md.parent.name
-        text = eval_md.read_text()
 
-        match = re.search(
-            r"##\s*Should\s+NOT\s+trigger\s*\n(.*?)(?=\n##|\Z)",
-            text, re.DOTALL | re.IGNORECASE,
-        )
-        if not match:
-            continue
+# ---------------------------------------------------------------------------
+# Normalized call representation (direct + CodeMode)
+# ---------------------------------------------------------------------------
 
-        for row in _parse_table_rows(match.group(1)):
-            if len(row) < 2:
+_CODE_MODE_META = frozenset({"search", "get_schema", "execute"})
+_MCP_PREFIX = "mcp__openstudio__"
+_CALL_TOOL_RE = re.compile(r"call_tool\(\s*[\"'](\w+)[\"']\s*,?\s*")
+
+
+def _balanced_braces(code: str, start: int) -> str | None:
+    if start >= len(code) or code[start] != "{":
+        return None
+    depth = 0
+    quote: str | None = None
+    for i in range(start, len(code)):
+        ch = code[i]
+        if quote:
+            if ch == "\\":
                 continue
-            prompt = _strip_quotes(row[0])
-            reason = row[1].strip()
-            if prompt:
-                cases.append({
-                    "prompt": prompt,
-                    "reason": reason,
-                    "skill": skill_name,
-                })
-    return cases
+            if ch == quote:
+                quote = None
+        elif ch in ("'", '"'):
+            quote = ch
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return code[start : i + 1]
+    return None
+
+
+def _quote_bare_keys(t: str) -> str:
+    """JS-ish object -> JSON: quote bare keys."""
+    return re.sub(r"([{,]\s*)([A-Za-z_]\w*)\s*:", r'\1"\2":', t)
+
+
+def _parse_args_object(text: str | None) -> dict:
+    """Best-effort parse of a call_tool args object (JSON / Python / JS-ish)."""
+    if not text:
+        return {}
+    for attempt in (
+        json.loads,
+        _ast.literal_eval,
+        lambda t: json.loads(_quote_bare_keys(t)),
+    ):
+        with contextlib.suppress(Exception):
+            obj = attempt(text)
+            if isinstance(obj, dict):
+                return obj
+    return {}
+
+
+def calls_from_code(code: str) -> list[dict]:
+    """Extract call_tool("name", {...}) invocations from a CodeMode block."""
+    calls = []
+    for m in _CALL_TOOL_RE.finditer(code):
+        args_text = _balanced_braces(code, m.end())
+        calls.append({"tool": m.group(1), "input": _parse_args_object(args_text)})
+    return calls
+
+
+def normalize_calls(result_or_calls) -> list[dict]:
+    """Uniform [{"tool", "input"}] from an AgentResult or raw tool-call list.
+
+    Direct MCP calls keep their input dicts; CodeMode execute blocks are
+    expanded into the tools they invoke (inputs parsed best-effort).
+    """
+    raw = (result_or_calls if isinstance(result_or_calls, list)
+           else result_or_calls.mcp_tool_calls)
+    calls: list[dict] = []
+    for c in raw:
+        name = c["tool"].removeprefix(_MCP_PREFIX)
+        if name in _CODE_MODE_META:
+            if name == "execute":
+                calls.extend(calls_from_code(c["input"].get("code", "")))
+            continue
+        calls.append({"tool": name, "input": c.get("input") or {}})
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Critical-param matcher
+# ---------------------------------------------------------------------------
+
+def _values_equal(actual, expected: str) -> bool:
+    try:
+        return float(actual) == float(expected)
+    except (TypeError, ValueError):
+        return str(actual) == expected
+
+
+def check_critical_params(
+    criticals: list[CriticalParam],
+    expected_tools: list[str],
+    calls: list[dict],
+    registry: dict[str, set[str] | frozenset[str] | tuple],
+) -> list[str]:
+    """Return failure strings for unmet critical-param assertions.
+
+    For each assertion, candidate calls are those whose tool is in the row's
+    expected list AND whose schema contains the parameter. Any candidate
+    satisfying the assertion passes it.
+    """
+    failures: list[str] = []
+    for crit in criticals:
+        candidates = [
+            c for c in calls
+            if c["tool"] in expected_tools
+            and crit.param in registry.get(c["tool"], ())
+        ]
+        if not candidates:
+            failures.append(
+                f"no call to an expected tool carrying '{crit.param}' "
+                f"(expected tools: {expected_tools})",
+            )
+            continue
+        if crit.op == "present":
+            if not any(crit.param in c["input"] for c in candidates):
+                failures.append(
+                    f"'{crit.param}' missing from inputs of "
+                    f"{sorted({c['tool'] for c in candidates})}",
+                )
+        else:
+            if not any(
+                crit.param in c["input"]
+                and _values_equal(c["input"][crit.param], crit.value)
+                for c in candidates
+            ):
+                got = [
+                    f"{c['tool']}({crit.param}={c['input'].get(crit.param)!r})"
+                    for c in candidates
+                ]
+                failures.append(
+                    f"'{crit.param}' != {crit.value!r} on every candidate: {got}",
+                )
+    return failures

--- a/tests/llm/test_03_eval_cases.py
+++ b/tests/llm/test_03_eval_cases.py
@@ -21,12 +21,24 @@ Key design decisions:
 from __future__ import annotations
 
 import pytest
+from doc_contract_lib import load_tool_registry
 
 from .conftest import BASELINE_MODEL, baseline_model_exists, get_sim_run_id, get_tier
-from .eval_parser import load_should_trigger
+from .eval_parser import (
+    check_critical_params,
+    load_should_not_trigger,
+    load_should_trigger,
+    normalize_calls,
+)
 from .runner import run_claude
 
 pytestmark = [pytest.mark.llm, pytest.mark.tier1]
+
+# AST-derived tool schemas (pure, no imports) — critical-param assertions
+# only apply to expected tools whose schema carries the parameter.
+REGISTRY_PARAMS = {
+    name: set(sig.params) for name, sig in load_tool_registry().items()
+}
 
 # Prompts too vague or too complex for single-turn testing.
 # Vague prompts: agent consults skill guides but doesn't act within timeout.
@@ -54,12 +66,16 @@ EVAL_CASES = [
 NEEDS_MODEL = {"add-hvac", "simulate", "energy-report", "retrofit",
                "qaqc", "troubleshoot", "view"}
 
+# Skills whose target tools need a COMPLETED simulation run_id, not just a
+# loaded model (get_run_logs, run_qaqc_checks) — they get the run-id prefix.
+NEEDS_RUN_ID = {"troubleshoot", "qaqc"}
+
 LOAD_PREFIX = (
     f"First load the model at {BASELINE_MODEL} using load_osm_model. Then "
 )
 
-def _troubleshoot_prefix() -> str:
-    """Build a prompt prefix for troubleshoot tests, including run_id if available."""
+def _run_id_prefix() -> str:
+    """Prompt prefix including a completed-simulation run_id if available."""
     run_id = get_sim_run_id()
     if run_id:
         return (
@@ -131,8 +147,8 @@ def test_eval_tool_selection(case):
     if case["skill"] in NEEDS_MODEL:
         if not baseline_model_exists():
             pytest.skip("Baseline model not found — run test_01_setup first")
-        if case["skill"] == "troubleshoot":
-            prompt = _troubleshoot_prefix() + prompt.lower()
+        if case["skill"] in NEEDS_RUN_ID:
+            prompt = _run_id_prefix() + prompt.lower()
         else:
             prompt = LOAD_PREFIX + prompt.lower()
     prompt += SUFFIX
@@ -148,4 +164,58 @@ def test_eval_tool_selection(case):
     assert any(t in expected for t in tool_names), (
         f"[{case['skill']}] Expected one of {sorted(expected)}, "
         f"got: {tool_names}"
+    )
+
+    # Critical-param assertions from the eval.md third column (previously
+    # parsed and ignored — plan finding E3). Grammar in eval_parser docstring.
+    failures = check_critical_params(
+        case["critical_params"], case["expected_tools"],
+        normalize_calls(result), REGISTRY_PARAMS,
+    )
+    assert not failures, (
+        f"[{case['skill']}] critical-param assertions failed: {failures}; "
+        f"calls: {normalize_calls(result)}"
+    )
+
+
+# Negative cases: the prompt must be answered WITHOUT the forbidden tools,
+# using at least one declared alternative (parsed from the machine-checkable
+# "Should NOT trigger" tables).
+NEGATIVE_CASES = load_should_not_trigger()
+
+
+@pytest.mark.parametrize(
+    "case", NEGATIVE_CASES,
+    ids=[f"neg:{_case_id(c)}" for c in NEGATIVE_CASES],
+)
+def test_eval_negative_routing(case):
+    """Verify agent avoids forbidden tools and uses a declared alternative."""
+    # Regression: "Should NOT trigger" tables were parsed but never asserted
+    # (plan finding E3) — negative routing had zero coverage
+    tier = get_tier()
+    if tier not in ("all", "1"):
+        pytest.skip("Tier 1 not selected")
+
+    prompt = case["prompt"]
+    if case["skill"] in NEEDS_MODEL:
+        if not baseline_model_exists():
+            pytest.skip("Baseline model not found — run test_01_setup first")
+        if case["skill"] in NEEDS_RUN_ID:
+            prompt = _run_id_prefix() + prompt.lower()
+        else:
+            prompt = LOAD_PREFIX + prompt.lower()
+    prompt += SUFFIX
+
+    result = run_claude(prompt, timeout=180)
+    called = set(result.tool_names)
+
+    forbidden_called = called & set(case["forbidden_tools"])
+    assert not forbidden_called, (
+        f"[{case['skill']}] forbidden tools called for "
+        f"'{case['prompt']}': {sorted(forbidden_called)}"
+    )
+    assert called & set(case["alternatives"]), (
+        f"[{case['skill']}] none of the declared alternatives "
+        f"{case['alternatives']} called for '{case['prompt']}'; got: "
+        f"{sorted(called)}"
     )

--- a/tests/test_doc_contract_lib.py
+++ b/tests/test_doc_contract_lib.py
@@ -1,0 +1,322 @@
+"""Pure unit tests for the doc-contract validator and eval-parser machinery.
+
+Synthetic sources/calls only — no OpenStudio, no MCP server, no LLM. These
+prove the PR-1 validators can actually catch the finding classes (A1-A8, C5,
+E3) before any content fix lands.
+"""
+from __future__ import annotations
+
+import pytest
+from doc_contract_lib import (
+    DocCall,
+    extract_calls,
+    parse_tools_source,
+    validate_doc_calls,
+)
+from llm.eval_parser import (
+    CriticalParam,
+    calls_from_code,
+    check_critical_params,
+    normalize_calls,
+    parse_critical_params,
+    parse_eval_files,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# AST registry extraction
+# ---------------------------------------------------------------------------
+
+SYNTH_TOOLS = '''
+def register(mcp):
+    @mcp.tool(name="alpha_tool", tags={"core"})
+    def alpha(osm_path: str, epw_path: str | None = None):
+        """doc"""
+        return None
+
+    @mcp.tool(tags={"hvac"}, name="beta_tool")
+    def beta(loop_name: str, properties: str) -> str:
+        return ""
+'''
+
+
+def test_parse_tools_source_extracts_names_params_required():
+    # Validates: AST extraction captures MCP name, param order, and required set
+    sigs = {s.name: s for s in parse_tools_source(SYNTH_TOOLS, "synth")}
+    assert set(sigs) == {"alpha_tool", "beta_tool"}
+    assert sigs["alpha_tool"].params == ("osm_path", "epw_path")
+    assert sigs["alpha_tool"].required == frozenset({"osm_path"})
+    assert sigs["alpha_tool"].tags == frozenset({"core"})
+    assert sigs["beta_tool"].required == frozenset({"loop_name", "properties"})
+
+
+def test_parse_tools_source_rejects_implicit_name():
+    # Validates: @mcp.tool without literal name= fails loudly instead of
+    # silently registering under the function name
+    src = "def register(mcp):\n    @mcp.tool(tags={'x'})\n    def foo(a):\n        return a\n"
+    with pytest.raises(ValueError, match=r"no\s+literal name="):
+        parse_tools_source(src, "synth")
+
+
+# ---------------------------------------------------------------------------
+# Call extraction from markdown
+# ---------------------------------------------------------------------------
+
+def _registry():
+    return {s.name: s for s in parse_tools_source(SYNTH_TOOLS, "synth")}
+
+
+def test_extract_calls_finds_fenced_and_inline_calls():
+    # Validates: calls inside fenced blocks (where ~90% of served examples
+    # live) and inline backtick prose are both extracted (plan E1)
+    md = (
+        'Use `alpha_tool(osm_path="/runs/a.osm")` inline.\n'
+        "```\nbeta_tool(loop_name=\"CHW\", properties='{\"a\": 1}')\n```\n"
+    )
+    calls = {c.name: c for c in extract_calls(md, "t")}
+    assert set(calls) == {"alpha_tool", "beta_tool"}
+    assert calls["alpha_tool"].kwargs == {"osm_path": '"/runs/a.osm"'}
+    assert calls["beta_tool"].kwargs["loop_name"] == '"CHW"'
+
+
+def test_extract_calls_skips_measure_body_fences_and_strings():
+    # Validates: ruby/python fences and quoted run_body strings never
+    # fabricate tool calls or kwargs (SQL/Ruby text is opaque)
+    md = (
+        "```ruby\nfake_tool_call(bogus_kwarg=1)\n```\n"
+        "```python\nother_fake_call(x=2)\n```\n"
+        '```\ncreate_thing(run_body="inner_fake(a=1, b=2)")\n```\n'
+    )
+    calls = extract_calls(md, "t")
+    assert [c.name for c in calls] == ["create_thing"]
+    assert calls[0].kwargs == {"run_body": '"inner_fake(a=1, b=2)"'}
+
+
+def test_extract_calls_multiline_with_comment_and_elision():
+    # Validates: multi-line calls parse across lines; unquoted # comments do
+    # not corrupt args; bare ... marks the call as elided
+    md = (
+        "```\nalpha_tool(\n"
+        '    osm_path="/runs/x.osm",  # explains the path\n'
+        "    ...)\n```\n"
+    )
+    calls = extract_calls(md, "t")
+    assert len(calls) == 1
+    assert calls[0].elided is True
+    assert calls[0].kwargs == {"osm_path": '"/runs/x.osm"'}
+
+
+def test_extract_calls_ignores_dotted_method_calls():
+    # Validates: obj.some_method(x) is never mistaken for an MCP tool call
+    md = "```\nmodel.get_thing(a=1)\nsql.exec_and_return(b=2)\n```\n"
+    assert extract_calls(md, "t") == []
+
+
+# ---------------------------------------------------------------------------
+# Call validation
+# ---------------------------------------------------------------------------
+
+def test_validate_flags_unknown_tool():
+    # Regression: ghost tool names (E3's list_infiltration) escaped the old
+    # backtick-only validator
+    calls = [DocCall("ghost_tool", {}, [], False, 1, "doc")]
+    errors = validate_doc_calls(calls, _registry())
+    assert len(errors) == 1 and "unknown tool 'ghost_tool" in errors[0]
+
+
+def test_validate_flags_unknown_kwarg():
+    # Regression: save_osm_model(save_path=...) shipped in 8 served examples
+    # (A1) — kwargs must exist on the real signature
+    calls = [DocCall(
+        "alpha_tool",
+        {"save_path": '"/x.osm"', "osm_path": '"/x.osm"'}, [], False, 3, "doc",
+    )]
+    errors = validate_doc_calls(calls, _registry())
+    assert len(errors) == 1
+    assert "no parameter 'save_path'" in errors[0] and "doc:3" in errors[0]
+
+
+def test_validate_flags_bare_identifier_positional():
+    # Regression: compare_runs(run_id_a, run_id_b) taught fake kwarg names
+    # positionally (A3) — doc examples must name real parameters
+    calls = [DocCall("beta_tool", {}, ["run_id_a", "run_id_b"], False, 9, "doc")]
+    errors = validate_doc_calls(calls, _registry())
+    assert any("bare identifier" in e for e in errors)
+
+
+def test_validate_flags_missing_required_args():
+    # Regression: MCP prompts emitted run_simulation() / get_run_status()
+    # with no required args (C5)
+    calls = [DocCall("alpha_tool", {}, [], False, 2, "prompt:x")]
+    errors = validate_doc_calls(calls, _registry())
+    assert len(errors) == 1 and "missing required argument(s) ['osm_path']" in errors[0]
+
+
+def test_validate_elided_call_skips_required_check():
+    # Validates: an explicitly elided example — alpha_tool(...) — is not a
+    # contract violation, but its named kwargs are still checked
+    ok = [DocCall("alpha_tool", {}, [], True, 1, "doc")]
+    assert validate_doc_calls(ok, _registry()) == []
+    bad = [DocCall("alpha_tool", {"bogus": "1"}, [], True, 1, "doc")]
+    assert len(validate_doc_calls(bad, _registry())) == 1
+
+
+def test_validate_known_exception_is_tolerated():
+    # Validates: the B1 bridge — (context, tool, kwarg) triples are tolerated
+    # until the PR that exposes the kwarg removes them
+    calls = [DocCall("alpha_tool", {"run_id": '"r"', "osm_path": '"m"'}, [], False, 1, "x/SKILL.md")]
+    errors = validate_doc_calls(
+        calls, _registry(),
+        known_exceptions=frozenset({("x/SKILL.md", "alpha_tool", "run_id")}),
+    )
+    assert errors == []
+
+
+def test_validate_literal_positionals_satisfy_required_in_order():
+    # Validates: quoted-literal positionals ("name") count toward required
+    # params in order — search_api("X") style examples stay legal
+    calls = [DocCall("alpha_tool", {}, ['"/runs/m.osm"'], False, 1, "doc")]
+    assert validate_doc_calls(calls, _registry()) == []
+
+
+# ---------------------------------------------------------------------------
+# Critical-params grammar
+# ---------------------------------------------------------------------------
+
+def test_parse_critical_params_grammar():
+    # Validates: documented grammar — bare name / 'name present' / name=value;
+    # em dash means no assertions
+    assert parse_critical_params("—") == []
+    assert parse_critical_params("run_id") == [CriticalParam("run_id", "present", None)]
+    assert parse_critical_params("epw_path present") == [
+        CriticalParam("epw_path", "present", None)]
+    assert parse_critical_params('system_type=7, stream="energyplus"') == [
+        CriticalParam("system_type", "equals", "7"),
+        CriticalParam("stream", "equals", "energyplus"),
+    ]
+
+
+def test_parse_critical_params_reports_prose():
+    # Regression: the critical-params column was parsed-then-ignored (E3);
+    # prose cells must surface as format errors, not silent drops
+    errors: list[str] = []
+    parse_critical_params("the run id from step 2", "here", errors)
+    assert len(errors) == 1 and "unparseable critical param" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Negative-table parsing (synthetic eval.md trees)
+# ---------------------------------------------------------------------------
+
+def _write_eval(tmp_path, body: str):
+    d = tmp_path / "some-skill"
+    d.mkdir()
+    (d / "eval.md").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+def test_parse_eval_files_new_negative_format(tmp_path):
+    # Validates: | Query | Forbidden tools | Expected alternatives | rows
+    # become assertable negative cases
+    root = _write_eval(tmp_path, (
+        "## Should trigger\n"
+        "| Query | Expected tools | Critical params |\n|---|---|---|\n"
+        '| "Do it" | alpha_tool | osm_path |\n\n'
+        "## Should NOT trigger\n"
+        "| Query | Forbidden tools | Expected alternatives |\n|---|---|---|\n"
+        '| "Other thing" | alpha_tool | beta_tool |\n'
+    ))
+    parsed = parse_eval_files(root)
+    assert parsed["errors"] == []
+    assert parsed["negative_cases"] == [{
+        "prompt": "Other thing",
+        "forbidden_tools": ["alpha_tool"],
+        "alternatives": ["beta_tool"],
+        "skill": "some-skill",
+    }]
+
+
+def test_parse_eval_files_rejects_prose_negative_table(tmp_path):
+    # Regression: old | Query | Why | tables were parsed but unassertable —
+    # they must be reported as format errors (E3)
+    root = _write_eval(tmp_path, (
+        "## Should NOT trigger\n"
+        "| Query | Why |\n|---|---|\n"
+        '| "Other thing" | use beta skill |\n'
+    ))
+    parsed = parse_eval_files(root)
+    assert parsed["negative_cases"] == []
+    assert any("unassertable" in e for e in parsed["errors"])
+
+
+def test_parse_eval_files_rejects_wildcard_expected_tools(tmp_path):
+    # Regression: 'extract_* tools' rows were silently filtered by the old
+    # parser (E3) — wildcards must be format errors
+    root = _write_eval(tmp_path, (
+        "## Should trigger\n"
+        "| Query | Expected tools | Critical params |\n|---|---|---|\n"
+        '| "Report" | extract_* tools | — |\n'
+    ))
+    parsed = parse_eval_files(root)
+    assert parsed["cases"] == []
+    assert any("extract_*" in e for e in parsed["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Normalized calls (direct + CodeMode) and the critical matcher
+# ---------------------------------------------------------------------------
+
+def test_normalize_calls_direct_and_code_mode():
+    # Validates: direct MCP calls keep inputs; CodeMode execute blocks expand
+    # into the tools they invoke with best-effort parsed inputs
+    raw = [
+        {"tool": "mcp__openstudio__alpha_tool", "input": {"osm_path": "/x"}},
+        {"tool": "mcp__openstudio__execute",
+         "input": {"code": 'call_tool("beta_tool", {loop_name: "CHW"})'}},
+    ]
+    calls = normalize_calls(raw)
+    assert calls == [
+        {"tool": "alpha_tool", "input": {"osm_path": "/x"}},
+        {"tool": "beta_tool", "input": {"loop_name": "CHW"}},
+    ]
+
+
+def test_calls_from_code_json_and_python_args():
+    # Validates: JSON and Python-literal arg objects both parse; unparseable
+    # objects degrade to {} instead of crashing the matcher
+    code = (
+        'call_tool("a_b", {"x": 1})\n'
+        "call_tool('c_d', {'y': 2})\n"
+        'call_tool("e_f", make_args())\n'
+    )
+    assert calls_from_code(code) == [
+        {"tool": "a_b", "input": {"x": 1}},
+        {"tool": "c_d", "input": {"y": 2}},
+        {"tool": "e_f", "input": {}},
+    ]
+
+
+_MATCH_REGISTRY = {"alpha_tool": {"osm_path", "system_type"}, "beta_tool": {"loop_name"}}
+
+
+def test_check_critical_params_presence_and_equality():
+    # Validates: presence + equality assertions match against calls to
+    # expected tools whose schema carries the param (numeric-normalized)
+    calls = [{"tool": "alpha_tool", "input": {"system_type": 7}}]
+    crits = [CriticalParam("system_type", "equals", "7")]
+    assert check_critical_params(crits, ["alpha_tool"], calls, _MATCH_REGISTRY) == []
+    crits = [CriticalParam("system_type", "equals", "5")]
+    failures = check_critical_params(crits, ["alpha_tool"], calls, _MATCH_REGISTRY)
+    assert len(failures) == 1 and "system_type" in failures[0]
+
+
+def test_check_critical_params_requires_a_carrying_call():
+    # Regression: the old harness ignored criticals entirely — an agent that
+    # never called the tool carrying the param must FAIL the assertion
+    calls = [{"tool": "beta_tool", "input": {"loop_name": "CHW"}}]
+    crits = [CriticalParam("osm_path", "present", None)]
+    failures = check_critical_params(crits, ["alpha_tool", "beta_tool"], calls,
+                                     _MATCH_REGISTRY)
+    assert len(failures) == 1 and "no call to an expected tool" in failures[0]

--- a/tests/test_doc_contract_lib.py
+++ b/tests/test_doc_contract_lib.py
@@ -312,6 +312,17 @@ def test_check_critical_params_presence_and_equality():
     assert len(failures) == 1 and "system_type" in failures[0]
 
 
+def test_check_critical_params_bool_values():
+    # Validates: eval cells like geometry_diagnostics=true match a boolean
+    # True input (case-insensitive), and mismatched booleans fail
+    reg = {"view_tool": {"geometry_diagnostics"}}
+    calls = [{"tool": "view_tool", "input": {"geometry_diagnostics": True}}]
+    crits = [CriticalParam("geometry_diagnostics", "equals", "true")]
+    assert check_critical_params(crits, ["view_tool"], calls, reg) == []
+    crits = [CriticalParam("geometry_diagnostics", "equals", "false")]
+    assert len(check_critical_params(crits, ["view_tool"], calls, reg)) == 1
+
+
 def test_check_critical_params_requires_a_carrying_call():
     # Regression: the old harness ignored criticals entirely — an agent that
     # never called the tool carrying the param must FAIL the assertion

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -1,9 +1,10 @@
-"""Validate Claude Code SKILL.md files.
+"""Contract validation for every served agent-guidance surface.
 
-Checks:
-1. YAML frontmatter parses correctly
-2. Required frontmatter fields present
-3. Every backtick-quoted tool name exists in registered MCP tools
+Validates that .claude/skills/**/*.md, eval.md tables, and the six MCP
+prompt templates only instruct calls that the live tool registry accepts:
+real tool names, real kwarg names, required args present. The registry is
+AST-parsed from mcp_server/skills/*/tools.py — no imports, so this stays a
+true unit test (plan finding E2).
 """
 from __future__ import annotations
 
@@ -12,94 +13,238 @@ from pathlib import Path
 
 import pytest
 import yaml
-
-from mcp_server.skills import register_all_skills
+from doc_contract_lib import (
+    REPO_ROOT,
+    SERVED_SKILLS_DIR,
+    extract_calls,
+    extract_prompt_templates,
+    load_tool_registry,
+    validate_doc_calls,
+)
+from llm.eval_parser import parse_eval_files
+from test_skill_registration import EXPECTED_TOOLS
 
 pytestmark = pytest.mark.unit
 
-# Repo-relative path (host/CI), fallback to Docker baked-in path
-_REPO_SKILLS = Path(__file__).resolve().parent.parent / ".claude" / "skills"
-_DOCKER_SKILLS = Path("/skills")
-SKILLS_DIR = _REPO_SKILLS if _REPO_SKILLS.exists() else _DOCKER_SKILLS
+PROMPTS_TOOLS_PY = (
+    REPO_ROOT / "mcp_server" / "skills" / "prompts_resources" / "tools.py"
+)
+
+# (context, tool, kwarg) triples temporarily tolerated. B1: apply_measure's
+# run_id path is implemented in operations.py but not yet exposed on the MCP
+# wrapper — PR "fix/apply-measure-run-id" adds the kwarg and MUST remove
+# these entries so the validator enforces it.
+KNOWN_EXCEPTIONS = frozenset({
+    ("measure-authoring/SKILL.md", "apply_measure", "run_id"),
+    ("tool-workflows/SKILL.md", "apply_measure", "run_id"),
+})
+
+# snake_case callees in served docs that are legitimately not MCP tools
+IGNORE_NAMES: frozenset[str] = frozenset()
 
 
-def _get_registered_tool_names() -> set[str]:
-    """Register all MCP tools and return the set of tool names."""
-    registered = {}
-
-    class FakeMCP:
-        def tool(self, name=None, **kwargs):
-            def decorator(fn):
-                tool_name = name or fn.__name__
-                registered[tool_name] = fn
-                return fn
-            return decorator
-        def prompt(self, **kw):
-            return lambda fn: fn
-        def resource(self, *a, **kw):
-            return lambda fn: fn
-
-    register_all_skills(FakeMCP())
-    return set(registered.keys())
+def _served_markdown_files() -> list[Path]:
+    # eval.md is validated by test_eval_tables_are_machine_checkable under its
+    # own table grammar ("(x2)" annotations etc.), not the call scanner
+    return sorted(
+        p for p in SERVED_SKILLS_DIR.glob("*/*.md") if p.name != "eval.md"
+    )
 
 
 def _parse_skill_md(path: Path) -> tuple[dict, str]:
-    """Parse SKILL.md into (frontmatter_dict, body_text)."""
     text = path.read_text(encoding="utf-8")
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", text, re.DOTALL)
     assert match, f"No YAML frontmatter in {path}"
-    frontmatter = yaml.safe_load(match.group(1))
-    body = match.group(2)
-    return frontmatter, body
+    return yaml.safe_load(match.group(1)), match.group(2)
 
 
-def _find_skill_files() -> list[Path]:
-    """Find all SKILL.md files under .claude/skills/."""
-    if not SKILLS_DIR.exists():
-        return []
-    return sorted(SKILLS_DIR.glob("*/SKILL.md"))
+def _context(path: Path) -> str:
+    return f"{path.parent.name}/{path.name}"
 
 
-def _extract_tool_references(body: str) -> set[str]:
-    """Extract tool names from backtick-quoted function calls in markdown.
-
-    Only matches `tool_name(` patterns where tool_name contains an underscore —
-    all MCP tool names use snake_case (e.g. create_measure), so this filters
-    out Ruby method refs like `run()` or `arguments()`.
-    """
-    return {m for m in re.findall(r"`(\w+)\(", body) if "_" in m}
+# ---- registry ---------------------------------------------------------------
 
 
-# ---- tests ------------------------------------------------------------------
+def test_ast_registry_matches_expected_tools():
+    # Validates: AST-parsed @mcp.tool roster == EXPECTED_TOOLS — the doc
+    # validator checks against the real registry, not a drifted copy
+    names = set(load_tool_registry())
+    assert names == EXPECTED_TOOLS, (
+        f"AST registry drift: missing={sorted(EXPECTED_TOOLS - names)}, "
+        f"extra={sorted(names - EXPECTED_TOOLS)}"
+    )
+
+
+# ---- SKILL.md frontmatter ---------------------------------------------------
 
 
 def test_skill_files_exist():
-    # Validates: at least 3 SKILL.md files exist under .claude/skills/
-    files = _find_skill_files()
-    assert len(files) >= 3, f"Expected >= 3 SKILL.md files, found {len(files)}"
+    # Validates: served skills corpus present (>= 10 SKILL.md under .claude/skills)
+    files = sorted(SERVED_SKILLS_DIR.glob("*/SKILL.md"))
+    assert len(files) >= 10, f"Expected >= 10 SKILL.md files, found {len(files)}"
 
 
 def test_frontmatter_valid():
-    # Validates: every SKILL.md has valid YAML frontmatter with non-trivial description
-    for path in _find_skill_files():
+    # Validates: every SKILL.md has YAML frontmatter with a non-trivial description
+    for path in sorted(SERVED_SKILLS_DIR.glob("*/SKILL.md")):
         fm, _ = _parse_skill_md(path)
-        skill_name = path.parent.name
-        assert isinstance(fm, dict), f"{skill_name}: frontmatter is not a dict"
-        assert "description" in fm, f"{skill_name}: missing 'description'"
-        assert len(fm["description"]) > 10, f"{skill_name}: description too short"
+        skill = path.parent.name
+        assert isinstance(fm, dict), f"{skill}: frontmatter is not a dict"
+        assert "description" in fm, f"{skill}: missing 'description'"
+        assert len(fm["description"]) > 10, f"{skill}: description too short"
 
 
-def test_tool_references_valid():
-    # Validates: every backtick-quoted tool name in SKILL.md exists in MCP tool registry
-    registered = _get_registered_tool_names()
+# ---- served call contracts --------------------------------------------------
 
-    all_errors = []
-    for path in _find_skill_files():
-        _, body = _parse_skill_md(path)
-        skill_name = path.parent.name
-        refs = _extract_tool_references(body)
-        unknown = refs - registered
+
+def test_served_skill_calls_match_tool_contracts():
+    # Regression: served skills taught save_osm_model(save_path=), compare_runs
+    # positional ids, get_run_logs(log_type=), shift_schedule_time(
+    # shift_value_hours=), add_rooftop_pv(fraction_of_roof=), economizer/sizing
+    # flat kwargs (plan A1-A8) — agents copied them and failed
+    registry = load_tool_registry()
+    errors: list[str] = []
+    for path in _served_markdown_files():
+        text = path.read_text(encoding="utf-8")
+        if path.name == "SKILL.md":
+            _, text = _parse_skill_md(path)
+        calls = extract_calls(text, _context(path))
+        errors.extend(validate_doc_calls(
+            calls, registry,
+            known_exceptions=KNOWN_EXCEPTIONS,
+            ignore_names=IGNORE_NAMES,
+        ))
+    assert not errors, "Served-doc contract errors:\n" + "\n".join(errors)
+
+
+def test_mcp_prompt_templates_are_executable():
+    # Regression: MCP prompts emitted run_simulation() without osm_path,
+    # get_run_status() without run_id, assign_construction_to_surface() with
+    # no fields, and compare_runs(run_id_a, run_id_b) (plan C5)
+    registry = load_tool_registry()
+    templates = extract_prompt_templates(PROMPTS_TOOLS_PY)
+    assert len(templates) >= 6, f"expected >= 6 MCP prompts, got {sorted(templates)}"
+    errors: list[str] = []
+    for name, text in sorted(templates.items()):
+        calls = extract_calls(text, f"prompt:{name}")
+        errors.extend(validate_doc_calls(calls, registry))
+    assert not errors, "MCP prompt contract errors:\n" + "\n".join(errors)
+
+
+def test_full_building_simulation_prompt_applies_system_type():
+    # Regression: full_building_simulation accepted system_type but no step
+    # applied it — the built model silently ignored the requested system (C5)
+    registry = load_tool_registry()
+    text = extract_prompt_templates(PROMPTS_TOOLS_PY)["full_building_simulation"]
+    calls = extract_calls(text, "prompt:full_building_simulation")
+    carrying = [
+        c.name for c in calls
+        if c.name in registry and any(
+            "__PARAM_system_type__" in v
+            for v in (*c.kwargs.values(), *c.positional)
+        )
+    ]
+    assert carrying, (
+        "full_building_simulation's system_type parameter must be passed to "
+        "at least one tool call in the emitted steps"
+    )
+
+
+# ---- eval.md tables ---------------------------------------------------------
+
+
+def test_eval_tables_are_machine_checkable():
+    # Regression: eval tables carried ghost tools (list_infiltration), wildcard
+    # rows (extract_*), a ghost critical param (format), and prose-only
+    # negative tables no test could assert (plan E3)
+    registry = load_tool_registry()
+    parsed = parse_eval_files()
+    errors = list(parsed["errors"])
+
+    for case in parsed["cases"]:
+        where = f"{case['skill']}/eval.md ('{case['prompt'][:40]}')"
+        unknown = [t for t in case["expected_tools"] if t not in registry]
         if unknown:
-            all_errors.append(f"{skill_name}: unknown tools {sorted(unknown)}")
+            errors.append(f"{where}: unknown expected tools {unknown}")
+        for crit in case["critical_params"]:
+            carriers = [
+                t for t in case["expected_tools"]
+                if t in registry and crit.param in registry[t].params
+            ]
+            if not carriers:
+                errors.append(
+                    f"{where}: critical param '{crit.param}' is not a "
+                    f"parameter of any expected tool {case['expected_tools']}",
+                )
 
-    assert not all_errors, "Tool reference errors:\n" + "\n".join(all_errors)
+    for case in parsed["negative_cases"]:
+        where = f"{case['skill']}/eval.md negative ('{case['prompt'][:40]}')"
+        unknown = [
+            t for t in (*case["forbidden_tools"], *case["alternatives"])
+            if t not in registry
+        ]
+        if unknown:
+            errors.append(f"{where}: unknown tools {unknown}")
+
+    assert not errors, "Eval table errors:\n" + "\n".join(errors)
+
+
+def test_every_eval_file_has_negative_cases():
+    # Validates: each eval.md contributes assertable negative-routing cases —
+    # the load_should_not_trigger data is actually consumed by an LLM test
+    parsed = parse_eval_files()
+    skills_with_neg = {c["skill"] for c in parsed["negative_cases"]}
+    eval_files = {p.parent.name for p in SERVED_SKILLS_DIR.rglob("eval.md")}
+    missing = eval_files - skills_with_neg
+    assert not missing, (
+        f"eval.md files with no machine-checkable negative cases: {sorted(missing)}"
+    )
+
+
+# ---- cross-surface consistency (C1/C2) --------------------------------------
+
+
+def test_polling_cadence_consistent_across_surfaces():
+    # Regression: simulate SKILL.md said poll every 3-5 s while the tool
+    # docstring said once per minute and server instructions said 1-2 min —
+    # sleep-less clients burned an LLM turn per poll (plan C1)
+    _, simulate = _parse_skill_md(SERVED_SKILLS_DIR / "simulate" / "SKILL.md")
+    assert not re.search(r"\d+\s*-\s*\d+\s*second", simulate), (
+        "simulate SKILL.md must not instruct seconds-scale polling"
+    )
+    canonical = "once per minute"
+    assert canonical in simulate, (
+        f"simulate SKILL.md must carry the canonical cadence '{canonical}'"
+    )
+    sim_tools = (REPO_ROOT / "mcp_server" / "skills" / "simulation"
+                 / "tools.py").read_text(encoding="utf-8")
+    assert canonical in sim_tools, "get_run_status docstring lost the cadence"
+    server_py = (REPO_ROOT / "mcp_server" / "server.py").read_text(encoding="utf-8")
+    assert canonical in server_py, (
+        "server instructions must match the docstring cadence tier"
+    )
+    assert "1-2 minutes" not in server_py, (
+        "server instructions contradict the once-per-minute docstring tier"
+    )
+
+
+def test_weather_discovery_routes_to_list_weather_files():
+    # Regression: simulate + tool-workflows routed weather discovery via
+    # list_files() while server instructions + docstring say list_weather_files
+    # (plan C2)
+    _, simulate = _parse_skill_md(SERVED_SKILLS_DIR / "simulate" / "SKILL.md")
+    assert "list_weather_files" in simulate, (
+        "simulate SKILL.md must route weather discovery to list_weather_files"
+    )
+    assert "list_files(" not in simulate, (
+        "simulate SKILL.md must not use list_files for weather discovery"
+    )
+    _, workflows = _parse_skill_md(SERVED_SKILLS_DIR / "tool-workflows" / "SKILL.md")
+    weather = re.search(r"## Set Up Weather\n(.*?)(?=\n## |\Z)", workflows, re.DOTALL)
+    assert weather, "tool-workflows lost its Set Up Weather section"
+    assert "list_weather_files" in weather.group(1), (
+        "tool-workflows weather recipe must use list_weather_files"
+    )
+    assert "list_files(" not in weather.group(1), (
+        "tool-workflows weather recipe must not use list_files"
+    )


### PR DESCRIPTION
Part 1 of the skills-consistency plan (docs/plans/plan-skills-consistency-fixes.md).

## The problem

The skill guides we serve to AI agents (`.claude/skills/*/SKILL.md`, the eval tables, and the six MCP prompt templates) had drifted from the actual tool signatures. Agents copy these examples verbatim, so every mismatch turns into a failed tool call at runtime. Examples that were wrong until now:

- `save_osm_model(save_path=...)` — the parameter is actually `osm_path` (appeared in 8 places across 6 guides)
- `get_run_logs(log_type="stderr")` — the real parameter is `stream`, with values `"openstudio"` or `"energyplus"`
- `compare_runs(run_id_a, run_id_b)` — the real keywords are `baseline_run_id` / `retrofit_run_id`
- `shift_schedule_time(shift_value_hours=)` and `add_rooftop_pv(fraction_of_roof=)` — both parameter names were wrong
- The economizer and plant-loop sizing examples passed flat keyword args, but those tools take a `properties` JSON dict
- Custom-measure examples pointed at `/runs/custom_measures/`, a directory that no longer exists (measures live under `/measures/<user>/custom/`)
- Three of the six MCP prompts emitted steps that cannot run at all (e.g. `run_simulation()` with no model path, `get_run_status()` with no run id), and the "full building simulation" prompt accepted a system type and then never used it
- The old test only checked backtick-quoted tool names, so none of this ever failed CI

## What this PR does

**New validation layer (committed first, failing on the old content):**
- `tests/doc_contract_lib.py` reads every `@mcp.tool` signature straight from the source files (no imports, so the unit tests can never accidentally pull in OpenStudio), extracts the tool calls written in the guides — including code blocks — and checks each one: does the tool exist, are the keyword names real, are required arguments present.
- `tests/test_skill_docs.py` runs those checks over every served guide, every eval table, and all six MCP prompt templates. It also checks that the polling-cadence and weather-discovery advice matches across the guide, the tool docstring, and the server instructions.
- The eval tables got a defined grammar. The "critical params" column (previously parsed and then ignored) now produces real assertions, and the "should NOT trigger" tables were rewritten from free-text explanations into a checkable form (query → forbidden tools → acceptable alternatives) with a new LLM test that enforces them.

**Content fixes (second commit, turning the suite green):** all of the mismatches above, plus consistent polling advice (check about once a minute — each status poll costs the agent a full LLM turn), weather discovery via `list_weather_files`, and the qaqc guide's severity labels aligned with what `validate_model` actually reports.

One thing deliberately left alone: two examples that pass `run_id` to `apply_measure`. The tool doesn't accept that argument yet — #140 fixes the tool, and removes the temporary exception here.

## How it was verified

- Full unit suite in Docker: 468 passed.
- A targeted live-agent run (10 eval cases covering the new assertions) passed after two negative-case rows were widened to accept legitimate "inspect first" behavior.
- `ruff` clean on all touched files.