### PR TITLE
Tool catalog and router now derive from live registration instead of hand-maintained lists

### DIFF
--- a/.claude/skills/add-hvac/SKILL.md
+++ b/.claude/skills/add-hvac/SKILL.md
@@ -83,3 +83,23 @@ compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-ho
   call, the tool fans out automatically
 - Systems 5-8 create one shared air loop for all zones (multi-zone VAV)
 - Systems 1-2, 9-10 create zone equipment only (no air loops)
+- Plant loops: System 5 creates a HW loop; 7 creates CHW + HW + condenser;
+  8 creates CHW + condenser; 6 creates none (electric PFP reheat)
+- DOAS zone equipment types: FanCoil (CHW+HW), Radiant (CHW+HW),
+  ChilledBeams (CHW only), FourPipeBeam (CHW+HW)
+
+## Why These Defaults (comfort tuning, issue #97)
+
+The generic templates apply these automatically so systems are viable out of
+the box — don't undo them without a reason:
+
+- App G sizing factors (1.25 heating / 1.15 cooling) + night-cycle
+  availability managers on air-loop systems
+- VAV reheat terminals use DamperHeatingAction=Reverse (Normal caps heating
+  at minimum airflow — 1807 unmet heating hours on the benchmark)
+- System 4 heat pump: -12.2 C compressor lockout, cycling Fan:OnOff, 40 C max
+  supplemental supply temperature (autosized 16.7 C could not heat a 21 C zone)
+- DOAS loop availability defaults to the served zones' People schedule
+  (24/7 buildings stay always-on); override via availability_schedule_name
+- VRF uses the standard outdoor-unit family with waste-heat recovery
+  (the FluidTemperatureControl family needs different terminal coils)

--- a/.claude/skills/file-transfer/SKILL.md
+++ b/.claude/skills/file-transfer/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: file-transfer
+description: Move user files to or from a remote openstudio-mcp server — upload local models/measures/weather for server-side tools, or hand results back as download links. Use when a needed file is on the user's machine, or the user wants a file from the server.
+---
+
+# File Transfer (remote servers)
+
+Over HTTP the server runs on a different machine than the user. Every file
+tool (`load_osm_model`, `apply_measure`, `change_building_location`,
+`import_floorspacejs`) takes a **server-side path**, but the user's files are
+on their laptop. Never pass file bytes through tool arguments (base64 in-band
+is token-prohibitive and leaks bytes into context/logs) — move bytes
+out-of-band over signed HTTP routes on the same port.
+
+## Upload (get a local file onto the server)
+
+0. Check first: `list_files()` / `list_uploads()` — staged inputs (e.g. under
+   `/inputs`) are already server-visible and need no upload.
+1. `request_upload(filename="model.osm", size_bytes=<bytes>)` →
+   `{file_id, upload_url, ...}` (optional `sha256` for integrity,
+   `kind="measure"` for measure zips)
+2. Have the user PUT the raw bytes:
+   ```
+   curl --upload-file model.osm "<upload_url>"
+   ```
+3. `get_upload(file_id=<file_id>)` → `server_path` once ready
+   (`extracted_path` for a `.zip` — ready for `apply_measure(measure_dir=...)`)
+4. Pass that server path to `load_osm_model` / `change_building_location` / etc.
+
+## Download (hand a server file back to the user)
+
+`request_download(path=<server_path>)` or
+`request_download(run_id=<run_id>, bundle=True)` → `download_url`; the user
+fetches it:
+```
+curl -O -J "<download_url>"
+```
+For small text (logs, err files) prefer `read_file` / `get_run_logs` — no
+download needed.
+
+## Notes
+
+- Upload URLs are signed (HMAC, short TTL) and op/file-scoped; the bearer
+  token never enters a URL. Uploads land in your private per-user area and
+  count against a quota; archives are zip-bomb and path-escape guarded.
+- `delete_upload(file_id=...)` frees quota.
+- Shell-less clients: `python -m mcp_server.tools.osmcp put <file> --kind measure`
+  and `python -m mcp_server.tools.osmcp get <server_path>` wrap the same two
+  HTTP calls.

--- a/.claude/skills/file-transfer/eval.md
+++ b/.claude/skills/file-transfer/eval.md
@@ -1,7 +1,7 @@
 ## Should trigger
 | Query | Expected tools | Critical params |
 |---|---|---|
-| "Get me an upload URL for my local model office.osm, about 2 MB" | request_upload | filename=office.osm |
+| "Get me an upload URL for my local model office.osm, size 2500000 bytes" | request_upload | filename=office.osm, size_bytes=2500000 |
 | "I have a measure zip on my laptop the server needs" | request_upload | kind=measure |
 | "Give me a download link for the results of run run_abc123" | request_download | run_id=run_abc123 |
 | "What files have I uploaded?" | list_uploads | — |

--- a/.claude/skills/file-transfer/eval.md
+++ b/.claude/skills/file-transfer/eval.md
@@ -1,7 +1,7 @@
 ## Should trigger
 | Query | Expected tools | Critical params |
 |---|---|---|
-| "Upload my local model office.osm (about 2 MB) to the server" | request_upload | filename=office.osm |
+| "Get me an upload URL for my local model office.osm, about 2 MB" | request_upload | filename=office.osm |
 | "I have a measure zip on my laptop the server needs" | request_upload | kind=measure |
 | "Give me a download link for the results of run run_abc123" | request_download | run_id=run_abc123 |
 | "What files have I uploaded?" | list_uploads | — |

--- a/.claude/skills/file-transfer/eval.md
+++ b/.claude/skills/file-transfer/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Upload my local model office.osm (about 2 MB) to the server" | request_upload | filename=office.osm |
+| "I have a measure zip on my laptop the server needs" | request_upload | kind=measure |
+| "Give me a download link for the results of run run_abc123" | request_download | run_id=run_abc123 |
+| "What files have I uploaded?" | list_uploads | — |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Load the model at /inputs/office.osm" | request_upload | load_osm_model |
+| "Show me the last lines of the simulation error log for run run_abc123" | request_download | get_run_logs, read_file, extract_simulation_errors |
+| "What weather files are on the server?" | request_upload | list_weather_files, list_files |

--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -99,5 +99,12 @@ left once merge and weld have closed what they can.
   simulation. `paired_area_mismatches` is informational: E+ accepts those.
 - `repair_and_validate_gbxml_geometry()` mutates the model (via `match_surfaces()` and the pair
   sync) before reporting — if you need to inspect pre-match state, save a copy of the model first.
+- **Check `zero_volume_zone_count` in the import report.** Conditioned
+  (thermostat-assigned, non-plenum) thermal zones with zero or uncomputable
+  volume are the same enclosure defects the Space-level checks catch, but they
+  specifically corrupt autosized equipment capacities. `zero_volume_zones`
+  names them — fix like any other non-enclosed space (usually
+  `repair_missing_roof_ceiling()`, then re-run
+  `repair_and_validate_gbxml_geometry()` to confirm).
 - After geometry is clean, spaces still need standards space types — see the
   `attribute-space-types` skill.

--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -18,6 +18,17 @@ Use measure authoring when:
 
 Do NOT use when an existing tool already does the job (e.g., `replace_air_terminals` for terminal swaps, `adjust_thermostat_setpoints` for thermostat changes).
 
