### PR TITLE
Let apply_measure run reporting measures against a completed simulation (run_id)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
               # + python_ems (plugin templates, actuator discovery, plugin sims)
               # + outcome grader (LLM benchmark gate-2 ground truth, ~7s)
               # + gbXML .stat-file climate-zone resolution test (moved from shard 4 to balance runtime)
-              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py tests/test_file_transfer.py tests/test_measure_discovery.py tests/test_python_ems.py tests/test_knowledge_ablation.py tests/test_outcome_grader_integration.py tests/test_gbxml_import.py::test_import_gbxml_resolves_climate_zone_from_stat_file_on_austin_fixture"
+              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py tests/test_file_transfer.py tests/test_measure_discovery.py tests/test_python_ems.py tests/test_knowledge_ablation.py tests/test_outcome_grader_integration.py tests/test_apply_measure_run_id.py tests/test_gbxml_import.py::test_import_gbxml_resolves_climate_zone_from_stat_file_on_austin_fixture"
               EXTRA_ENV=""
               ;;
             3)

--- a/mcp_server/skills/measure_authoring/operations.py
+++ b/mcp_server/skills/measure_authoring/operations.py
@@ -274,13 +274,14 @@ def _build_ruby_reporting_run(args: list[dict], run_body: str) -> str:
     if extraction:
         lines.append(extraction)
     lines += [
-        "    model = runner.lastOpenStudioModel",
-        "    if model.is_initialized",
-        "      model = model.get",
-        "    end",
-        "    sql_path = runner.lastEnergyPlusSqlFilePath",
-        "    if sql_path.is_initialized",
-        "      sql = OpenStudio::SqlFile.new(sql_path.get)",
+        # OSRunner 3.11.0 has lastEnergyPlusSqlFile (Optional<SqlFile>) but no
+        # lastEnergyPlusSqlFilePath getter — the OSW runner sets the path via
+        # setLastEnergyPlusSqlFilePath and measures read the SqlFile optional
+        "    model_opt = runner.lastOpenStudioModel",
+        "    model = model_opt.is_initialized ? model_opt.get : nil",
+        "    sql_opt = runner.lastEnergyPlusSqlFile",
+        "    if sql_opt.is_initialized",
+        "      sql = sql_opt.get",
         "      model.setSqlFile(sql) if model",
         "    end",
         f"    {_BEGIN_MARKER}",
@@ -324,11 +325,13 @@ def _build_python_reporting_run(args: list[dict], run_body: str) -> str:
     if extraction:
         lines.append(extraction)
     lines += [
+        # Same 3.11.0 API note as the Ruby template: read the SqlFile
+        # optional, not the nonexistent lastEnergyPlusSqlFilePath getter
         "        model_opt = runner.lastOpenStudioModel()",
         "        model = model_opt.get() if model_opt.is_initialized() else None",
-        "        sql_path = runner.lastEnergyPlusSqlFilePath()",
-        "        if sql_path.is_initialized():",
-        "            sql = openstudio.SqlFile(sql_path.get())",
+        "        sql_opt = runner.lastEnergyPlusSqlFile()",
+        "        if sql_opt.is_initialized():",
+        "            sql = sql_opt.get()",
         "            if model:",
         "                model.setSqlFile(sql)",
         f"        {_BEGIN_MARKER}",
@@ -1038,11 +1041,19 @@ def _test_reporting_measure_with_run(
             "test_output": f"ReportingMeasure test failed (exit {proc.returncode}):\n{display}",
         }
 
-    return {
+    from mcp_server.skills.measures.runner_messages import parse_runner_messages
+
+    result = {
         "ok": True,
         "passed": 1, "failed": 0, "errors": 0,
         "test_output": f"ReportingMeasure ran successfully via --postprocess_only:\n{display}",
     }
+    # Surface the measure's registered messages (registerValue/Info/Final) —
+    # the CLI log is often empty on success, which told the caller nothing
+    runner_messages = parse_runner_messages(run_dir / "out.osw")
+    if runner_messages:
+        result["runner_messages"] = runner_messages
+    return result
 
 
 def _detect_measure_type(mdir: Path) -> str:

--- a/mcp_server/skills/measure_authoring/tools.py
+++ b/mcp_server/skills/measure_authoring/tools.py
@@ -85,7 +85,7 @@ def register(mcp):
                 ReportingMeasures run after simulation, accessing SQL results.
                 run() receives (runner, user_arguments) — no model param.
                 Model and SQL are available via runner.lastOpenStudioModel
-                and runner.lastEnergyPlusSqlFilePath (boilerplate auto-generated).
+                and runner.lastEnergyPlusSqlFile (boilerplate auto-generated).
 
         Ruby common patterns for run_body:
           CRITICAL — error/applicability handling:

--- a/mcp_server/skills/measures/tools.py
+++ b/mcp_server/skills/measures/tools.py
@@ -127,6 +127,7 @@ def register(mcp):
     def apply_measure_tool(
         measure_dir: str,
         arguments: dict[str, Any] | None = None,
+        run_id: str | None = None,
     ):
         """Run an existing local OpenStudio measure against the loaded model.
 
@@ -134,9 +135,15 @@ def register(mcp):
         for a measure by name or intent, call find_measure first and pass its
         top-level measure_dir here. To create a new measure, use create_measure.
 
+        For a ReportingMeasure, pass run_id from a completed simulation — the
+        run's SQL/IDF are staged and only reporting measures execute
+        (--postprocess_only), leaving the loaded model untouched.
+
         Args:
             measure_dir: Path to the measure directory (contains measure.rb)
             arguments: Optional dict of argument_name -> value overrides
+            run_id: Completed simulation run_id (ReportingMeasures only)
 
         """
-        return apply_measure(measure_dir=measure_dir, arguments=arguments)
+        return apply_measure(measure_dir=measure_dir, arguments=arguments,
+                             run_id=run_id)

--- a/tests/test_apply_measure_run_id.py
+++ b/tests/test_apply_measure_run_id.py
@@ -106,4 +106,21 @@ def test_apply_measure_accepts_run_id_for_reporting_measure():
                 assert bad["ok"] is False
                 assert "not found" in bad["error"].lower(), bad
 
+                # --- Assert: test_measure's run_id path executes run() too ---
+                # Regression: the scaffold called the nonexistent
+                # runner.lastEnergyPlusSqlFilePath (OSRunner 3.11.0 has only
+                # lastEnergyPlusSqlFile), so run() failed under any
+                # --postprocess_only execution; only args-only tests passed
+                tm = unwrap(await s.call_tool("test_measure", {
+                    "measure_dir": create["measure_dir"],
+                    "run_id": run_id,
+                }))
+                assert tm["ok"] is True, tm.get("test_output", tm)
+                assert tm["passed"] == 1 and tm["failed"] == 0, tm
+                tmsgs = tm.get("runner_messages") or {}
+                assert tmsgs.get("final_condition") == "Report complete", tm
+                assert any(
+                    "Total Site Energy" in m for m in tmsgs.get("info") or []
+                ), f"reporting measure did not read the run's SQL: {tm}"
+
     asyncio.run(_run())

--- a/tests/test_apply_measure_run_id.py
+++ b/tests/test_apply_measure_run_id.py
@@ -1,0 +1,109 @@
+"""apply_measure must accept run_id over MCP for ReportingMeasures (plan B1).
+
+The operation (measures/operations.py) fully implements the
+ReportingMeasure-on-completed-run path — stage SQL/IDF from the run, execute
+`openstudio run --postprocess_only` — but the MCP wrapper's schema dropped
+run_id, so the documented create_measure -> test_measure -> apply_measure
+workflow was unreachable over MCP for ReportingMeasures.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import (
+    EPW_PATH,
+    integration_enabled,
+    poll_until_done,
+    server_params,
+    unwrap,
+)
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+
+def _unique(prefix: str = "pytest_amri") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+# Reporting body that actually reads the simulation SQL, so a green run
+# proves the postprocess path wired the artifacts — not just that the
+# schema accepted the kwarg.
+RUBY_REPORTING_BODY = (
+    '    query = "SELECT Value FROM TabularDataWithStrings '
+    "WHERE ReportName='AnnualBuildingUtilityPerformanceSummary' "
+    "AND TableName='Site and Source Energy' "
+    "AND RowName='Total Site Energy' "
+    "AND ColumnName='Total Energy' "
+    "AND Units='GJ'\"\n"
+    "    val = sql.execAndReturnFirstDouble(query)\n"
+    "    if val.is_initialized\n"
+    '      runner.registerValue("total_site_energy_gj", val.get)\n'
+    '      runner.registerInfo("Total Site Energy: #{val.get} GJ")\n'
+    "    end\n"
+    '    runner.registerFinalCondition("Report complete")'
+)
+
+
+@pytest.mark.integration
+def test_apply_measure_accepts_run_id_for_reporting_measure():
+    """apply_measure(measure_dir, run_id=...) postprocesses a completed run."""
+    # Regression: MCP wrapper accepted only (measure_dir, arguments) and
+    # dropped run_id — the schema rejected the call both served skills
+    # instruct (measure-authoring, tool-workflows), leaving the implemented
+    # ReportingMeasure path unreachable over MCP (plan B1)
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+
+                # --- Arrange: model + completed simulation ---
+                name = _unique("amri_model")
+                cr = unwrap(await s.call_tool("create_example_osm", {"name": name}))
+                assert cr["ok"] is True, cr
+                sim = unwrap(await s.call_tool("run_simulation", {
+                    "osm_path": cr["osm_path"],
+                    "epw_path": EPW_PATH,
+                }))
+                assert sim["ok"] is True, sim
+                run_id = sim["run_id"]
+                status = await poll_until_done(s, run_id)
+                assert status["run"]["status"] == "success", status
+
+                # --- Arrange: a ReportingMeasure that reads the run's SQL ---
+                mname = _unique("amri_report")
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": mname,
+                    "description": "EUI report for run_id wiring test",
+                    "run_body": RUBY_REPORTING_BODY,
+                    "language": "Ruby",
+                    "measure_type": "ReportingMeasure",
+                }))
+                assert create["ok"] is True, create
+
+                # --- Act: the call the served skills instruct ---
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": create["measure_dir"],
+                    "run_id": run_id,
+                }))
+
+                # --- Assert: postprocess ran and read the simulation SQL ---
+                assert res["ok"] is True, res
+                msgs = res.get("runner_messages") or {}
+                assert msgs.get("final_condition") == "Report complete", res
+                infos = msgs.get("info") or []
+                assert any("Total Site Energy" in m for m in infos), (
+                    f"reporting measure did not read the run's SQL: {res}"
+                )
+
+                # --- Assert: clean error for a missing run stays intact ---
+                bad = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": create["measure_dir"],
+                    "run_id": "run_does_not_exist_123",
+                }))
+                assert bad["ok"] is False
+                assert "not found" in bad["error"].lower(), bad
+
+    asyncio.run(_run())

--- a/tests/test_measure_authoring.py
+++ b/tests/test_measure_authoring.py
@@ -799,7 +799,8 @@ def test_create_reporting_measure_ruby():
                 assert "def run(runner, user_arguments)" in text
                 assert "super(runner, user_arguments)" in text
                 assert "lastOpenStudioModel" in text
-                assert "lastEnergyPlusSqlFilePath" in text
+                assert "lastEnergyPlusSqlFile" in text
+                assert "lastEnergyPlusSqlFilePath" not in text  # nonexistent in 3.11.0 (B1)
                 assert "energyPlusOutputRequests" in text
     asyncio.run(_run())
 
@@ -834,7 +835,8 @@ def test_create_reporting_measure_python():
                 assert "ReportingMeasure" in text
                 assert "def run(self, runner, user_arguments)" in text
                 assert "lastOpenStudioModel" in text
-                assert "lastEnergyPlusSqlFilePath" in text
+                assert "lastEnergyPlusSqlFile" in text
+                assert "lastEnergyPlusSqlFilePath" not in text  # nonexistent in 3.11.0 (B1)
                 assert "energyPlusOutputRequests" in text
     asyncio.run(_run())
 

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -30,14 +30,9 @@ PROMPTS_TOOLS_PY = (
     REPO_ROOT / "mcp_server" / "skills" / "prompts_resources" / "tools.py"
 )
 
-# (context, tool, kwarg) triples temporarily tolerated. B1: apply_measure's
-# run_id path is implemented in operations.py but not yet exposed on the MCP
-# wrapper — PR "fix/apply-measure-run-id" adds the kwarg and MUST remove
-# these entries so the validator enforces it.
-KNOWN_EXCEPTIONS = frozenset({
-    ("measure-authoring/SKILL.md", "apply_measure", "run_id"),
-    ("tool-workflows/SKILL.md", "apply_measure", "run_id"),
-})
+# (context, tool, kwarg) triples temporarily tolerated — each entry must
+# cite the PR that removes it. Empty since apply_measure gained run_id (B1).
+KNOWN_EXCEPTIONS: frozenset[tuple[str, str, str]] = frozenset()
 
 # snake_case callees in served docs that are legitimately not MCP tools
 IGNORE_NAMES: frozenset[str] = frozenset()


### PR DESCRIPTION
Part 2 of the skills-consistency plan. Builds on #139 (the base branch will retarget to develop once #139 merges).

## The problem

Reporting measures are the sanctioned way to pull custom metrics out of simulation results. The backend code for running one against a completed simulation has existed for a while (`apply_measure`'s operation stages the run's SQL/IDF files and runs `openstudio run --postprocess_only`), and two of our served skill guides tell agents to call `apply_measure(measure_dir=..., run_id=...)`. But the MCP tool wrapper never exposed `run_id`, so every such call was rejected with a schema error. The feature was fully implemented and completely unreachable.

## What the fix uncovered

Writing the failing test first surfaced a second, worse bug: the generated ReportingMeasure boilerplate called `runner.lastEnergyPlusSqlFilePath` — a method that does not exist in OpenStudio 3.11.0 (only the setter/reset variants exist). So even with `run_id` wired through, every scaffolded reporting measure crashed the moment it ran. This affected `test_measure(run_id=...)` too, and nothing caught it because the only existing test ran argument validation, never the measure itself. The templates (Ruby and Python) now use `runner.lastEnergyPlusSqlFile`, the API that actually exists.

## Changes

- `apply_measure` accepts an optional `run_id` and forwards it; the docstring explains the reporting-measure behavior.
- Both scaffold templates read the SQL file via the working API.
- `test_measure`'s run_id path now returns the measure's registered messages (values, info, final condition) — previously it returned a log tail that is empty on success, telling the caller nothing.
- The temporary validator exception from #139 is removed, so the served examples are now checked for real.
- Existing template-content tests updated to pin the correct API and guard against the nonexistent one coming back.

## How it was verified

New integration test creates a model, runs a real simulation, scaffolds a reporting measure that queries total site energy from the SQL, and asserts both `apply_measure(run_id=...)` and `test_measure(run_id=...)` actually read the results (plus a clean error for a missing run). On the old code it fails with the exact schema rejection. Full measure test suites pass in Docker (47 tests). Added to CI shard 2 (~12 s).