### PR TITLE
Move stranded skill guidance where agents can actually read it; retire internal SKILL.md files

### DIFF
--- a/.claude/skills/add-hvac/SKILL.md
+++ b/.claude/skills/add-hvac/SKILL.md
@@ -83,3 +83,23 @@ compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-ho
   call, the tool fans out automatically
 - Systems 5-8 create one shared air loop for all zones (multi-zone VAV)
 - Systems 1-2, 9-10 create zone equipment only (no air loops)
+- Plant loops: System 5 creates a HW loop; 7 creates CHW + HW + condenser;
+  8 creates CHW + condenser; 6 creates none (electric PFP reheat)
+- DOAS zone equipment types: FanCoil (CHW+HW), Radiant (CHW+HW),
+  ChilledBeams (CHW only), FourPipeBeam (CHW+HW)
+
+## Why These Defaults (comfort tuning, issue #97)
+
+The generic templates apply these automatically so systems are viable out of
+the box — don't undo them without a reason:
+
+- App G sizing factors (1.25 heating / 1.15 cooling) + night-cycle
+  availability managers on air-loop systems
+- VAV reheat terminals use DamperHeatingAction=Reverse (Normal caps heating
+  at minimum airflow — 1807 unmet heating hours on the benchmark)
+- System 4 heat pump: -12.2 C compressor lockout, cycling Fan:OnOff, 40 C max
+  supplemental supply temperature (autosized 16.7 C could not heat a 21 C zone)
+- DOAS loop availability defaults to the served zones' People schedule
+  (24/7 buildings stay always-on); override via availability_schedule_name
+- VRF uses the standard outdoor-unit family with waste-heat recovery
+  (the FluidTemperatureControl family needs different terminal coils)

--- a/.claude/skills/file-transfer/SKILL.md
+++ b/.claude/skills/file-transfer/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: file-transfer
+description: Move user files to or from a remote openstudio-mcp server — upload local models/measures/weather for server-side tools, or hand results back as download links. Use when a needed file is on the user's machine, or the user wants a file from the server.
+---
+
+# File Transfer (remote servers)
+
+Over HTTP the server runs on a different machine than the user. Every file
+tool (`load_osm_model`, `apply_measure`, `change_building_location`,
+`import_floorspacejs`) takes a **server-side path**, but the user's files are
+on their laptop. Never pass file bytes through tool arguments (base64 in-band
+is token-prohibitive and leaks bytes into context/logs) — move bytes
+out-of-band over signed HTTP routes on the same port.
+
+## Upload (get a local file onto the server)
+
+0. Check first: `list_files()` / `list_uploads()` — staged inputs (e.g. under
+   `/inputs`) are already server-visible and need no upload.
+1. `request_upload(filename="model.osm", size_bytes=<bytes>)` →
+   `{file_id, upload_url, ...}` (optional `sha256` for integrity,
+   `kind="measure"` for measure zips)
+2. Have the user PUT the raw bytes:
+   ```
+   curl --upload-file model.osm "<upload_url>"
+   ```
+3. `get_upload(file_id=<file_id>)` → `server_path` once ready
+   (`extracted_path` for a `.zip` — ready for `apply_measure(measure_dir=...)`)
+4. Pass that server path to `load_osm_model` / `change_building_location` / etc.
+
+## Download (hand a server file back to the user)
+
+`request_download(path=<server_path>)` or
+`request_download(run_id=<run_id>, bundle=True)` → `download_url`; the user
+fetches it:
+```
+curl -O -J "<download_url>"
+```
+For small text (logs, err files) prefer `read_file` / `get_run_logs` — no
+download needed.
+
+## Notes
+
+- Upload URLs are signed (HMAC, short TTL) and op/file-scoped; the bearer
+  token never enters a URL. Uploads land in your private per-user area and
+  count against a quota; archives are zip-bomb and path-escape guarded.
+- `delete_upload(file_id=...)` frees quota.
+- Shell-less clients: `python -m mcp_server.tools.osmcp put <file> --kind measure`
+  and `python -m mcp_server.tools.osmcp get <server_path>` wrap the same two
+  HTTP calls.

--- a/.claude/skills/file-transfer/eval.md
+++ b/.claude/skills/file-transfer/eval.md
@@ -1,7 +1,7 @@
 ## Should trigger
 | Query | Expected tools | Critical params |
 |---|---|---|