+## Reuse Before Writing (find_measure / BCL routing)
+
+For requests to use an EXISTING measure by name, BCL page title, or intent,
+call `find_measure` first. It searches your own custom measures, bundled
+common measures, ComStock measures, and your BCL cache before searching BCL;
+a strong BCL match is downloaded into your per-user `bcl` dir. Pass its
+returned `measure_dir` straight to `list_measure_arguments` or
+`apply_measure`. Use `search_bcl_measures` only to inspect BCL candidates
+without downloading; `list_custom_measures` lists what you've authored.
+Custom measures are private per user — never tell users measures are shared.
+
 ## Workflow
 
 ### 1. Create the Measure
@@ -121,7 +132,8 @@ Python gotchas (different from Ruby):
 - `obj.name()` returns an OptionalString — use `str(obj.name())` or `obj.name().get()`, never bare `obj.name()`.
 - `runner.registerError("msg")` must be followed by `return False` (capital F; it does not halt).
 - Optionals: `opt = surface.construction()` then `if opt.is_initialized(): c = opt.get()`.
-- Unit conversion: `openstudio.convert(val, "W/m^2", "Btu/hr*ft^2").get()`.
+- Unit conversion: `openstudio.convert(val, "W/m^2", "Btu/hr*ft^2").get()` —
+  full unit-string table: `get_skill_file(skill_name="measure-authoring", filename="unit-conversions.md")`.
 
 ### Envelope
 ```python

--- a/.claude/skills/measure-authoring/unit-conversions.md
+++ b/.claude/skills/measure-authoring/unit-conversions.md
@@ -1,0 +1,27 @@
+# Unit Conversion — OpenStudio.convert
+
+`OpenStudio.convert(value, from_unit, to_unit).get` (Ruby) /
+`openstudio.convert(value, from_unit, to_unit).get()` (Python) — composable
+unit parser.
+
+Syntax: `*` (multiply), `/` (divide), `^` (exponent). Scale prefixes: `k`, `M`, `G`, `m`, `c`.
+
+| Category | Unit strings |
+|---|---|
+| Energy | `J`, `kJ`, `MJ`, `GJ`, `kWh`, `MWh`, `Btu`, `kBtu`, `therm` |
+| Power | `W`, `kW`, `Btu/h`, `ton` |
+| EUI | `kWh/m^2`, `kBtu/ft^2`, `GJ/m^2` |
+| Power density | `W/m^2`, `W/ft^2`, `Btu/hr*ft^2` |
+| R-value | `m^2*K/W`, `ft^2*hr*R/Btu` |
+| U-value | `W/m^2*K`, `Btu/hr*ft^2*R` |
+| Thermal conductivity | `W/m*K`, `Btu/hr*ft*R` |
+| Specific heat | `J/kg*K`, `Btu/lb_m*R` |
+| Flow rate | `m^3/s`, `cfm`, `L/s`, `gal/min` |
+| Flow/area | `cfm/ft^2`, `m^3/s*m^2`, `L/s*m^2` |
+| Temperature | `C`, `F`, `K`, `R` |
+| Length/Area/Volume | `m`, `ft`, `in`, `m^2`, `ft^2`, `m^3`, `ft^3`, `gal`, `L` |
+| Pressure | `Pa`, `kPa`, `psi`, `inHg` |
+| Mass/Density | `kg`, `lb`, `lb_m`, `kg/m^3`, `lb/ft^3` |
+| Illuminance | `lux`, `fc` |
+
+Source: [OpenStudio SDK units](https://github.com/NREL/OpenStudio/tree/develop/src/utilities/units/)

--- a/.claude/skills/osaf-analysis/SKILL.md
+++ b/.claude/skills/osaf-analysis/SKILL.md
@@ -9,6 +9,17 @@ disable-model-invocation: true
 Use this skill when working with OpenStudio Server / OSAF analysis JSON,
 support ZIPs, sampling sweeps, optimization, calibration, or server smoke tests.
 
+## Defaults That Matter
+
+- Omit `output_variables` when creating OSA JSON unless the user explicitly
+  asks for a custom set — the tools then include the foundational OpenStudio
+  Results outputs (EUI, site energy, peak demand, unmet hours, per-fuel end
+  uses) with export+visualize enabled so OSAF plots work. Use
+  `openstudio_analysis_default_output_variables` to inspect or extend the
+  default payload.
+- The OSA seed weather file is an **EPW**. DDY/STAT files are support files —
+  never set one as the analysis weather file.
+
 ## Discover Algorithms
 
 For “list OSAF algorithms” or “what is this algorithm best for”, call:

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -70,28 +70,12 @@ change_building_location(weather_file="/inputs/Chicago.epw")
 
 ## Fair HVAC System Sweep (decision-grade comparison)
 
-Compare candidate systems on the SAME configured model — standards-tuned
-equipment/controls each time, loads and schedules never touched:
-
-```
-# One-time setup: geometry + weather + typical build + any load customizations
-create_bar_building(...); change_building_location(...)
-create_typical_building(template="90.1-2019", climate_zone="ASHRAE 169-2013-5A")
-# ... apply load reductions, setbacks, etc. ...
-
-# Per candidate: swap ONLY the HVAC, simulate, compare
-create_typical_building(system_type="PVAV with gas boiler reheat",
-    template="90.1-2019", climate_zone="ASHRAE 169-2013-5A", hvac_only=True)
-save_osm_model(save_name="sweep_pvav"); run_simulation(osm_path=<osm_path from save>)
-
-create_typical_building(system_type="PSZ-HP", ..., hvac_only=True)
-save_osm_model(save_name="sweep_pszhp"); run_simulation(osm_path=<osm_path from save>)
-
-compare_runs(baseline_run_id=<run A>, retrofit_run_id=<run B>)  # EUI + unmet-hours deltas
-```
-
-Do NOT use add_baseline_system/add_doas_system for comparative studies — they
-are generic wiring templates without standards tuning (see add-hvac skill).
+Owned by the `add-hvac` skill — see its "Comparing Systems / Decision-Grade
+Results" section (`get_skill("add-hvac")`): per-candidate
+`create_typical_building(system_type=..., hvac_only=True)` swaps on the SAME
+configured model, then `compare_runs`. Do NOT use
+add_baseline_system/add_doas_system for comparative studies — generic wiring
+templates, no standards tuning.
 
 ## Tune Component Properties
 
@@ -124,58 +108,17 @@ apply_measure(measure_dir="/inputs/measures/my_measure",
 
 Note: All measure arguments are strings. Booleans → `"true"` / `"false"`. Numbers → `"42"`.
 
-## Write and Apply a Custom Measure
+## Write and Apply a Custom Measure / ReportingMeasure
 
-Full chain: create → test → apply → simulate → compare results.
-
-```
-# 1. Baseline simulation
-save_osm_model(save_name="baseline")            # response carries osm_path
-run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
-extract_summary_metrics(run_id=<baseline_id>)
-
-# 2. Create custom measure
-create_measure(name="my_measure", description="...",
-    language="Ruby", run_body="    model.get...each { |x| ... }")
-test_measure(measure_dir="/measures/<user>/custom/my_measure")  # use the measure_dir returned by create_measure
-
-# 3. Reload original model, apply measure, re-simulate
-load_osm_model(osm_path="<original>")
-apply_measure(measure_dir="/measures/<user>/custom/my_measure")
-save_osm_model(save_name="retrofit")
-run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
-extract_summary_metrics(run_id=<retrofit_id>)
-
-# 4. Compare baseline vs retrofit EUI
-```
-
-See the `measure-authoring` skill for run_body patterns and language guidance.
-
-For HVAC measures, verify methods exist and get wiring code first:
+Owned by the `measure-authoring` skill (`get_skill("measure-authoring")`):
+the create_measure → test_measure → apply_measure chain, run_body patterns
+(Ruby + Python), ReportingMeasures against a completed run
+(`test_measure(measure_dir=..., run_id=...)` /
+`apply_measure(measure_dir=..., run_id=...)`), and the before/after
+comparison workflow. For HVAC measures, verify methods and wiring first:
 ```
 search_api("CoilCoolingFourPipeBeam")             # check real setter/getter names
 search_wiring_patterns("four pipe beam")           # get working Ruby wiring code
