### PR TITLE
Server-resolved model saves (save_name) and a proper way to fetch skill support files

### DIFF
--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -7,8 +7,9 @@ description: Translate a Revit-exported gbXML file into an OpenStudio model, the
 
 ## Workflow
 
-1. `import_gbxml(gbxml_path=..., epw_path=..., ...)` (optional `osm_path`, `run_name`) — needs four files under
-   `/inputs`: the gbXML file, its project EPW, and the EPW's companion `.stat`/`.ddy` files
+1. `import_gbxml(gbxml_path=..., epw_path=..., ...)` (optional `osm_path`, `run_name`) — needs four files staged
+   SERVER-side (e.g. under `/inputs`; remote clients upload with `request_upload`): the
+   gbXML file, its project EPW, and the EPW's companion `.stat`/`.ddy` files
    (same directory, same filename stem as the EPW). Result auto-loads the model and always
    returns a `climate_zone` (+ `climate_zone_source`) unless truly unresolvable — if
    `climate_zone_resolved` is `false`, call `change_building_location` explicitly before any

--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -49,15 +49,15 @@ apply_measure(measure_dir="/measures/<user>/custom/set_lights_8w")
 ### 4. Verify Results (Before/After Comparison)
 For rigorous validation, run a baseline simulation BEFORE applying the measure:
 ```
-save_osm_model(osm_path="/runs/baseline.osm")
-run_simulation(osm_path="/runs/baseline.osm", epw_path="<epw>")
+save_osm_model(save_name="baseline")            # response carries osm_path
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 extract_summary_metrics(run_id=<baseline_id>)   # record baseline EUI
 
 # reload, apply measure, re-simulate
 load_osm_model(osm_path="<original>")
 apply_measure(measure_dir="/measures/<user>/custom/set_lights_8w")
-save_osm_model(osm_path="/runs/retrofit.osm")
-run_simulation(osm_path="/runs/retrofit.osm", epw_path="<epw>")
+save_osm_model(save_name="retrofit")
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 extract_summary_metrics(run_id=<retrofit_id>)   # compare to baseline
 ```
 

--- a/.claude/skills/new-building/SKILL.md
+++ b/.claude/skills/new-building/SKILL.md
@@ -86,8 +86,8 @@ For fully custom buildings not matching DOE prototypes:
 
 After any workflow:
 ```
-save_osm_model(osm_path="/runs/<name>.osm")
-run_simulation(osm_path="/runs/<name>.osm", epw_path="/inputs/<city>.epw")
+save_osm_model(save_name="<name>")              # response carries osm_path
+run_simulation(osm_path=<osm_path from save>, epw_path="/inputs/<city>.epw")
 get_run_status(run_id=<id>)
 extract_summary_metrics(run_id=<id>)
 ```

--- a/.claude/skills/openstudio-patterns/SKILL.md
+++ b/.claude/skills/openstudio-patterns/SKILL.md
@@ -121,7 +121,7 @@ search_wiring_patterns("four pipe beam")     # get working connection code
 | `"system_type must be 1-10"` | Invalid system number | Check `list_baseline_systems` |
 | Simulation fails, no results | Missing weather file or design days | `change_building_location` (sets EPW + DDY + climate zone) |
 | EUI = 0 or unreasonable | No loads, no HVAC, or no run period | Check `inspect_osm_summary` for missing objects |
-| `"Output directory is not allowed"` / `"... path not allowed"` | Path outside your allowed roots (over HTTP each user is scoped to `/runs/<user>/`) | Use `/runs/` for output, `/inputs/` for input files; over HTTP use paths returned by tools |
+| `"Output directory is not allowed"` / `"... path not allowed"` | Path outside your allowed roots (over HTTP each user is scoped to `/runs/<user>/`) | Save with `save_osm_model(save_name=...)` and reuse the paths tools return; staged inputs are read-only |
 
 ## Save vs Simulate
 

--- a/.claude/skills/retrofit/SKILL.md
+++ b/.claude/skills/retrofit/SKILL.md
@@ -13,8 +13,8 @@ Apply energy conservation measures to an existing model and compare before/after
 ### 1. Establish Baseline
 Ensure a simulation has been run on the current model. If not:
 ```
-save_osm_model(osm_path="/runs/baseline.osm")
-run_simulation(osm_path="/runs/baseline.osm", epw_path="<epw>")
+save_osm_model(save_name="baseline")            # response carries osm_path
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 get_run_status(run_id=<id>)
 extract_summary_metrics(run_id=<baseline_id>)
 ```