-| "Get me an upload URL for my local model office.osm, about 2 MB" | request_upload | filename=office.osm |
+| "Get me an upload URL for my local model office.osm, size 2500000 bytes" | request_upload | filename=office.osm, size_bytes=2500000 |
 | "I have a measure zip on my laptop the server needs" | request_upload | kind=measure |
 | "Give me a download link for the results of run run_abc123" | request_download | run_id=run_abc123 |
 | "What files have I uploaded?" | list_uploads | — |

--- a/.claude/skills/file-transfer/eval.md
+++ b/.claude/skills/file-transfer/eval.md
@@ -1,7 +1,7 @@
 ## Should trigger
 | Query | Expected tools | Critical params |
 |---|---|---|
-| "Upload my local model office.osm (about 2 MB) to the server" | request_upload | filename=office.osm |
+| "Get me an upload URL for my local model office.osm, about 2 MB" | request_upload | filename=office.osm |
 | "I have a measure zip on my laptop the server needs" | request_upload | kind=measure |
 | "Give me a download link for the results of run run_abc123" | request_download | run_id=run_abc123 |
 | "What files have I uploaded?" | list_uploads | — |

--- a/.claude/skills/file-transfer/eval.md
+++ b/.claude/skills/file-transfer/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Upload my local model office.osm (about 2 MB) to the server" | request_upload | filename=office.osm |
+| "I have a measure zip on my laptop the server needs" | request_upload | kind=measure |
+| "Give me a download link for the results of run run_abc123" | request_download | run_id=run_abc123 |
+| "What files have I uploaded?" | list_uploads | — |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Load the model at /inputs/office.osm" | request_upload | load_osm_model |
+| "Show me the last lines of the simulation error log for run run_abc123" | request_download | get_run_logs, read_file, extract_simulation_errors |
+| "What weather files are on the server?" | request_upload | list_weather_files, list_files |

--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -99,5 +99,12 @@ left once merge and weld have closed what they can.
   simulation. `paired_area_mismatches` is informational: E+ accepts those.
 - `repair_and_validate_gbxml_geometry()` mutates the model (via `match_surfaces()` and the pair
   sync) before reporting — if you need to inspect pre-match state, save a copy of the model first.
+- **Check `zero_volume_zone_count` in the import report.** Conditioned
+  (thermostat-assigned, non-plenum) thermal zones with zero or uncomputable
+  volume are the same enclosure defects the Space-level checks catch, but they
+  specifically corrupt autosized equipment capacities. `zero_volume_zones`
+  names them — fix like any other non-enclosed space (usually
+  `repair_missing_roof_ceiling()`, then re-run
+  `repair_and_validate_gbxml_geometry()` to confirm).
 - After geometry is clean, spaces still need standards space types — see the
   `attribute-space-types` skill.

--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -18,6 +18,17 @@ Use measure authoring when:
 
 Do NOT use when an existing tool already does the job (e.g., `replace_air_terminals` for terminal swaps, `adjust_thermostat_setpoints` for thermostat changes).
 
+## Reuse Before Writing (find_measure / BCL routing)
+
+For requests to use an EXISTING measure by name, BCL page title, or intent,
+call `find_measure` first. It searches your own custom measures, bundled
+common measures, ComStock measures, and your BCL cache before searching BCL;
+a strong BCL match is downloaded into your per-user `bcl` dir. Pass its
+returned `measure_dir` straight to `list_measure_arguments` or
+`apply_measure`. Use `search_bcl_measures` only to inspect BCL candidates
+without downloading; `list_custom_measures` lists what you've authored.
+Custom measures are private per user — never tell users measures are shared.
+
 ## Workflow
 
 ### 1. Create the Measure
@@ -121,7 +132,8 @@ Python gotchas (different from Ruby):
 - `obj.name()` returns an OptionalString — use `str(obj.name())` or `obj.name().get()`, never bare `obj.name()`.
 - `runner.registerError("msg")` must be followed by `return False` (capital F; it does not halt).
 - Optionals: `opt = surface.construction()` then `if opt.is_initialized(): c = opt.get()`.