-```
-
-## Write and Apply a Custom ReportingMeasure
-
-ReportingMeasures run after simulation to analyze SQL results.
-
-```
-# 1. Run simulation first
-save_osm_model(save_name="model")               # response carries osm_path
-run_simulation(osm_path=<osm_path from save>, epw_path="<epw>")
-
-# 2. Create reporting measure
-create_measure(name="custom_report", description="...",
-    language="Ruby", measure_type="ReportingMeasure",
-    run_body="    val = sql.execAndReturnFirstDouble('SELECT ...')\n    runner.registerValue('metric', val.get) if val.is_initialized")
-
-# 3. Test against completed simulation
-test_measure(measure_dir="/measures/<user>/custom/custom_report", run_id="<run_id>")
-
-# 4. Apply to completed simulation
-apply_measure(measure_dir="/measures/<user>/custom/custom_report", run_id="<run_id>")
 ```
 
 ## Object Cleanup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
               # + geometry repair write guards (in-process setVertices fault injection, ~2s —
               #   must not go to shard 2 with test_geometry.py: that file drives the same three
               #   tools through the stdio server subprocess, which monkeypatch cannot reach)
-              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_geometry_write_guards.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_patch_construction_choice.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
+              FILES="tests/test_component_controls.py tests/test_object_management.py tests/test_generic_access.py tests/test_create_loads.py tests/test_building.py tests/test_doas_system.py tests/test_hvac.py tests/test_measures.py tests/test_measure_authoring.py tests/test_skill_qaqc.py tests/test_hvac_supply_wiring.py tests/test_validate_model.py tests/test_api_reference.py tests/test_paired_vertex_sync.py tests/test_geometry_write_guards.py tests/test_ground_contact.py tests/test_gbxml_import_timeout.py tests/test_trim_order_invariance.py tests/test_patch_construction_choice.py tests/test_registry_discovery.py tests/test_gbxml_import.py::test_import_gbxml_falls_back_to_wmo_lookup_when_stat_file_unusable"
               EXTRA_ENV=""
               ;;
             4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Always use openstudio-mcp tools for BEM tasks:
 - Each skill lives in `mcp_server/skills/<name>/`
 - `tools.py` exports `register(mcp)` — MCP tool definitions only
 - `operations.py` — business logic, returns plain dicts, no MCP awareness
-- `SKILL.md` — skill definition for LLM context
+- `README.md` — internal dev notes; LLM-facing skills live in `.claude/skills/` (served via get_skill)
 - Key modules: `model_manager.py` (load/get/save/clear model), `osm_helpers.py` (fetch_object, optional_name, list_all_as_dicts), `skills/__init__.py` (auto-discovers all skills)
 
 ## Stdout Suppression

--- a/mcp_server/skills/__init__.py
+++ b/mcp_server/skills/__init__.py
@@ -25,11 +25,15 @@ def register_all_skills(mcp) -> list[str]:
 
     Returns list of registered skill names.
     """
+    from mcp_server.tool_registry import CollectingMCP, reset_descriptors
+
     registered = []
     package = importlib.import_module(__name__)
     ablate = os.environ.get("OSMCP_DISABLE_KNOWLEDGE_SKILLS") == "1"
+    # Fresh descriptor collection per full registration (tests re-register)
+    reset_descriptors()
 
-    for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
+    for _importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
         if not ispkg:
             continue
         if ablate and modname in _KNOWLEDGE_SKILLS:
@@ -38,7 +42,9 @@ def register_all_skills(mcp) -> list[str]:
         try:
             tools_mod = importlib.import_module(f"{__name__}.{modname}.tools")
             if hasattr(tools_mod, "register"):
-                tools_mod.register(mcp)
+                # Collecting facade: delegates to the real MCP while recording
+                # ToolDescriptors — catalog/router derive from that registry
+                tools_mod.register(CollectingMCP(mcp, modname))
                 registered.append(modname)
                 logger.info("Registered skill: %s", modname)
             else:

--- a/mcp_server/skills/analysis/README.md
+++ b/mcp_server/skills/analysis/README.md
@@ -1,6 +1,8 @@
-# analysis
+# analysis — internal dev notes
 
-OpenStudio Server / OSAF analysis workflows.
+OpenStudio Server / OSAF analysis workflows. Served agent guidance lives in
+`.claude/skills/osaf-analysis/SKILL.md` (via `get_skill("osaf-analysis")`),
+including the output_variables default and EPW-seed-weather doctrine.
 
 ## Defaults
 

--- a/mcp_server/skills/file_transfer/README.md
+++ b/mcp_server/skills/file_transfer/README.md
@@ -1,6 +1,8 @@
-# file_transfer
+# file_transfer — internal dev notes
 
 Move user files to/from a **remote (HTTP) openstudio-mcp server** securely.
+Served agent guidance lives in `.claude/skills/file-transfer/SKILL.md`
+(model-invocable; via `get_skill("file-transfer")`).
 
 ## Why
 Over HTTP the server runs on a different machine than the user. Every file tool

--- a/mcp_server/skills/gbxml_import/README.md
+++ b/mcp_server/skills/gbxml_import/README.md
@@ -1,5 +1,10 @@
 # gbxml_import
 
+> Internal dev notes. Served agent guidance lives in
+> `.claude/skills/gbxml-import/SKILL.md` (via `get_skill("gbxml-import")`),
+> including the zero-volume-zone remedy.
+
+
 Translate a gbXML file (typically exported from Revit 2022+) into an OpenStudio `.osm` model.
 
 ## Why

--- a/mcp_server/skills/hvac_systems/README.md
+++ b/mcp_server/skills/hvac_systems/README.md
@@ -1,6 +1,8 @@
-# hvac_systems
+# hvac_systems — internal dev notes
 
 System-level HVAC templates and ASHRAE 90.1 Appendix G baseline systems.
+Served agent guidance lives in `.claude/skills/add-hvac/SKILL.md` (via
+`get_skill("add-hvac")`), including the comfort-defaults doctrine.
 
 ## Overview
 
@@ -24,19 +26,9 @@ modern templates (DOAS, VRF, Radiant) and terminal replacement tools.
 - Systems 5-6: packaged VAV (HW reheat / PFP boxes), one shared air loop
 - Systems 7-8: central plant VAV (chiller/boiler/tower)
 
-## Comfort defaults (issue #97, benchmark-verified)
+## Comfort defaults
 
-Applied automatically so generic systems are viable out of the box:
-- App G sizing factors (1.25 heating / 1.15 cooling) + night-cycle
-  availability managers on air-loop systems
-- VAV reheat terminals use DamperHeatingAction=Reverse (Normal caps heating
-  at minimum airflow — was 1807 unmet heating hrs on the benchmark)
-- System 4 heat pump: -12.2C compressor lockout, cycling Fan:OnOff, 40C max
-  supplemental supply temp (autosized 16.7C could not heat a 21C zone)
-- DOAS loop availability defaults to the served zones' People schedule
-  (24/7 buildings stay always-on); override via availability_schedule_name
-- VRF uses the standard outdoor-unit family with waste-heat recovery
-  (the FluidTemperatureControl family needs different terminal coils)
+Migrated to the served add-hvac skill ("Why These Defaults") — edit it there. Implementation: baseline.py / templates.py.
 
 ## Tools
 
@@ -178,14 +170,14 @@ Get detailed metadata for a specific ASHRAE baseline system type.
 **Heating:** Gas furnace or electric resistance
 **Cooling:** Single-speed DX coil
 **Use Case:** Small commercial, retail, single-zone buildings
-**Notes:** Central air loop serving single zone, supports economizer
+**Notes:** One air loop per zone — pass the full zone list, the tool fans out; supports economizer
 
 ### System 4: PSZ-HP
 **Equipment:** Packaged single-zone heat pump rooftop unit
 **Heating:** DX heat pump with supplemental electric
 **Cooling:** DX heat pump
 **Use Case:** Small commercial, retail
-**Notes:** Single zone only, supports economizer
+**Notes:** One air loop per zone (pass the full zone list); supports economizer
 
 ### System 5: Packaged VAV w/ Reheat
 **Equipment:** Packaged rooftop VAV with hot water reheat
@@ -250,7 +242,7 @@ Validation results included in tool response under `"validation"` key.
 
 - Systems 1-2 create zone equipment (no air loops)
 - System 3 creates central air loop with outdoor air system
-- Systems 5-8 create plant loops (chilled water, hot water, condenser)
+- Plant loops: System 5 creates HW; 7 creates CHW + HW + condenser; 8 creates CHW + condenser; 6 creates none (electric PFP reheat)
 - Economizer parameter only applies to central systems (3-8)
 - Fuel parameters validated against system type capabilities
 
@@ -262,7 +254,9 @@ Validation results included in tool response under `"validation"` key.
 | `Radiant` | Low-temp radiant panels (floor/ceiling) | CHW + HW |
 | `ChilledBeams` | Passive/active chilled beams (cooling only) | CHW only |
 | `FourPipeBeam` | 4-pipe active chilled beams (heating + cooling) | CHW + HW |
-| `CooledBeam` | 2-pipe cooled beams (cooling only) | CHW only |
+
+(`CooledBeam` is a terminal type for `replace_air_terminals`, NOT a valid
+`add_doas_system` zone_equipment_type — the tool accepts only the four above.)
 
 ## API Reference
 
@@ -274,4 +268,3 @@ Validation results included in tool response under `"validation"` key.
 
 - `hvac/` skill — Query existing air loops, plant loops, zone equipment
 - `spaces/` skill — Create thermal zones to serve with HVAC systems
-- Phase 4 Implementation Plan — docs/PHASE_4_IMPLEMENTATION_PLAN.md

--- a/mcp_server/skills/measure_authoring/README.md
+++ b/mcp_server/skills/measure_authoring/README.md
@@ -1,6 +1,9 @@
-# measure_authoring
+# measure_authoring — internal dev notes
 
-Create, test, edit, and apply custom OpenStudio measures.
+Create, test, edit, and apply custom OpenStudio measures. Served agent
+guidance lives in `.claude/skills/measure-authoring/SKILL.md` (via
+`get_skill("measure-authoring")`; unit-conversion table is its
+`unit-conversions.md` supporting file).
 
 ## Overview
 
@@ -19,14 +22,7 @@ authored and downloaded measures live under their own `/measures/<user>/{custom,
 and are never visible to or writable by other users. Don't tell users measures are
 shared.
 
-For requests to use an existing measure by name, BCL page title, or intent,
-first call `find_measure`. It searches the caller's own custom measures,
-bundled common measures, bundled ComStock measures, and the caller's BCL cache
-before searching BCL. If BCL returns a strong match, `find_measure` downloads it
-into the caller's `bcl` dir and returns a top-level `measure_dir` / `selected_measure_dir`.
-Pass that value directly to `list_measure_arguments` or `apply_measure`. Use
-`search_bcl_measures` only when you need to inspect BCL candidates without
-downloading.
+BCL/find_measure routing guidance: served skill ("Reuse Before Writing").
 
 ## Before Writing HVAC Measures
 
@@ -127,29 +123,7 @@ Inspect arguments of any measure (from `measure_application` skill).
 
 ## Unit Conversion
 
-`OpenStudio.convert(value, from_unit, to_unit).get` — composable unit parser.
-
-Syntax: `*` (multiply), `/` (divide), `^` (exponent). Scale prefixes: `k`, `M`, `G`, `m`, `c`.
-
-| Category | Unit strings |
-|---|---|
-| Energy | `J`, `kJ`, `MJ`, `GJ`, `kWh`, `MWh`, `Btu`, `kBtu`, `therm` |
-| Power | `W`, `kW`, `Btu/h`, `ton` |
-| EUI | `kWh/m^2`, `kBtu/ft^2`, `GJ/m^2` |
-| Power density | `W/m^2`, `W/ft^2`, `Btu/hr*ft^2` |
-| R-value | `m^2*K/W`, `ft^2*hr*R/Btu` |
-| U-value | `W/m^2*K`, `Btu/hr*ft^2*R` |
-| Thermal conductivity | `W/m*K`, `Btu/hr*ft*R` |
-| Specific heat | `J/kg*K`, `Btu/lb_m*R` |
-| Flow rate | `m^3/s`, `cfm`, `L/s`, `gal/min` |
-| Flow/area | `cfm/ft^2`, `m^3/s*m^2`, `L/s*m^2` |
-| Temperature | `C`, `F`, `K`, `R` |
-| Length/Area/Volume | `m`, `ft`, `in`, `m^2`, `ft^2`, `m^3`, `ft^3`, `gal`, `L` |
-| Pressure | `Pa`, `kPa`, `psi`, `inHg` |
-| Mass/Density | `kg`, `lb`, `lb_m`, `kg/m^3`, `lb/ft^3` |
-| Illuminance | `lux`, `fc` |
-
-Source: [OpenStudio SDK units](https://github.com/NREL/OpenStudio/tree/develop/src/utilities/units/)
+Migrated to the served supporting file `.claude/skills/measure-authoring/unit-conversions.md` — edit it there. `tests/test_unit_conversions.py` verifies every documented unit string.
 
 ## Languages
 

--- a/mcp_server/skills/measure_authoring/tools.py
+++ b/mcp_server/skills/measure_authoring/tools.py
@@ -111,7 +111,7 @@ def register(mcp):
             opt = surface.construction; if opt.is_initialized then c = opt.get end
             OpenStudio.convert(val, "W/m^2", "Btu/hr*ft^2").get — unit conversion
               Common: W/m^2↔Btu/hr*ft^2, m^2*K/W↔ft^2*hr*R/Btu, kWh/m^2↔kBtu/ft^2
-              See SKILL.md "Unit Conversion" table for full list
+              Full table: get_skill_file(skill_name="measure-authoring", filename="unit-conversions.md")
             model.alwaysOnDiscreteSchedule — reusable schedule for constructors
           HVAC traversal (Ruby):
             model.getAirLoopHVACs.each { |loop| ... }

--- a/mcp_server/skills/prompts_resources/tools.py
+++ b/mcp_server/skills/prompts_resources/tools.py
@@ -295,124 +295,14 @@ def register(mcp):
         mime_type="application/json",
     )
     def tool_catalog_resource() -> str:
-        catalog = {
-            "server_info": ["get_server_status", "get_versions"],
-            "model_management": [
-                "create_example_osm", "create_baseline_osm",
-                "inspect_osm_summary", "load_osm_model",
-                "save_osm_model", "list_files",
-            ],
-            "simulation": [
-                "validate_osw", "run_osw", "run_simulation",
-                "get_run_status", "get_run_logs",
-                "get_run_artifacts", "cancel_run",
-            ],
-            "results": [
-                "extract_summary_metrics", "read_file",
-                "copy_file", "extract_end_use_breakdown",
-                "extract_envelope_summary", "extract_hvac_sizing",
-                "extract_zone_summary", "extract_component_sizing",
-                "query_timeseries",
-            ],
-            "building": [
-                "get_building_info", "get_model_summary",
-            ],
-            "spaces": [
-                "list_spaces", "get_space_details",
-                "list_thermal_zones", "get_thermal_zone_details",
-                "create_space", "create_thermal_zone",
-            ],
-            "geometry": [
-                "list_surfaces", "get_surface_details",
-                "list_subsurfaces", "create_surface",
-                "create_subsurface", "create_space_from_floor_print",
-                "match_surfaces", "set_window_to_wall_ratio",
-                "import_floorspacejs",
-            ],
-            "constructions": [
-                "list_materials", "get_construction_details",
-                "create_standard_opaque_material",
-                "create_construction",
-                "add_layer_to_construction",
-                "assign_construction_to_surface",
-            ],
-            "schedules": [
-                "get_schedule_details",
-                "create_schedule_ruleset",
-            ],
-            "hvac": [
-                "list_air_loops", "get_air_loop_details",
-                "list_plant_loops", "get_plant_loop_details",
-                "list_zone_hvac_equipment", "get_zone_hvac_details",
-                "add_air_loop",
-            ],
-            "loads": [
-                "get_load_details",
-                "create_people_definition",
-                "create_lights_definition",
-                "create_electric_equipment",
-                "create_gas_equipment", "create_infiltration",
-            ],
-            "space_types": [
-                "get_space_type_details",
-            ],
-            "simulation_outputs": [
-                "add_output_variable", "add_output_meter",
-            ],
-            "hvac_systems": [
-                "add_baseline_system", "list_baseline_systems",
-                "get_baseline_system_info", "replace_air_terminals",
-                "replace_zone_terminal", "add_doas_system",
-                "add_vrf_system", "add_radiant_system",
-            ],
-            "component_properties": [
-                "get_component_properties",
-                "set_component_properties",
-                "set_economizer_properties",
-                "set_sizing_properties",
-                "set_sizing_system_properties", "get_sizing_system_properties",
-                "set_sizing_zone_properties", "get_sizing_zone_properties",
-                "get_setpoint_manager_properties", "set_setpoint_manager_properties",
-            ],
-            "loop_operations": [
-                "create_plant_loop",
-                "add_supply_equipment", "remove_supply_equipment",
-                "add_demand_component", "remove_demand_component",
-                "add_zone_equipment", "remove_zone_equipment",
-                "remove_all_zone_equipment",
-            ],
-            "object_management": [
-                "delete_object", "rename_object",
-                "list_model_objects", "get_object_fields",
-                "set_object_property",
-            ],
-            "weather": [
-                "get_weather_info",
-                "add_design_day", "get_simulation_control",
-                "set_simulation_control", "get_run_period",
-                "set_run_period",
-            ],
-            "measures": [
-                "list_measure_arguments", "apply_measure",
-            ],
-            "comstock": [
-                "list_comstock_measures", "create_typical_building",
-                "create_bar_building", "create_new_building",
-            ],
-            "common_measures": [
-                "list_common_measures", "view_model",
-                "view_simulation_data", "generate_results_report",
-                "run_qaqc_checks", "adjust_thermostat_setpoints",
-                "replace_window_constructions",
-                "enable_ideal_air_loads", "clean_unused_objects",
-                "change_building_location",
-                "set_thermostat_schedules",
-                "replace_thermostat_schedules",
-                "shift_schedule_time", "add_rooftop_pv",
-                "add_pv_to_shading", "add_ev_load",
-                "add_zone_ventilation", "set_lifecycle_cost_params",
-                "add_cost_per_floor_area", "set_adiabatic_boundaries",
-            ],
-            "skill_discovery": ["list_skills", "get_skill"],
-        }
+        # Derived from the registration collector — never hand-maintained.
+        # Grouped by owning skill package; value is the tool's first
+        # docstring line.
+        from mcp_server.tool_registry import descriptors, ensure_collected
+
+        ensure_collected()
+        catalog: dict[str, dict[str, str]] = {}
+        for d in sorted(descriptors().values(),
+                        key=lambda d: (d.package, d.name)):
+            catalog.setdefault(d.package, {})[d.name] = d.description
         return json.dumps(catalog, indent=2)

--- a/mcp_server/skills/python_ems/README.md
+++ b/mcp_server/skills/python_ems/README.md
@@ -1,4 +1,4 @@
-# Python EMS skill
+# python_ems — internal dev notes
 
 EnergyPlus Python Plugin authoring + EMS actuator discovery.
 

--- a/mcp_server/skills/tool_router/operations.py
+++ b/mcp_server/skills/tool_router/operations.py
@@ -55,48 +55,58 @@ GROUP_KEYWORDS: dict[str, set[str]] = {
         "ev", "charging", "ventilation", "adiabatic", "ideal_air",
         "cleanup", "unused", "cost", "lifecycle", "window_construction",
     },
+    "analysis": {
+        "osaf", "analysis", "analyses", "osa", "sampling", "sample",
+        "sweep", "sweeps", "optimization", "optimize", "calibration",
+        "calibrate", "algorithm", "algorithms", "datapoint", "datapoints",
+        "submit", "batch", "lhs", "doe", "morris", "sobol", "nsga",
+        "pareto", "sensitivity", "seed", "server",
+    },
+    "files": {
+        "upload", "uploads", "download", "downloads", "transfer", "file",
+        "files", "laptop", "local", "remote", "stage", "staging", "url",
+        "quota", "zip",
+    },
+    "meta": {
+        "version", "versions", "status", "health", "server", "sdk",
+        "energyplus", "openstudio", "installed",
+    },
+    "space_types": {
+        "space_type", "space_types", "standards", "wizard", "attribution",
+        "attribute", "template", "templates", "gbxml", "building_type",
+        "assign", "conditioned",
+    },
 }
 