@@ -53,12 +53,12 @@ Ask the user which upgrades to apply. Available ECM tools:
 **Model Cleanup:**
 - `clean_unused_objects()` — remove orphans before re-simulation
 
-See [ecm-catalog.md](ecm-catalog.md) for typical savings ranges.
+For typical savings ranges, fetch the catalog: `get_skill_file(skill_name="retrofit", filename="ecm-catalog.md")`.
 
 ### 4. Re-Simulate
 ```
-save_osm_model(osm_path="/runs/retrofit.osm")
-run_simulation(osm_path="/runs/retrofit.osm", epw_path="<epw>")
+save_osm_model(save_name="retrofit")            # response carries osm_path
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 get_run_status(run_id=<id>)
 extract_summary_metrics(run_id=<retrofit_id>)
 extract_end_use_breakdown(run_id=<retrofit_id>)
@@ -73,7 +73,7 @@ For manual comparison, use `extract_summary_metrics` on both runs.
 
 ## Notes
 
-- Always save to a new path before re-simulating to preserve the baseline
+- Always save under a new save_name before re-simulating to preserve the baseline
 - Multiple ECMs can be stacked before re-simulating
 - Some measures modify the model in-memory (thermostat, window); others run as OpenStudio measures
 - For custom ECMs not covered by existing tools, use `create_measure` to write a custom measure (see `measure-authoring` skill)

--- a/.claude/skills/simulate/SKILL.md
+++ b/.claude/skills/simulate/SKILL.md
@@ -10,19 +10,19 @@ Run a simulation on the currently loaded model and present results.
 
 ## Steps
 
-1. Save the model to a unique path under `/runs/`:
+1. Save the model — the server picks a private writable path and returns it:
    ```
-   save_osm_model(osm_path="/runs/<descriptive_name>.osm")
+   save_osm_model(save_name="<descriptive_name>")   # response carries osm_path
    ```
 
-2. Ask the user which weather file to use. They must provide an EPW file path in the docker-mounted input directory. List available weather files if needed:
+2. Ask the user which weather file to use. Weather files are SERVER-side; list the available ones (remote clients can stage their own EPW with `request_upload`):
    ```
    list_weather_files()
    ```
 
-3. Run the simulation:
+3. Run the simulation with the path the save returned:
    ```
-   run_simulation(osm_path="<saved_path>", epw_path="<user_epw_path>")
+   run_simulation(osm_path=<osm_path from save>, epw_path="<epw_path>")
    ```
 
 4. Poll until complete — first status check ~60 seconds after submitting, then

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -59,7 +59,7 @@ create_electric_equipment(
 
 ## Set Up Weather
 
-User must provide an EPW file in the docker-mounted input directory.
+Weather files are SERVER-side (remote clients stage their own with `request_upload`).
 `change_building_location` sets weather, design days (from DDY), and climate zone in one call.
 The EPW must have companion `.stat` and `.ddy` files alongside it (same directory, same base filename).
 
@@ -82,10 +82,10 @@ create_typical_building(template="90.1-2019", climate_zone="ASHRAE 169-2013-5A")
 # Per candidate: swap ONLY the HVAC, simulate, compare
 create_typical_building(system_type="PVAV with gas boiler reheat",
     template="90.1-2019", climate_zone="ASHRAE 169-2013-5A", hvac_only=True)
-save_osm_model(osm_path="/runs/sweep_pvav.osm"); run_simulation(...)
+save_osm_model(save_name="sweep_pvav"); run_simulation(osm_path=<osm_path from save>)
 
 create_typical_building(system_type="PSZ-HP", ..., hvac_only=True)
-save_osm_model(osm_path="/runs/sweep_pszhp.osm"); run_simulation(...)
+save_osm_model(save_name="sweep_pszhp"); run_simulation(osm_path=<osm_path from save>)
 
 compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-hours deltas
 ```
@@ -130,8 +130,8 @@ Full chain: create → test → apply → simulate → compare results.
 
 ```
 # 1. Baseline simulation
-save_osm_model(osm_path="/runs/baseline.osm")
-run_simulation(osm_path="/runs/baseline.osm", epw_path="<epw>")
+save_osm_model(save_name="baseline")            # response carries osm_path
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 extract_summary_metrics(run_id=<baseline_id>)
 
 # 2. Create custom measure
@@ -142,8 +142,8 @@ test_measure(measure_dir="/measures/<user>/custom/my_measure")  # use the measur
 # 3. Reload original model, apply measure, re-simulate
 load_osm_model(osm_path="<original>")
 apply_measure(measure_dir="/measures/<user>/custom/my_measure")
-save_osm_model(osm_path="/runs/retrofit.osm")
-run_simulation(osm_path="/runs/retrofit.osm", epw_path="<epw>")
+save_osm_model(save_name="retrofit")
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 extract_summary_metrics(run_id=<retrofit_id>)
 
 # 4. Compare baseline vs retrofit EUI
@@ -163,7 +163,8 @@ ReportingMeasures run after simulation to analyze SQL results.
 
 ```
 # 1. Run simulation first