-- Unit conversion: `openstudio.convert(val, "W/m^2", "Btu/hr*ft^2").get()`.
+- Unit conversion: `openstudio.convert(val, "W/m^2", "Btu/hr*ft^2").get()` —
+  full unit-string table: `get_skill_file(skill_name="measure-authoring", filename="unit-conversions.md")`.
 
 ### Envelope
 ```python

--- a/.claude/skills/measure-authoring/unit-conversions.md
+++ b/.claude/skills/measure-authoring/unit-conversions.md
@@ -1,0 +1,27 @@
+# Unit Conversion — OpenStudio.convert
+
+`OpenStudio.convert(value, from_unit, to_unit).get` (Ruby) /
+`openstudio.convert(value, from_unit, to_unit).get()` (Python) — composable
+unit parser.
+
+Syntax: `*` (multiply), `/` (divide), `^` (exponent). Scale prefixes: `k`, `M`, `G`, `m`, `c`.
+
+| Category | Unit strings |
+|---|---|
+| Energy | `J`, `kJ`, `MJ`, `GJ`, `kWh`, `MWh`, `Btu`, `kBtu`, `therm` |
+| Power | `W`, `kW`, `Btu/h`, `ton` |
+| EUI | `kWh/m^2`, `kBtu/ft^2`, `GJ/m^2` |
+| Power density | `W/m^2`, `W/ft^2`, `Btu/hr*ft^2` |
+| R-value | `m^2*K/W`, `ft^2*hr*R/Btu` |
+| U-value | `W/m^2*K`, `Btu/hr*ft^2*R` |
+| Thermal conductivity | `W/m*K`, `Btu/hr*ft*R` |
+| Specific heat | `J/kg*K`, `Btu/lb_m*R` |
+| Flow rate | `m^3/s`, `cfm`, `L/s`, `gal/min` |
+| Flow/area | `cfm/ft^2`, `m^3/s*m^2`, `L/s*m^2` |
+| Temperature | `C`, `F`, `K`, `R` |
+| Length/Area/Volume | `m`, `ft`, `in`, `m^2`, `ft^2`, `m^3`, `ft^3`, `gal`, `L` |
+| Pressure | `Pa`, `kPa`, `psi`, `inHg` |
+| Mass/Density | `kg`, `lb`, `lb_m`, `kg/m^3`, `lb/ft^3` |
+| Illuminance | `lux`, `fc` |
+
+Source: [OpenStudio SDK units](https://github.com/NREL/OpenStudio/tree/develop/src/utilities/units/)

--- a/.claude/skills/osaf-analysis/SKILL.md
+++ b/.claude/skills/osaf-analysis/SKILL.md
@@ -9,6 +9,17 @@ disable-model-invocation: true
 Use this skill when working with OpenStudio Server / OSAF analysis JSON,
 support ZIPs, sampling sweeps, optimization, calibration, or server smoke tests.
 
+## Defaults That Matter
+
+- Omit `output_variables` when creating OSA JSON unless the user explicitly
+  asks for a custom set — the tools then include the foundational OpenStudio
+  Results outputs (EUI, site energy, peak demand, unmet hours, per-fuel end
+  uses) with export+visualize enabled so OSAF plots work. Use
+  `openstudio_analysis_default_output_variables` to inspect or extend the
+  default payload.
+- The OSA seed weather file is an **EPW**. DDY/STAT files are support files —
+  never set one as the analysis weather file.
+
 ## Discover Algorithms
 
 For “list OSAF algorithms” or “what is this algorithm best for”, call:

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -70,28 +70,12 @@ change_building_location(weather_file="/inputs/Chicago.epw")
 
 ## Fair HVAC System Sweep (decision-grade comparison)
 
-Compare candidate systems on the SAME configured model — standards-tuned
-equipment/controls each time, loads and schedules never touched:
-
-```
-# One-time setup: geometry + weather + typical build + any load customizations
-create_bar_building(...); change_building_location(...)
-create_typical_building(template="90.1-2019", climate_zone="ASHRAE 169-2013-5A")
-# ... apply load reductions, setbacks, etc. ...
-
-# Per candidate: swap ONLY the HVAC, simulate, compare
-create_typical_building(system_type="PVAV with gas boiler reheat",
-    template="90.1-2019", climate_zone="ASHRAE 169-2013-5A", hvac_only=True)
-save_osm_model(save_name="sweep_pvav"); run_simulation(osm_path=<osm_path from save>)
-
-create_typical_building(system_type="PSZ-HP", ..., hvac_only=True)
-save_osm_model(save_name="sweep_pszhp"); run_simulation(osm_path=<osm_path from save>)
-
-compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-hours deltas
-```
-
-Do NOT use add_baseline_system/add_doas_system for comparative studies — they
-are generic wiring templates without standards tuning (see add-hvac skill).
+Owned by the `add-hvac` skill — see its "Comparing Systems / Decision-Grade
+Results" section (`get_skill("add-hvac")`): per-candidate
+`create_typical_building(system_type=..., hvac_only=True)` swaps on the SAME
+configured model, then `compare_runs`. Do NOT use
+add_baseline_system/add_doas_system for comparative studies — generic wiring
+templates, no standards tuning.
 
 ## Tune Component Properties
 
@@ -124,58 +108,17 @@ apply_measure(measure_dir="/inputs/measures/my_measure",
 
 Note: All measure arguments are strings. Booleans → `"true"` / `"false"`. Numbers → `"42"`.
 
-## Write and Apply a Custom Measure
+## Write and Apply a Custom Measure / ReportingMeasure
 
-Full chain: create → test → apply → simulate → compare results.
-
-```
-# 1. Baseline simulation
-save_osm_model(save_name="baseline")            # response carries osm_path
-run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
-extract_summary_metrics(run_id=<baseline_id>)
-
-# 2. Create custom measure
-create_measure(name="my_measure", description="...",
-    language="Ruby", run_body="    model.get...each { |x| ... }")
-test_measure(measure_dir="/measures/<user>/custom/my_measure")  # use the measure_dir returned by create_measure
-
-# 3. Reload original model, apply measure, re-simulate
-load_osm_model(osm_path="<original>")
-apply_measure(measure_dir="/measures/<user>/custom/my_measure")
-save_osm_model(save_name="retrofit")
-run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
-extract_summary_metrics(run_id=<retrofit_id>)
-
-# 4. Compare baseline vs retrofit EUI
-```
-
-See the `measure-authoring` skill for run_body patterns and language guidance.
-
-For HVAC measures, verify methods exist and get wiring code first:
+Owned by the `measure-authoring` skill (`get_skill("measure-authoring")`):
+the create_measure → test_measure → apply_measure chain, run_body patterns
+(Ruby + Python), ReportingMeasures against a completed run
+(`test_measure(measure_dir=..., run_id=...)` /
+`apply_measure(measure_dir=..., run_id=...)`), and the before/after
+comparison workflow. For HVAC measures, verify methods and wiring first:
 ```
 search_api("CoilCoolingFourPipeBeam")             # check real setter/getter names
 search_wiring_patterns("four pipe beam")           # get working Ruby wiring code