-# Tool descriptions per group — built from the FakeMCP registry at module
-# load time. We define them statically here to avoid import-time side effects.
-# Maps group -> list of {"name": ..., "description": ...}
+# Tool descriptions per group — derived from the registration collector
+# (mcp_server.tool_registry), lazily and once per collected roster.
+# Maps group (tag) -> list of {"name": ..., "description": ...}
 _TOOL_INDEX: dict[str, list[dict[str, str]]] = {}
 _INDEX_BUILT = False
 
 
+def reset_tool_index() -> None:
+    """Drop the cached index (tests re-seed the descriptor registry)."""
+    global _INDEX_BUILT
+    _TOOL_INDEX.clear()
+    _INDEX_BUILT = False
+
+
 def _build_tool_index() -> None:
-    """Build tool index from skill registration (lazy, once)."""
+    """Build the tag -> tools index from collected ToolDescriptors (lazy)."""
     global _INDEX_BUILT
     if _INDEX_BUILT:
         return
 
-    from mcp_server.skills import register_all_skills
+    from mcp_server.tool_registry import descriptors, ensure_collected
 
-    tools_by_group: dict[str, list[dict[str, str]]] = {}
-
-    class IndexMCP:
-        def tool(self, name=None, tags=None, **kwargs):
-            def decorator(fn):
-                tool_name = name or fn.__name__
-                doc = fn.__doc__ or ""
-                # First line of docstring as description
-                desc = doc.strip().split("\n")[0] if doc.strip() else ""
-                for tag in (tags or set()):
-                    tools_by_group.setdefault(tag, []).append({
-                        "name": tool_name,
-                        "description": desc,
-                    })
-                return fn
-            return decorator
-
-        def prompt(self, **kw):
-            return lambda fn: fn
-
-        def resource(self, *a, **kw):
-            return lambda fn: fn
-
-    register_all_skills(IndexMCP())
-    _TOOL_INDEX.update(tools_by_group)
+    ensure_collected()
+    for d in sorted(descriptors().values(), key=lambda d: d.name):
+        for tag in d.tags:
+            _TOOL_INDEX.setdefault(tag, []).append({
+                "name": d.name,
+                "description": d.description,
+            })
     _INDEX_BUILT = True
 
 