-run_simulation(osm_path="/runs/model.osm", epw_path="<epw>")
+save_osm_model(save_name="model")               # response carries osm_path
+run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
 
 # 2. Create reporting measure
 create_measure(name="custom_report", description="...",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
               # + generic HVAC template comfort benchmark (issue #97)
               # + weather fail-fast + failed-run extraction guard
               # + hvac_only standards swap parity benchmark (issue #97, moved from shard 4 to balance runtime)
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py tests/test_generic_hvac_comfort.py tests/test_hvac_only_swap.py tests/test_run_simulation_weather_guard.py"
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py tests/test_generic_hvac_comfort.py tests/test_hvac_only_swap.py tests/test_run_simulation_weather_guard.py tests/test_save_name_delivery.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/mcp_server/skills/model_management/operations.py
+++ b/mcp_server/skills/model_management/operations.py
@@ -179,11 +179,36 @@ def load_osm_model(osm_path: str, version_translate: bool = True) -> dict[str, A
         return {"ok": False, "error": f"Failed to load OSM: {e}", "osm_path": str(p)}
 
 
-def save_osm_model(osm_path: str | None = None) -> dict[str, Any]:
+def _resolve_save_name(save_name: str) -> Path | None:
+    """Server-resolved save-as target for a bare name, or None if invalid.
+
+    Accepts a basename only (no separators, drives, traversal, or hidden
+    names), normalizes the .osm suffix, and resolves under the caller's
+    private run root — no user key or writable-root knowledge is client input.
+    """
+    if (
+        not save_name
+        or any(c in save_name for c in "/\\:")
+        or save_name in (".", "..")
+        or save_name.startswith(".")
+        or Path(save_name).name != save_name
+    ):
+        return None
+    name = save_name if save_name.endswith(".osm") else f"{save_name}.osm"
+    return (user_run_root() / "models" / name).resolve()
+
+
+def save_osm_model(
+    osm_path: str | None = None,
+    save_name: str | None = None,
+) -> dict[str, Any]:
     """Save the currently loaded model to disk.
 
     Args:
-        osm_path: Optional path to save to. If None, saves to the original load path.
+        osm_path: Optional explicit path to save to. If None, saves to the
+            original load path.
+        save_name: Optional bare name — the server resolves the path inside
+            the caller's private run area (client-neutral save-as).
 
     Returns:
         Dict with ok=True and saved path on success, ok=False with error on failure
@@ -193,8 +218,25 @@ def save_osm_model(osm_path: str | None = None) -> dict[str, Any]:
     if current_model is None:
         return {"ok": False, "error": "No model loaded. Call load_osm_model first."}
 
+    if osm_path is not None and save_name is not None:
+        return {
+            "ok": False,
+            "error": "Pass either osm_path or save_name, not both.",
+        }
+
     # Determine save path
-    if osm_path is not None:
+    if save_name is not None:
+        p = _resolve_save_name(save_name)
+        if p is None:
+            return {
+                "ok": False,
+                "error": (
+                    f"Invalid save_name '{save_name}': must be a bare file "
+                    "name (no separators, drives, or leading dots); "
+                    ".osm is appended automatically."
+                ),
+            }
+    elif osm_path is not None:
         p = Path(osm_path).resolve()
     else:
         current_path = model_manager.get_model_path()

--- a/mcp_server/skills/model_management/tools.py
+++ b/mcp_server/skills/model_management/tools.py
@@ -26,15 +26,26 @@ def register(mcp):
         return load_osm_model(osm_path=osm_path, version_translate=version_translate)
 
     @mcp.tool(name="save_osm_model", tags={"core"})
-    def save_osm_model_tool(osm_path: str | None = None):
+    def save_osm_model_tool(
+        osm_path: str | None = None,
+        save_name: str | None = None,
+    ):
         """Save the currently loaded model to disk as an OSM file.
         IMPORTANT: call after making changes to persist the model. Changes
         are lost if you don't save before loading a different model.
 
+        Prefer save_name — the server picks a private writable path and the
+        response returns the actual osm_path to pass to run_simulation.
+        A model loaded from a read-only area (staged inputs, repo assets)
+        cannot be saved back in place; save_name always works.
+
         Args:
-            osm_path: Optional path to save to. If not provided, saves to original load path.
+            osm_path: Optional explicit server-side path. If neither arg is
+                given, saves to the original load path.
+            save_name: Bare file name, e.g. "baseline" (".osm" appended;
+                no directories). Mutually exclusive with osm_path.
         """
-        return save_osm_model(osm_path=osm_path)
+        return save_osm_model(osm_path=osm_path, save_name=save_name)
 
     @mcp.tool(name="create_example_osm", tags={"geometry"})
     def create_example_osm_tool(name: str | None = None, out_dir: str | None = None):

--- a/mcp_server/skills/prompts_resources/tools.py
+++ b/mcp_server/skills/prompts_resources/tools.py
@@ -46,13 +46,13 @@ def register(mcp):
             f'weather_file="/inputs/{climate_city}.epw")  # builds typical model\n'
             f'2. create_typical_building(system_type="{system_a}", '
             'hvac_only=True)  # standards-tuned swap, loads untouched\n'
-            '3. save_osm_model(osm_path="/runs/sweep_a.osm") and '
-            'run_simulation(osm_path="/runs/sweep_a.osm")\n'
+            '3. save_osm_model(save_name="sweep_a") and '
+            "run_simulation(osm_path=<osm_path from save>)\n"
             "4. get_run_status(run_id=<id from run_simulation>) until complete\n"
             f'5. create_typical_building(system_type="{system_b}", '
             'hvac_only=True)  # swap to candidate B on the SAME model\n'
-            '6. save_osm_model(osm_path="/runs/sweep_b.osm") and '
-            'run_simulation(osm_path="/runs/sweep_b.osm")\n'
+            '6. save_osm_model(save_name="sweep_b") and '
+            "run_simulation(osm_path=<osm_path from save>)\n"
             "7. compare_runs(baseline_run_id=<run A id>, "
             "retrofit_run_id=<run B id>) — EUI, end uses, unmet hours\n\n"
             "Note: system_type takes openstudio-standards names — call "
@@ -91,7 +91,7 @@ def register(mcp):
             "existing layers; verify assembly_r_si_after > before\n"
             "6. assign_construction_to_surface(surface_name=<target surface>, "
             "construction_name=<new construction>) for each target surface\n"
-            '7. save_osm_model(osm_path="/runs/retrofit.osm") — save to a '
+            '7. save_osm_model(save_name="retrofit") — the server picks a '
             "new path, never over a read-only input"
         )
 
@@ -116,8 +116,8 @@ def register(mcp):
             f'weather_file="/inputs/{climate_city}.epw", '
             f'system_type="{system_type}")\n'
             "2. list_spaces() — verify geometry and loads\n"
-            '3. save_osm_model(osm_path="/runs/full_building.osm") and '
-            'run_simulation(osm_path="/runs/full_building.osm")\n'
+            '3. save_osm_model(save_name="full_building") and '
+            "run_simulation(osm_path=<osm_path from save>)\n"
             "4. Poll get_run_status(run_id=<id from run_simulation>) "
             "until complete\n"
             "5. extract_summary_metrics(run_id=<id>) — review EUI and "
@@ -172,7 +172,7 @@ def register(mcp):
             "4. get_model_summary() — verify what was added\n"
             "5. list_air_loops() — inspect HVAC\n"
             '6. list_model_objects(object_type="Construction") — inspect envelope\n'
-            '7. save_osm_model(osm_path="/runs/typical.osm") — save to a new '
+            '7. save_osm_model(save_name="typical") — the server picks a '
             "path, never over a read-only input"
         )
 

--- a/mcp_server/skills/skill_discovery/operations.py
+++ b/mcp_server/skills/skill_discovery/operations.py
@@ -103,12 +103,94 @@ def get_skill_op(name: str) -> dict:
         "content": body,
     }
 
-    # List supporting files so agent knows to ask for them
-    supporting = []
-    for f in sorted(skill_dir.iterdir()):
-        if f.name != "SKILL.md" and f.is_file():
-            supporting.append(f.name)
+    # List agent-support files so the agent knows to fetch them
+    supporting = [
+        f.name for f in sorted(skill_dir.iterdir())
+        if f.is_file() and _is_agent_support_file(f.name)
+    ]
     if supporting:
         result["supporting_files"] = supporting
+        result["supporting_files_hint"] = (
+            "Fetch with get_skill_file(skill_name=..., filename=...)"
+        )
 
     return result
+
+
+# Extensions a skill may serve to agents as supporting reference material.
+# SKILL.md is delivered via get_skill; eval.md is test data; README.md is
+# developer notes; hidden files and other artifacts are never served.
+_SUPPORT_EXTENSIONS = {".md", ".txt", ".csv", ".json"}
+_NON_SUPPORT_NAMES = {"SKILL.md", "eval.md", "README.md"}
+
+
+def _is_agent_support_file(name: str) -> bool:
+    """Whether a file in a skill directory is agent-facing support material."""
+    if name in _NON_SUPPORT_NAMES or name.startswith("."):
+        return False
+    return Path(name).suffix.lower() in _SUPPORT_EXTENSIONS
+
+
+def get_skill_file_op(skill_name: str, filename: str) -> dict:
+    """Read one supporting file of a skill (the sole retrieval affordance).
+
+    Resolves inside the configured SKILLS_DIR only; rejects absolute paths,
+    traversal, and files that are not agent support material.
+    """
+    safe_skill = Path(skill_name).name
+    if (
+        safe_skill in (".", "..", "")
+        or "/" in skill_name or "\\" in skill_name
+    ):
+        return {"ok": False, "error": f"Invalid skill name: '{skill_name}'"}
+    skill_dir = SKILLS_DIR / safe_skill
+    if not (skill_dir / "SKILL.md").is_file():
+        return {
+            "ok": False,
+            "error": (
+                f"Skill '{skill_name}' not found. "
+                "Use list_skills() to see available workflows."
+            ),
+        }
+
+    if (
+        not filename
+        or Path(filename).is_absolute()
+        or "/" in filename or "\\" in filename
+        or Path(filename).name != filename
+    ):
+        return {"ok": False, "error": f"Invalid filename: '{filename}'"}
+    if not _is_agent_support_file(filename):
+        return {
+            "ok": False,
+            "error": (
+                f"'{filename}' is not an agent support file. Available: "
+                "see supporting_files in get_skill(...)."
+            ),
+        }
+
+    target = (skill_dir / filename).resolve()
+    try:
+        target.relative_to(SKILLS_DIR.resolve())
+    except ValueError:
+        return {"ok": False, "error": f"Invalid filename: '{filename}'"}
+    if not target.is_file():
+        return {
+            "ok": False,
+            "error": (
+                f"File '{filename}' not found in skill '{safe_skill}'. "
+                "Check supporting_files in get_skill(...)."
+            ),
+        }
+
+    try:
+        content = target.read_text(encoding="utf-8")
+    except OSError as e:
+        return {"ok": False, "error": f"Failed to read file: {e}"}
+
+    return {
+        "ok": True,
+        "skill": safe_skill,
+        "filename": filename,
+        "content": content,
+    }

--- a/mcp_server/skills/skill_discovery/tools.py
+++ b/mcp_server/skills/skill_discovery/tools.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from mcp_server.skills.skill_discovery.operations import (
+    get_skill_file_op,
     get_skill_op,
     list_skills_op,
 )
@@ -32,3 +33,16 @@ def register(mcp):
                   "new-building", "retrofit", "add-hvac", "qaqc")
         """
         return get_skill_op(name)
+
+    @mcp.tool(name="get_skill_file", tags={"core"})
+    def get_skill_file_tool(skill_name: str, filename: str):
+        """Fetch a supporting file advertised by get_skill (its
+        supporting_files list) — reference tables and catalogs that back a
+        workflow guide, e.g. get_skill_file(skill_name="retrofit",
+        filename="ecm-catalog.md").
+
+        Args:
+            skill_name: Skill name from list_skills
+            filename: File name from get_skill's supporting_files
+        """
+        return get_skill_file_op(skill_name, filename)

--- a/tests/test_knowledge_ablation.py
+++ b/tests/test_knowledge_ablation.py
@@ -12,7 +12,7 @@ from conftest import integration_enabled, server_params
 from mcp import ClientSession
 from mcp.client.stdio import stdio_client
 
-KNOWLEDGE_TOOLS = {"list_skills", "get_skill", "recommend_tools"}
+KNOWLEDGE_TOOLS = {"list_skills", "get_skill", "get_skill_file", "recommend_tools"}
 
 
 async def _tool_names() -> set:

--- a/tests/test_save_name_delivery.py
+++ b/tests/test_save_name_delivery.py
@@ -124,7 +124,7 @@ def test_save_name_scopes_to_caller_and_isolates_users():
 
                 # Mutual exclusion with osm_path
                 both = unwrap(await s1.call_tool("save_osm_model", {
-                    "save_name": "x", "osm_path": "/tmp/x.osm",
+                    "save_name": "x", "osm_path": "/runs/x.osm",
                 }))
                 assert both["ok"] is False, both
 

--- a/tests/test_save_name_delivery.py
+++ b/tests/test_save_name_delivery.py
@@ -1,0 +1,172 @@
+"""Client-neutral model saving (save_name) + skill support-file delivery.
+
+Plan findings C3 + F4: served skills taught literal /runs/... writes that the
+HTTP identity layer denies (each HTTP user owns RUN_ROOT/<user_key>, not
+/runs), and advertised supporting files (ecm-catalog.md) with no fetch path.
+
+save_osm_model(save_name=...) is the server-resolved save-as: basename in,
+server picks the caller-private path, response returns the real osm_path.
+get_skill_file(skill_name, filename) is the sole support-file retrieval
+affordance.
+"""
+import asyncio
+import uuid
+
+import pytest
+from conftest import (
+    http_server,
+    http_session,
+    integration_enabled,
+    server_params,
+    unwrap,
+)
+from doc_contract_lib import load_tool_registry
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+# Read-only shared asset (under /repo, a shared read root in the container)
+READONLY_OSM = "/repo/tests/assets/baseline_model_constructions.osm"
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:10]}"
+
+
+# ---------------------------------------------------------------------------
+# Unit: tool contracts (AST — no imports)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_save_osm_model_exposes_save_name():
+    # Regression: served skills wrote literal /runs/<name>.osm — denied for
+    # HTTP users whose writable root is /runs/<user_key> (C3). save_name is
+    # the client-neutral affordance; the server resolves the real path.
+    registry = load_tool_registry()
+    assert "save_name" in registry["save_osm_model"].params, (
+        "save_osm_model must accept save_name (server-resolved save-as)"
+    )
+
+
+@pytest.mark.unit
+def test_get_skill_file_registered():
+    # Regression: get_skill advertised supporting_files (ecm-catalog.md) with
+    # no documented fetch path (F4) — get_skill_file is the retrieval tool
+    registry = load_tool_registry()
+    assert "get_skill_file" in registry, "get_skill_file tool must exist"
+    sig = registry["get_skill_file"]
+    assert set(sig.required) == {"skill_name", "filename"}, sig
+
+
+# ---------------------------------------------------------------------------
+# Integration: HTTP identity — save_name lands in the caller's private root
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_save_name_scopes_to_caller_and_isolates_users():
+    # Regression: with identity-scoped roots, a no-arg save of a model loaded
+    # from a read-only shared root is denied and literal /runs paths are not
+    # a user's writable area — save_name must resolve inside the caller's
+    # run root and stay invisible to other principals (C3)
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    with http_server({"MCP_AUTH": "none"}) as (url, _proc):
+        async def _run():
+            async with http_session(url) as s1, http_session(url) as s2:
+                ld = unwrap(await s1.call_tool("load_osm_model",
+                                               {"osm_path": READONLY_OSM}))
+                assert ld["ok"] is True, ld
+
+                # No-arg save resolves to the read-only original path — denied
+                denied = unwrap(await s1.call_tool("save_osm_model", {}))
+                assert denied["ok"] is False, denied
+                assert "not allowed" in denied["error"].lower(), denied
+
+                # Server-resolved save-as
+                saved = unwrap(await s1.call_tool("save_osm_model",
+                                                  {"save_name": "baseline"}))
+                assert saved["ok"] is True, saved
+                path = saved["osm_path"]
+                assert path.endswith("/models/baseline.osm"), path
+                assert path != "/runs/models/baseline.osm", (
+                    "HTTP user's save must land under /runs/<user_key>/, "
+                    f"not the shared /runs root: {path}"
+                )
+
+                # The returned path feeds back into the caller's own tools
+                reload_own = unwrap(await s1.call_tool("load_osm_model",
+                                                       {"osm_path": path}))
+                assert reload_own["ok"] is True, reload_own
+
+                # Another principal can neither read nor overwrite it
+                other_read = unwrap(await s2.call_tool("load_osm_model",
+                                                       {"osm_path": path}))
+                assert other_read["ok"] is False, other_read
+                assert "not allowed" in other_read["error"].lower(), other_read
+
+                ld2 = unwrap(await s2.call_tool("load_osm_model",
+                                                {"osm_path": READONLY_OSM}))
+                assert ld2["ok"] is True, ld2
+                s2_saved = unwrap(await s2.call_tool("save_osm_model",
+                                                     {"save_name": "baseline"}))
+                assert s2_saved["ok"] is True, s2_saved
+                assert s2_saved["osm_path"] != path, (
+                    "two principals saving the same save_name must get "
+                    "distinct private paths"
+                )
+
+                # Separator/traversal names are rejected with a clear error
+                for bad in ("../escape", "a/b", "..", "C:evil"):
+                    res = unwrap(await s1.call_tool("save_osm_model",
+                                                    {"save_name": bad}))
+                    assert res["ok"] is False, (bad, res)
+                    assert "save_name" in res["error"], (bad, res)
+
+                # Mutual exclusion with osm_path
+                both = unwrap(await s1.call_tool("save_osm_model", {
+                    "save_name": "x", "osm_path": "/tmp/x.osm",
+                }))
+                assert both["ok"] is False, both
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Integration: get_skill_file serves the advertised support file
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_get_skill_file_serves_ecm_catalog():
+    # Regression: retrofit advertised ecm-catalog.md with no fetch path (F4);
+    # get_skill lists it in supporting_files and get_skill_file returns it
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+
+                skill = unwrap(await s.call_tool("get_skill",
+                                                 {"name": "retrofit"}))
+                assert skill["ok"] is True, skill
+                assert skill["supporting_files"] == ["ecm-catalog.md"], skill
+
+                res = unwrap(await s.call_tool("get_skill_file", {
+                    "skill_name": "retrofit", "filename": "ecm-catalog.md",
+                }))
+                assert res["ok"] is True, res
+                assert res["filename"] == "ecm-catalog.md"
+                assert "## Envelope" in res["content"], (
+                    "ecm-catalog content missing expected ECM category"
+                )
+
+                # Traversal and non-support files are refused
+                for bad in ("../retrofit/ecm-catalog.md", "/etc/passwd",
+                            "SKILL.md", "eval.md", ".hidden.md"):
+                    denied = unwrap(await s.call_tool("get_skill_file", {
+                        "skill_name": "retrofit", "filename": bad,
+                    }))
+                    assert denied["ok"] is False, (bad, denied)
+
+    asyncio.run(_run())