-```
-
-## Write and Apply a Custom ReportingMeasure
-
-ReportingMeasures run after simulation to analyze SQL results.
-
-```
-# 1. Run simulation first
-save_osm_model(save_name="model")               # response carries osm_path
-run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
-
-# 2. Create reporting measure
-create_measure(name="custom_report", description="...",
-    language="Ruby", measure_type="ReportingMeasure",
-    run_body="    val = sql.execAndReturnFirstDouble('SELECT ...')\n    runner.registerValue('metric', val.get) if val.is_initialized")
-
-# 3. Test against completed simulation
-test_measure(measure_dir="/measures/<user>/custom/custom_report", run_id="<run_id>")
-
-# 4. Apply to completed simulation
-apply_measure(measure_dir="/measures/<user>/custom/custom_report", run_id="<run_id>")
 ```
 
 ## Object Cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Always use openstudio-mcp tools for BEM tasks:
 - Each skill lives in `mcp_server/skills/<name>/`
 - `tools.py` exports `register(mcp)` — MCP tool definitions only
 - `operations.py` — business logic, returns plain dicts, no MCP awareness
-- `SKILL.md` — skill definition for LLM context
+- `README.md` — internal dev notes; LLM-facing skills live in `.claude/skills/` (served via get_skill)
 - Key modules: `model_manager.py` (load/get/save/clear model), `osm_helpers.py` (fetch_object, optional_name, list_all_as_dicts), `skills/__init__.py` (auto-discovers all skills)
 
 ## Stdout Suppression

--- a/mcp_server/skills/analysis/README.md
+++ b/mcp_server/skills/analysis/README.md
@@ -1,6 +1,8 @@
-# analysis
+# analysis — internal dev notes
 
-OpenStudio Server / OSAF analysis workflows.
+OpenStudio Server / OSAF analysis workflows. Served agent guidance lives in
+`.claude/skills/osaf-analysis/SKILL.md` (via `get_skill("osaf-analysis")`),
+including the output_variables default and EPW-seed-weather doctrine.
 
 ## Defaults
 

--- a/mcp_server/skills/file_transfer/README.md
+++ b/mcp_server/skills/file_transfer/README.md
@@ -1,6 +1,8 @@
-# file_transfer
+# file_transfer — internal dev notes
 
 Move user files to/from a **remote (HTTP) openstudio-mcp server** securely.
+Served agent guidance lives in `.claude/skills/file-transfer/SKILL.md`
+(model-invocable; via `get_skill("file-transfer")`).
 
 ## Why
 Over HTTP the server runs on a different machine than the user. Every file tool

--- a/mcp_server/skills/gbxml_import/README.md
+++ b/mcp_server/skills/gbxml_import/README.md
@@ -1,5 +1,10 @@
 # gbxml_import
 
+> Internal dev notes. Served agent guidance lives in
+> `.claude/skills/gbxml-import/SKILL.md` (via `get_skill("gbxml-import")`),
+> including the zero-volume-zone remedy.
+
+
 Translate a gbXML file (typically exported from Revit 2022+) into an OpenStudio `.osm` model.
 
 ## Why

--- a/mcp_server/skills/hvac_systems/README.md
+++ b/mcp_server/skills/hvac_systems/README.md
@@ -1,6 +1,8 @@
-# hvac_systems
+# hvac_systems — internal dev notes
 
 System-level HVAC templates and ASHRAE 90.1 Appendix G baseline systems.
+Served agent guidance lives in `.claude/skills/add-hvac/SKILL.md` (via
+`get_skill("add-hvac")`), including the comfort-defaults doctrine.
 
 ## Overview
 
@@ -24,19 +26,9 @@ modern templates (DOAS, VRF, Radiant) and terminal replacement tools.
 - Systems 5-6: packaged VAV (HW reheat / PFP boxes), one shared air loop
 - Systems 7-8: central plant VAV (chiller/boiler/tower)
 
-## Comfort defaults (issue #97, benchmark-verified)
+## Comfort defaults
 
-Applied automatically so generic systems are viable out of the box:
-- App G sizing factors (1.25 heating / 1.15 cooling) + night-cycle
-  availability managers on air-loop systems
-- VAV reheat terminals use DamperHeatingAction=Reverse (Normal caps heating
-  at minimum airflow — was 1807 unmet heating hrs on the benchmark)
-- System 4 heat pump: -12.2C compressor lockout, cycling Fan:OnOff, 40C max
-  supplemental supply temp (autosized 16.7C could not heat a 21C zone)
-- DOAS loop availability defaults to the served zones' People schedule
-  (24/7 buildings stay always-on); override via availability_schedule_name
-- VRF uses the standard outdoor-unit family with waste-heat recovery
-  (the FluidTemperatureControl family needs different terminal coils)
+Migrated to the served add-hvac skill ("Why These Defaults") — edit it there. Implementation: baseline.py / templates.py.
 
 ## Tools
 
@@ -178,14 +170,14 @@ Get detailed metadata for a specific ASHRAE baseline system type.
 **Heating:** Gas furnace or electric resistance
 **Cooling:** Single-speed DX coil
 **Use Case:** Small commercial, retail, single-zone buildings
-**Notes:** Central air loop serving single zone, supports economizer
+**Notes:** One air loop per zone — pass the full zone list, the tool fans out; supports economizer
 
 ### System 4: PSZ-HP
 **Equipment:** Packaged single-zone heat pump rooftop unit
 **Heating:** DX heat pump with supplemental electric
 **Cooling:** DX heat pump
 **Use Case:** Small commercial, retail
-**Notes:** Single zone only, supports economizer
+**Notes:** One air loop per zone (pass the full zone list); supports economizer
 
 ### System 5: Packaged VAV w/ Reheat
 **Equipment:** Packaged rooftop VAV with hot water reheat
@@ -250,7 +242,7 @@ Validation results included in tool response under `"validation"` key.
 
 - Systems 1-2 create zone equipment (no air loops)
 - System 3 creates central air loop with outdoor air system
-- Systems 5-8 create plant loops (chilled water, hot water, condenser)
+- Plant loops: System 5 creates HW; 7 creates CHW + HW + condenser; 8 creates CHW + condenser; 6 creates none (electric PFP reheat)
 - Economizer parameter only applies to central systems (3-8)
 - Fuel parameters validated against system type capabilities
 
@@ -262,7 +254,9 @@ Validation results included in tool response under `"validation"` key.
 | `Radiant` | Low-temp radiant panels (floor/ceiling) | CHW + HW |
 | `ChilledBeams` | Passive/active chilled beams (cooling only) | CHW only |
 | `FourPipeBeam` | 4-pipe active chilled beams (heating + cooling) | CHW + HW |
-| `CooledBeam` | 2-pipe cooled beams (cooling only) | CHW only |
+
+(`CooledBeam` is a terminal type for `replace_air_terminals`, NOT a valid
+`add_doas_system` zone_equipment_type — the tool accepts only the four above.)
 
 ## API Reference
 
@@ -274,4 +268,3 @@ Validation results included in tool response under `"validation"` key.
 
 - `hvac/` skill — Query existing air loops, plant loops, zone equipment
 - `spaces/` skill — Create thermal zones to serve with HVAC systems
-- Phase 4 Implementation Plan — docs/PHASE_4_IMPLEMENTATION_PLAN.md

--- a/mcp_server/skills/measure_authoring/README.md
+++ b/mcp_server/skills/measure_authoring/README.md
@@ -1,6 +1,9 @@
-# measure_authoring
+# measure_authoring — internal dev notes
 
-Create, test, edit, and apply custom OpenStudio measures.
+Create, test, edit, and apply custom OpenStudio measures. Served agent
+guidance lives in `.claude/skills/measure-authoring/SKILL.md` (via
+`get_skill("measure-authoring")`; unit-conversion table is its
+`unit-conversions.md` supporting file).
 
 ## Overview
 
@@ -19,14 +22,7 @@ authored and downloaded measures live under their own `/measures/<user>/{custom,
 and are never visible to or writable by other users. Don't tell users measures are
 shared.
 
-For requests to use an existing measure by name, BCL page title, or intent,
-first call `find_measure`. It searches the caller's own custom measures,
-bundled common measures, bundled ComStock measures, and the caller's BCL cache
-before searching BCL. If BCL returns a strong match, `find_measure` downloads it
-into the caller's `bcl` dir and returns a top-level `measure_dir` / `selected_measure_dir`.
-Pass that value directly to `list_measure_arguments` or `apply_measure`. Use
-`search_bcl_measures` only when you need to inspect BCL candidates without
-downloading.
+BCL/find_measure routing guidance: served skill ("Reuse Before Writing").
 
 ## Before Writing HVAC Measures
 
@@ -127,29 +123,7 @@ Inspect arguments of any measure (from `measure_application` skill).
 
 ## Unit Conversion
 
-`OpenStudio.convert(value, from_unit, to_unit).get` — composable unit parser.
-
-Syntax: `*` (multiply), `/` (divide), `^` (exponent). Scale prefixes: `k`, `M`, `G`, `m`, `c`.
-
-| Category | Unit strings |
-|---|---|
-| Energy | `J`, `kJ`, `MJ`, `GJ`, `kWh`, `MWh`, `Btu`, `kBtu`, `therm` |
-| Power | `W`, `kW`, `Btu/h`, `ton` |
-| EUI | `kWh/m^2`, `kBtu/ft^2`, `GJ/m^2` |
-| Power density | `W/m^2`, `W/ft^2`, `Btu/hr*ft^2` |
-| R-value | `m^2*K/W`, `ft^2*hr*R/Btu` |
-| U-value | `W/m^2*K`, `Btu/hr*ft^2*R` |
-| Thermal conductivity | `W/m*K`, `Btu/hr*ft*R` |
-| Specific heat | `J/kg*K`, `Btu/lb_m*R` |
-| Flow rate | `m^3/s`, `cfm`, `L/s`, `gal/min` |
-| Flow/area | `cfm/ft^2`, `m^3/s*m^2`, `L/s*m^2` |
-| Temperature | `C`, `F`, `K`, `R` |
-| Length/Area/Volume | `m`, `ft`, `in`, `m^2`, `ft^2`, `m^3`, `ft^3`, `gal`, `L` |
-| Pressure | `Pa`, `kPa`, `psi`, `inHg` |
-| Mass/Density | `kg`, `lb`, `lb_m`, `kg/m^3`, `lb/ft^3` |
-| Illuminance | `lux`, `fc` |
-
-Source: [OpenStudio SDK units](https://github.com/NREL/OpenStudio/tree/develop/src/utilities/units/)
+Migrated to the served supporting file `.claude/skills/measure-authoring/unit-conversions.md` — edit it there. `tests/test_unit_conversions.py` verifies every documented unit string.
 
 ## Languages
 

--- a/mcp_server/skills/measure_authoring/tools.py
+++ b/mcp_server/skills/measure_authoring/tools.py
@@ -111,7 +111,7 @@ def register(mcp):
             opt = surface.construction; if opt.is_initialized then c = opt.get end
             OpenStudio.convert(val, "W/m^2", "Btu/hr*ft^2").get — unit conversion
               Common: W/m^2↔Btu/hr*ft^2, m^2*K/W↔ft^2*hr*R/Btu, kWh/m^2↔kBtu/ft^2
-              See SKILL.md "Unit Conversion" table for full list
+              Full table: get_skill_file(skill_name="measure-authoring", filename="unit-conversions.md")
             model.alwaysOnDiscreteSchedule — reusable schedule for constructors
           HVAC traversal (Ruby):
             model.getAirLoopHVACs.each { |loop| ... }

--- a/mcp_server/skills/python_ems/README.md
+++ b/mcp_server/skills/python_ems/README.md
@@ -1,4 +1,4 @@
-# Python EMS skill
+# python_ems — internal dev notes
 
 EnergyPlus Python Plugin authoring + EMS actuator discovery.
 

--- a/tests/llm/runner.py
+++ b/tests/llm/runner.py
@@ -41,8 +41,14 @@ BUILTIN_TOOLS = frozenset({
     "Bash", "PowerShell", "LocalShell", "Glob", "Grep", "Read", "Edit",
     "Write", "NotebookEdit", "WebFetch", "WebSearch", "TodoWrite",
     "AskUserQuestion", "Skill", "EnterPlanMode", "ExitPlanMode",
-    "EnterWorktree", "LSP", "ListMcpResourcesTool", "ReadMcpResourceTool",
-    "Agent",
+    "EnterWorktree", "ExitWorktree", "LSP", "ListMcpResourcesTool",
+    "ReadMcpResourceTool", "Agent",
+    # Newer Claude Code built-ins — missing entries here get miscounted as
+    # MCP tool calls (a file-transfer eval failed with tool_names=["Monitor"])
+    "Monitor", "SendFeedback", "SendMessage", "ListAgents", "Artifact",
+    "Workflow", "ReportFindings", "SendUserFile", "PushNotification",
+    "RemoteTrigger", "ScheduleWakeup", "CronCreate", "CronDelete",
+    "CronList", "DesignSync",
 })
 
 # Tools that touch the HOST machine (shell, filesystem, network) — the

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -243,3 +243,22 @@ def test_weather_discovery_routes_to_list_weather_files():
     assert "list_files(" not in weather.group(1), (
         "tool-workflows weather recipe must not use list_files"
     )
+
+
+# ---- corpus invariant (D1-D6) -----------------------------------------------
+
+
+def test_no_internal_skill_md_files():
+    # Regression: mcp_server/skills/*/SKILL.md carried agent guidance that
+    # get_skill never serves (it reads the configured SKILLS_DIR only) — HVAC
+    # comfort doctrine, OSAF defaults, unit tables stranded (plan D1-D6).
+    # Internal developer notes are README.md; .claude/skills is the ONLY
+    # agent-guidance corpus.
+    stranded = sorted(
+        str(p.relative_to(REPO_ROOT))
+        for p in (REPO_ROOT / "mcp_server" / "skills").glob("*/SKILL.md")
+    )
+    assert stranded == [], (
+        f"internal SKILL.md files are never served — migrate agent guidance "
+        f"to .claude/skills and rename to README.md: {stranded}"
+    )

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -1,7 +1,10 @@
-"""Verify OpenStudio.convert() works for all unit strings documented in SKILL.md.
+"""Verify OpenStudio.convert() works for every documented unit string.
 
-These are the unit pairs that measures commonly use for BEM calculations.
-Runs inside Docker where the openstudio Python bindings are available.
+Source of truth: the SERVED table .claude/skills/measure-authoring/
+unit-conversions.md (fetched by agents via get_skill_file). A unit test below
+parses that table and asserts every unit string appears in CONVERSION_PAIRS,
+so the served doc and this suite cannot drift apart silently (plan E4).
+Conversion execution runs inside Docker where openstudio is available.
 """
 import pytest
 from conftest import integration_enabled
@@ -173,3 +176,35 @@ def test_temperature_conversions():
     c100_to_f = openstudio.convert(100.0, "C", "F")
     assert c100_to_f.is_initialized()
     assert abs(c100_to_f.get() - 212.0) < 0.01, f"100°C should be 212°F, got {c100_to_f.get()}"
+
+
+@pytest.mark.unit
+def test_served_unit_table_units_are_exercised():
+    # Validates: every unit string in the served unit-conversions.md table is
+    # exercised by this suite — the served doc and the tests cannot drift
+    # apart silently (plan E4). Pure text parsing, no openstudio import.
+    import re
+    from pathlib import Path
+
+    table = (
+        Path(__file__).resolve().parents[1]
+        / ".claude" / "skills" / "measure-authoring" / "unit-conversions.md"
+    ).read_text(encoding="utf-8")
+
+    documented = set()
+    for line in table.splitlines():
+        if not (line.startswith("|") and "`" in line):
+            continue
+        documented.update(re.findall(r"`([^`]+)`", line))
+    assert len(documented) >= 40, (
+        f"served unit table parsed suspiciously few unit strings: {sorted(documented)}"
+    )
+
+    exercised = set(IDENTITY_UNITS)
+    for a, b in CONVERSION_PAIRS:
+        exercised.update((a, b))
+    missing = sorted(documented - exercised)
+    assert not missing, (
+        f"unit strings documented in the served table but never exercised "
+        f"here: {missing} — add pairs or fix the doc"
+    )


### PR DESCRIPTION
Part 4 of the skills-consistency plan. Builds on #141 (stack: #139 → #141 → this).

## The problem

Six directories under `mcp_server/skills/` carried their own `SKILL.md` files full of agent guidance — HVAC comfort tuning rationale, OSAF analysis defaults, a unit-conversion reference, a gbXML repair remedy, the whole file-transfer workflow. But the `get_skill` tool only reads the served skills directory (`.claude/skills`), so agents could never see any of it. Real, hard-won doctrine was stranded in files nothing serves. Some of it had also gone stale or was simply wrong.

## What moved where

- **HVAC comfort defaults** (damper reverse action, heat-pump lockout/supplemental-heat caps, DOAS availability, which VRF family we use and why) → the served add-hvac guide, as a "Why These Defaults" section, plus the per-system plant-loop facts and the valid DOAS equipment types.
- **OSAF defaults** → the served osaf-analysis guide: leave `output_variables` alone unless the user asks (the tools fill in the standard outputs so plots work), and the analysis seed weather file is an EPW — DDY/STAT are companions, not the weather file.
- **Unit-conversion table** → a supporting file of the served measure-authoring skill, fetched with the new `get_skill_file` tool from #141. A new test parses the served table and checks every unit string is actually exercised by the conversion test suite, so the doc and the tests can no longer drift apart.
- **gbXML zero-volume-zone remedy** → the served gbxml-import guide (zones with no computable volume corrupt equipment autosizing; the guide now says how to spot and fix them).
- **File transfer** → a brand-new served `file-transfer` skill (upload local files to a remote server via signed URLs, hand results back as download links), with its own eval table.

## Cleanup done along the way

- The internal files are renamed to `README.md` (developer notes), each linking to its served twin. A new test permanently forbids `SKILL.md` under `mcp_server/skills/` so this can't regrow.
- Errors in the old HVAC doc were fixed during the move: systems 3/4 are not "single zone only" (the tool creates one air loop per zone from a zone list), the "systems 5-8 create plant loops" claim contradicted system 6 (electric reheat, no hot-water loop), `CooledBeam` was listed as a DOAS equipment option the tool actually rejects, and a link to a long-deleted planning doc was dropped.
- The tool-workflows guide had drifting copies of the HVAC-comparison and custom-measure recipes; those are now one-line pointers to the guides that own them.

## How it was verified

The no-internal-SKILL.md test failed first (on the six files), then everything green: the full served-docs validation from #139 automatically covers the new skill and its eval table, unit tier in Docker (485 passed), and the skill-discovery/save-name/unit-conversion integration tests.