--- a/mcp_server/skills/tool_router/tools.py
+++ b/mcp_server/skills/tool_router/tools.py
@@ -8,7 +8,8 @@ def register(mcp):
     @mcp.tool(tags={"core"}, name="recommend_tools")
     def recommend_tools_tool(task_description: str) -> dict:
         """Recommend relevant tools for a task. Call this when unsure which
-        tool to use. Returns a focused group of tools instead of all 140.
+        tool to use. Returns a focused group of tools instead of the full
+        roster.
 
         Args:
             task_description: What you want to do (e.g. "add VAV reheat",

--- a/mcp_server/tool_registry.py
+++ b/mcp_server/tool_registry.py
@@ -1,0 +1,95 @@
+"""Collected ToolDescriptor registry — runtime source of truth for discovery.
+
+Every skill's ``register(mcp)`` is invoked through :class:`CollectingMCP`,
+which delegates to the real MCP object while recording one
+:class:`ToolDescriptor` per ``@mcp.tool`` registration. The tool-catalog
+resource and the router index are built from these descriptors, so they can
+never drift from what is actually registered (including under the
+OSMCP_DISABLE_KNOWLEDGE_SKILLS ablation flag, where the skipped packages
+simply produce no descriptors).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ToolDescriptor:
+    name: str                # MCP-visible tool name
+    package: str             # owning mcp_server/skills/<package>
+    tags: frozenset[str]
+    description: str         # first line of the tool docstring
+
+
+_DESCRIPTORS: dict[str, ToolDescriptor] = {}
+
+
+def descriptors() -> dict[str, ToolDescriptor]:
+    """Snapshot of the collected descriptors (name -> ToolDescriptor)."""
+    return dict(_DESCRIPTORS)
+
+
+def reset_descriptors() -> None:
+    """Clear the registry — called at the start of each full registration."""
+    _DESCRIPTORS.clear()
+
+
+def ensure_collected() -> None:
+    """Populate descriptors if no registration has happened yet.
+
+    Consumers that can run outside a live server (router index in unit
+    contexts) call this; it registers all skills into a no-op MCP purely for
+    the collection side effect.
+    """
+    if _DESCRIPTORS:
+        return
+
+    class _NullMCP:
+        def tool(self, name=None, **kwargs):
+            return lambda fn: fn
+
+        def prompt(self, **kwargs):
+            return lambda fn: fn
+
+        def resource(self, *args, **kwargs):
+            return lambda fn: fn
+
+    from mcp_server.skills import register_all_skills
+    register_all_skills(_NullMCP())
+
+
+class CollectingMCP:
+    """Facade handed to each skill's register().
+
+    Delegates every call to the real MCP object — never monkeypatches the
+    shared FastMCP instance — while capturing a ToolDescriptor per tool.
+    """
+
+    def __init__(self, mcp, package: str):
+        self._mcp = mcp
+        self._package = package
+
+    def tool(self, name=None, tags=None, **kwargs):
+        real_decorator = self._mcp.tool(name=name, tags=tags, **kwargs)
+        package = self._package
+
+        def decorator(fn):
+            tool_name = name or fn.__name__
+            if tool_name in _DESCRIPTORS:
+                raise ValueError(
+                    f"duplicate MCP tool name '{tool_name}' "
+                    f"({_DESCRIPTORS[tool_name].package} and {package})",
+                )
+            doc = (fn.__doc__ or "").strip()
+            _DESCRIPTORS[tool_name] = ToolDescriptor(
+                name=tool_name,
+                package=package,
+                tags=frozenset(tags or ()),
+                description=doc.split("\n")[0] if doc else "",
+            )
+            return real_decorator(fn)
+
+        return decorator
+
+    def __getattr__(self, attr):
+        return getattr(self._mcp, attr)