--- a/tests/test_skill_registration.py
+++ b/tests/test_skill_registration.py
@@ -210,6 +210,7 @@ EXPECTED_TOOLS = {
     # Skill Discovery
     "list_skills",
     "get_skill",
+    "get_skill_file",
     # API Reference
     "search_api",
     "search_wiring_patterns",
@@ -279,7 +280,7 @@ def test_all_tool_names_registered():
 
 # The exact roster removed by the benchmark ablation arm (reviewer-response
 # plan D3) — keep in lockstep with _KNOWLEDGE_SKILLS in mcp_server/skills.
-KNOWLEDGE_TOOLS = {"list_skills", "get_skill", "recommend_tools"}
+KNOWLEDGE_TOOLS = {"list_skills", "get_skill", "get_skill_file", "recommend_tools"}
 
 
 def test_knowledge_skills_ablation_flag(monkeypatch):

--- a/tests/test_skill_tools.py
+++ b/tests/test_skill_tools.py
@@ -12,6 +12,7 @@ import pytest
 
 from mcp_server.skills.skill_discovery.operations import (
     _parse_frontmatter,
+    get_skill_file_op,
     get_skill_op,
     list_skills_op,
 )
@@ -221,3 +222,70 @@ def test_get_skill_path_traversal(tmp_path):
     assert result["ok"] is False
     assert "error" in result, "Path traversal rejection should include error message"
     assert result["error"].strip(), "Error message should not be empty for path traversal rejection"
+
+
+# --- get_skill_file + support-file classification ---
+
+def _support_skill_dir(tmp_path):
+    d = tmp_path / "retrofit"
+    d.mkdir()
+    (d / "SKILL.md").write_text("---\nname: retrofit\n---\nBody", encoding="utf-8")
+    (d / "eval.md").write_text("| Query |", encoding="utf-8")
+    (d / "ecm-catalog.md").write_text("## Envelope\nECM list", encoding="utf-8")
+    (d / ".hidden.md").write_text("secret", encoding="utf-8")
+    (d / "notes.pyc").write_text("junk", encoding="utf-8")
+    return tmp_path
+
+
+def test_supporting_files_filtered_to_agent_support(tmp_path):
+    # Regression: get_skill listed eval.md (test data) and would list hidden/
+    # developer artifacts in supporting_files (F4) — only agent support shows
+    root = _support_skill_dir(tmp_path)
+    with patch("mcp_server.skills.skill_discovery.operations.SKILLS_DIR", root):
+        result = get_skill_op("retrofit")
+    assert result["ok"] is True
+    assert result["supporting_files"] == ["ecm-catalog.md"]
+    assert "get_skill_file" in result["supporting_files_hint"]
+
+
+def test_get_skill_file_returns_content(tmp_path):
+    # Validates: get_skill_file serves an advertised support file's content
+    root = _support_skill_dir(tmp_path)
+    with patch("mcp_server.skills.skill_discovery.operations.SKILLS_DIR", root):
+        result = get_skill_file_op("retrofit", "ecm-catalog.md")
+    assert result["ok"] is True
+    assert result["skill"] == "retrofit"
+    assert result["filename"] == "ecm-catalog.md"
+    assert result["content"] == "## Envelope\nECM list"
+
+
+def test_get_skill_file_missing_file(tmp_path):
+    # Validates: missing support file returns ok=False pointing at get_skill
+    root = _support_skill_dir(tmp_path)
+    with patch("mcp_server.skills.skill_discovery.operations.SKILLS_DIR", root):
+        result = get_skill_file_op("retrofit", "nope.md")
+    assert result["ok"] is False
+    assert "not found" in result["error"].lower()
+    assert "supporting_files" in result["error"]
+
+
+@pytest.mark.parametrize("bad", [
+    "../retrofit/ecm-catalog.md", "/etc/passwd", r"..\x.md",
+    "SKILL.md", "eval.md", "README.md", ".hidden.md", "notes.pyc", "",
+])
+def test_get_skill_file_rejects_non_support_and_traversal(tmp_path, bad):
+    # Validates: traversal, absolute paths, hidden files, test data, and
+    # developer artifacts are refused — only classified agent support serves
+    root = _support_skill_dir(tmp_path)
+    with patch("mcp_server.skills.skill_discovery.operations.SKILLS_DIR", root):
+        result = get_skill_file_op("retrofit", bad)
+    assert result["ok"] is False
+    assert result["error"].strip()
+
+
+def test_get_skill_file_unknown_skill(tmp_path):
+    # Validates: unknown skill name gets the list_skills-pointing error
+    with patch("mcp_server.skills.skill_discovery.operations.SKILLS_DIR", tmp_path):
+        result = get_skill_file_op("ghost", "x.md")
+    assert result["ok"] is False
+    assert "not found" in result["error"].lower()


### PR DESCRIPTION
Part 3 of the skills-consistency plan. Builds on #139; independent of #140.

## Problem 1: guides taught save paths that multi-user servers reject

Served guides told agents to save models to literal paths like `/runs/baseline.osm`. That works for a local single-user server, but on a shared HTTP server each user's writable area is `/runs/<their-key>/` — the literal path is denied, and the agent has no way to know its own key (by design).

**Fix:** `save_osm_model` now accepts `save_name="baseline"` — just a name, no path. The server picks the right private location, saves there, and returns the actual path for the agent to feed into `run_simulation`. Bad names (path separators, drive letters, `..`, hidden files) are rejected with a clear message, and `save_name`/`osm_path` are mutually exclusive. Every guide and MCP prompt that wrote a literal `/runs/...` path now uses `save_name` and carries the returned path forward. Wording that assumed a docker-mounted input folder now says paths are server-side and points remote users at `request_upload`.

## Problem 2: advertised files nobody could fetch

`get_skill("retrofit")` advertises a supporting file (`ecm-catalog.md`) but there was no tool to retrieve it — and the listing also leaked `eval.md`, which is test data, not agent guidance.

**Fix:** new `get_skill_file(skill_name, filename)` tool serves supporting files, restricted to the skills directory (no absolute paths or traversal) and to genuine reference material (`SKILL.md`, `eval.md`, `README.md`, hidden files, and code artifacts are refused). `get_skill`'s file listing is filtered the same way and now includes a hint on how to fetch. Registered in the tool roster and in both knowledge-ablation rosters.

## How it was verified

Failing tests first: signature checks, an HTTP two-user test (model loaded from a read-only area can't be saved in place; `save_name` lands in the caller's private area; a second user can neither read it nor collide with it by using the same name), and a retrieval test for the retrofit catalog including traversal attempts. All green after the implementation, plus the existing load/save, per-user isolation, session isolation, and ablation suites. Unit tier in Docker: 483 passed. New test file added to CI shard 5.