--- a/tests/llm/runner.py
+++ b/tests/llm/runner.py
@@ -41,8 +41,14 @@ BUILTIN_TOOLS = frozenset({
     "Bash", "PowerShell", "LocalShell", "Glob", "Grep", "Read", "Edit",
     "Write", "NotebookEdit", "WebFetch", "WebSearch", "TodoWrite",
     "AskUserQuestion", "Skill", "EnterPlanMode", "ExitPlanMode",
-    "EnterWorktree", "LSP", "ListMcpResourcesTool", "ReadMcpResourceTool",
-    "Agent",
+    "EnterWorktree", "ExitWorktree", "LSP", "ListMcpResourcesTool",
+    "ReadMcpResourceTool", "Agent",
+    # Newer Claude Code built-ins — missing entries here get miscounted as
+    # MCP tool calls (a file-transfer eval failed with tool_names=["Monitor"])
+    "Monitor", "SendFeedback", "SendMessage", "ListAgents", "Artifact",
+    "Workflow", "ReportFindings", "SendUserFile", "PushNotification",
+    "RemoteTrigger", "ScheduleWakeup", "CronCreate", "CronDelete",
+    "CronList", "DesignSync",
 })
 
 # Tools that touch the HOST machine (shell, filesystem, network) — the

--- a/tests/test_registry_discovery.py
+++ b/tests/test_registry_discovery.py
@@ -145,9 +145,8 @@ def test_collector_rejects_duplicate_names():
 def test_router_routes_synthetic_files_tool():
     # Validates: recommend_tools builds its index from the collector — a
     # files-tagged tool is reachable via upload/transfer phrasing (F2)
-    from mcp_server.tool_registry import CollectingMCP, reset_descriptors
-
     from mcp_server.skills.tool_router import operations as router_ops
+    from mcp_server.tool_registry import CollectingMCP, reset_descriptors
 
     reset_descriptors()
     facade = CollectingMCP(_FakeMCP(), "file_transfer")

--- a/tests/test_registry_discovery.py
+++ b/tests/test_registry_discovery.py
@@ -1,0 +1,238 @@
+"""Registry-derived discovery surfaces: tool-catalog resource + router (F1, F2).
+
+The tool_catalog resource was a hand-maintained static dict (130 of the
+registered tools, claiming completeness) and the router's keyword groups
+missed four registration tags entirely — those tools were unreachable via
+recommend_tools. Both surfaces must derive from the live registration
+collector so they cannot drift.
+"""
+import asyncio
+import json
+
+import pytest
+from conftest import integration_enabled, server_params, unwrap
+from doc_contract_lib import load_tool_registry
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+from test_skill_registration import EXPECTED_TOOLS
+
+# ---------------------------------------------------------------------------
+# Unit: router coverage (AST registry — no imports of openstudio)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_every_registration_tag_has_router_keywords():
+    # Regression: tags analysis/files/meta/space_types had no keyword group —
+    # recommend_tools could never route to their tools (F2)
+    from mcp_server.skills.tool_router.operations import GROUP_KEYWORDS
+
+    tags = {t for sig in load_tool_registry().values() for t in sig.tags}
+    missing = sorted(tags - set(GROUP_KEYWORDS))
+    assert not missing, (
+        f"registration tags with no router keyword group (their tools are "
+        f"unreachable via recommend_tools): {missing}"
+    )
+    empty = sorted(g for g, kw in GROUP_KEYWORDS.items() if not kw)
+    assert not empty, f"keyword groups with no keywords: {empty}"
+
+
+@pytest.mark.unit
+def test_every_tool_reachable_via_router():
+    # Regression: 30+ tools carried only unrouted tags — recommend_tools
+    # could never surface them (F2). Every tool needs >= 1 routed tag.
+    from mcp_server.skills.tool_router.operations import GROUP_KEYWORDS
+
+    unreachable = sorted(
+        sig.name for sig in load_tool_registry().values()
+        if not (sig.tags & set(GROUP_KEYWORDS))
+    )
+    assert not unreachable, (
+        f"tools unreachable via recommend_tools (no routed tag): {unreachable}"
+    )
+
+
+@pytest.mark.unit
+def test_router_docstring_has_no_tool_count():
+    # Regression: recommend_tools docstring said "instead of all 140" — counts
+    # drift; doctrine is "150+", never exact counts in tool text (F2)
+    import re
+    from pathlib import Path
+
+    text = (
+        Path(__file__).resolve().parents[1]
+        / "mcp_server" / "skills" / "tool_router" / "tools.py"
+    ).read_text(encoding="utf-8")
+    m = re.search(r"all \d+", text)
+    assert m is None, f"hardcoded tool count in router docstring: '{m.group()}'"
+
+
+# ---------------------------------------------------------------------------
+# Unit: collector on synthetic registrations (no openstudio)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMCP:
+    def __init__(self):
+        self.registered = {}
+
+    def tool(self, name=None, tags=None, **kwargs):
+        def decorator(fn):
+            self.registered[name or fn.__name__] = fn
+            return fn
+        return decorator
+
+    def prompt(self, **kw):
+        return lambda fn: fn
+
+    def resource(self, *a, **kw):
+        return lambda fn: fn
+
+
+@pytest.mark.unit
+def test_collector_captures_descriptors_and_delegates():
+    # Validates: the collecting facade records name/package/tags/first-line
+    # description while still registering the function on the real MCP —
+    # no monkeypatching of the shared FastMCP instance (F1 design)
+    from mcp_server.tool_registry import (
+        CollectingMCP,
+        descriptors,
+        reset_descriptors,
+    )
+
+    reset_descriptors()
+    fake = _FakeMCP()
+    facade = CollectingMCP(fake, "synth_pkg")
+
+    @facade.tool(name="synth_tool", tags={"files"})
+    def synth_tool(x: str):
+        """First line description.
+
+        Second line ignored.
+        """
+        return x
+
+    assert "synth_tool" in fake.registered, "delegation to real MCP broken"
+    d = descriptors()["synth_tool"]
+    assert d.package == "synth_pkg"
+    assert d.tags == frozenset({"files"})
+    assert d.description == "First line description."
+    reset_descriptors()
+
+
+@pytest.mark.unit
+def test_collector_rejects_duplicate_names():
+    # Validates: two packages registering the same MCP name fail loudly at
+    # registration instead of silently shadowing each other
+    from mcp_server.tool_registry import CollectingMCP, reset_descriptors
+
+    reset_descriptors()
+    facade_a = CollectingMCP(_FakeMCP(), "pkg_a")
+    facade_b = CollectingMCP(_FakeMCP(), "pkg_b")
+
+    @facade_a.tool(name="dup_tool", tags={"core"})
+    def one():
+        """One."""
+
+    with pytest.raises(ValueError, match="dup_tool"):
+        @facade_b.tool(name="dup_tool", tags={"core"})
+        def two():
+            """Two."""
+    reset_descriptors()
+
+
+@pytest.mark.unit
+def test_router_routes_synthetic_files_tool():
+    # Validates: recommend_tools builds its index from the collector — a
+    # files-tagged tool is reachable via upload/transfer phrasing (F2)
+    from mcp_server.tool_registry import CollectingMCP, reset_descriptors
+
+    from mcp_server.skills.tool_router import operations as router_ops
+
+    reset_descriptors()
+    facade = CollectingMCP(_FakeMCP(), "file_transfer")
+
+    @facade.tool(name="synthetic_upload", tags={"files"})
+    def synthetic_upload():
+        """Upload a local file to the server."""
+
+    router_ops.reset_tool_index()
+    try:
+        res = router_ops.recommend_tools_op("upload my local model to the server")
+        assert res["ok"] is True
+        assert res["recommended_group"] == "files", res
+        assert [t["name"] for t in res["tools"]] == ["synthetic_upload"]
+    finally:
+        reset_descriptors()
+        router_ops.reset_tool_index()
+
+
+# ---------------------------------------------------------------------------
+# Integration: live catalog == live tools/list == EXPECTED_TOOLS
+# ---------------------------------------------------------------------------
+
+
+def _flatten_catalog(payload: dict) -> set[str]:
+    names: set[str] = set()
+    for tools in payload.values():
+        names.update(tools if isinstance(tools, list) else tools.keys())
+    return names
+
+
+@pytest.mark.integration
+def test_tool_catalog_matches_live_roster():
+    # Regression: the static tool_catalog dict advertised 130 names while
+    # claiming completeness — 60+ registered tools were invisible to catalog
+    # readers (F1). Normal mode: catalog == live tools/list == EXPECTED_TOOLS.
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+
+                live = {t.name for t in (await s.list_tools()).tools}
+                assert live == EXPECTED_TOOLS, (
+                    f"live roster drift: missing={sorted(EXPECTED_TOOLS - live)}, "
+                    f"extra={sorted(live - EXPECTED_TOOLS)}"
+                )
+
+                res = await s.read_resource("openstudio://tool-catalog")
+                payload = json.loads(res.contents[0].text)
+                catalog = _flatten_catalog(payload)
+                assert catalog == EXPECTED_TOOLS, (
+                    f"tool-catalog drift: missing={sorted(EXPECTED_TOOLS - catalog)}, "
+                    f"extra={sorted(catalog - EXPECTED_TOOLS)}"
+                )
+
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_recommend_tools_routes_previously_unrouted_tags():
+    # Regression: analysis/files/meta/space_types tools were unreachable via
+    # recommend_tools over the live server (F2)
+    if not integration_enabled():
+        pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable integration tests.")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                cases = {
+                    "upload my local model file to the remote server": "request_upload",
+                    "run an OSAF sampling analysis sweep on openstudio server": "openstudio_analysis_submit",
+                    "attribute standards space types after a gbxml import": "start_space_type_wizard",
+                }
+                for task, expected_tool in cases.items():
+                    res = unwrap(await s.call_tool(
+                        "recommend_tools", {"task_description": task}))
+                    assert res["ok"] is True, res
+                    names = [t["name"] for t in res["tools"]]
+                    assert expected_tool in names, (
+                        f"'{task}' -> group '{res['recommended_group']}' "
+                        f"without {expected_tool}: {names}"
+                    )
+
+    asyncio.run(_run())

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -243,3 +243,22 @@ def test_weather_discovery_routes_to_list_weather_files():
     assert "list_files(" not in weather.group(1), (
         "tool-workflows weather recipe must not use list_files"
     )
+
+
+# ---- corpus invariant (D1-D6) -----------------------------------------------
+
+
+def test_no_internal_skill_md_files():
+    # Regression: mcp_server/skills/*/SKILL.md carried agent guidance that
+    # get_skill never serves (it reads the configured SKILLS_DIR only) — HVAC
+    # comfort doctrine, OSAF defaults, unit tables stranded (plan D1-D6).
+    # Internal developer notes are README.md; .claude/skills is the ONLY
+    # agent-guidance corpus.
+    stranded = sorted(
+        str(p.relative_to(REPO_ROOT))
+        for p in (REPO_ROOT / "mcp_server" / "skills").glob("*/SKILL.md")
+    )
+    assert stranded == [], (
+        f"internal SKILL.md files are never served — migrate agent guidance "
+        f"to .claude/skills and rename to README.md: {stranded}"
+    )

--- a/tests/test_skill_registration.py
+++ b/tests/test_skill_registration.py
@@ -310,6 +310,17 @@ def test_knowledge_skills_ablation_flag(monkeypatch):
         f"extra={registered_names - (EXPECTED_TOOLS - KNOWLEDGE_TOOLS)}"
     )
 
+    # Validates: the ToolDescriptor collector sees the same ablated roster —
+    # catalog/router surfaces built from it exclude exactly the knowledge
+    # skills' descriptors, nothing else (plan PR 5)
+    from mcp_server.tool_registry import descriptors
+
+    collected = descriptors()
+    assert set(collected) == EXPECTED_TOOLS - KNOWLEDGE_TOOLS
+    assert not {d.package for d in collected.values()} & {
+        "skill_discovery", "tool_router",
+    }
+
 
 def test_export_tool_table_matches_expected_roster():
     # Validates: the paper's Table 1 exporter groups every EXPECTED_TOOLS

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -1,7 +1,10 @@
-"""Verify OpenStudio.convert() works for all unit strings documented in SKILL.md.
+"""Verify OpenStudio.convert() works for every documented unit string.
 
-These are the unit pairs that measures commonly use for BEM calculations.
-Runs inside Docker where the openstudio Python bindings are available.
+Source of truth: the SERVED table .claude/skills/measure-authoring/
+unit-conversions.md (fetched by agents via get_skill_file). A unit test below
+parses that table and asserts every unit string appears in CONVERSION_PAIRS,
+so the served doc and this suite cannot drift apart silently (plan E4).
+Conversion execution runs inside Docker where openstudio is available.
 """
 import pytest
 from conftest import integration_enabled
@@ -173,3 +176,35 @@ def test_temperature_conversions():
     c100_to_f = openstudio.convert(100.0, "C", "F")
     assert c100_to_f.is_initialized()
     assert abs(c100_to_f.get() - 212.0) < 0.01, f"100°C should be 212°F, got {c100_to_f.get()}"
+
+
+@pytest.mark.unit
+def test_served_unit_table_units_are_exercised():
+    # Validates: every unit string in the served unit-conversions.md table is
+    # exercised by this suite — the served doc and the tests cannot drift
+    # apart silently (plan E4). Pure text parsing, no openstudio import.
+    import re
+    from pathlib import Path
+
+    table = (
+        Path(__file__).resolve().parents[1]
+        / ".claude" / "skills" / "measure-authoring" / "unit-conversions.md"
+    ).read_text(encoding="utf-8")
+
+    documented = set()
+    for line in table.splitlines():
+        if not (line.startswith("|") and "`" in line):
+            continue
+        documented.update(re.findall(r"`([^`]+)`", line))
+    assert len(documented) >= 40, (
+        f"served unit table parsed suspiciously few unit strings: {sorted(documented)}"
+    )
+
+    exercised = set(IDENTITY_UNITS)
+    for a, b in CONVERSION_PAIRS:
+        exercised.update((a, b))
+    missing = sorted(documented - exercised)
+    assert not missing, (
+        f"unit strings documented in the served table but never exercised "
+        f"here: {missing} — add pairs or fix the doc"
+    )


### PR DESCRIPTION
Part 5 of the skills-consistency plan. Builds on #142 (stack: #139 → #141 → #142 → this).

## The problem

Two discovery surfaces were hand-maintained copies of the tool roster, and both had drifted badly:

- The `openstudio://tool-catalog` resource was a static dictionary listing 130 tool names while describing itself as "all MCP tools" — more than 60 registered tools were simply missing from it.
- The `recommend_tools` router matches task descriptions against keyword groups keyed by registration tag, but four tags (analysis, files, meta, space_types) had no keyword group at all. Roughly 35 tools — the whole OSAF analysis suite, file upload/download, the space-type wizard, server status — could never be recommended, no matter what the agent asked. Its docstring also hardcoded "all 140", a count that stopped being true long ago.

## The fix

A small collector now sits in the registration path: each skill's `register()` gets a facade that passes everything through to the real server object unchanged, while recording one descriptor per tool (name, owning package, tags, first line of the docstring). Nothing monkeypatches the shared FastMCP instance, and duplicate tool names now fail loudly at registration instead of silently shadowing.

- The tool-catalog resource is generated from those descriptors, grouped by owning package, with each tool's one-line description. The static dict is gone.
- The router builds its index from the same descriptors, and the four missing tags got keyword groups, so phrases like "upload my local model", "run an OSAF sampling sweep", or "attribute space types after a gbXML import" now route to the right tools.
- When the benchmark ablation flag removes the knowledge skills, they produce no descriptors, so the catalog and router shrink in lockstep with the real roster — asserted in the ablation test.

## How it was verified

Failing tests first (they document the exact drift), then green: a live-server test asserting catalog contents == the server's actual tools/list == the expected roster; a live test that the previously unreachable tools are now recommended; unit tests for the collector on synthetic registrations (delegation, descriptor capture, duplicate rejection); a guard that every registration tag has keywords and every tool is reachable; and a guard against hardcoded counts in the router docstring. Full unit tier in Docker: 491 passed. Routing/baseline/ablation suites: 47 passed.