### PR TITLE
Docs: stop hardcoding tool counts; point contributors at the real roster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — Codex CLI Instructions
 
 ## Project
-OpenStudio MCP server — 24 skills, 138 tools, ~18K prod lines.
+OpenStudio MCP server — 150+ tools across 30+ skill packages (exact roster: EXPECTED_TOOLS in tests/test_skill_registration.py).
 
 ## Architecture
 - `mcp_server/skills/<name>/tools.py` — MCP tool defs, calls operations

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Model Context Protocol server for [OpenStudio](https://openstudio.net/) building energy simulation.** It lets MCP hosts — Claude Desktop, Claude Code, Cursor, VS Code — create, query, and modify OpenStudio models, run EnergyPlus, and read results, all in plain language. The server handles the OpenStudio/EnergyPlus complexity behind MCP tool calls.
 
-**150+ tools · 13 workflow skills · 480+ integration tests**
+**150+ tools · bundled workflow skills · 480+ integration tests**
 
 ---
 
@@ -245,7 +245,7 @@ OSM, SQL, report, and log files as untrusted outputs.
 
 ## Skills & Tools (150+ total)
 
-In Claude Code, 16 bundled skills add workflow automation and domain knowledge:
+In Claude Code, the bundled skills add workflow automation and domain knowledge:
 
 | Skill | Type | What it does |
 |-------|------|--------------|
@@ -265,6 +265,7 @@ In Claude Code, 16 bundled skills add workflow automation and domain knowledge:
 | `/gbxml-import` | Task | Revit gbXML import + geometry-defect repair workflow |
 | `/osaf-analysis` | Task | OpenStudio Analysis Framework workflow: algorithm selection, validation, submission |
 | `/python-ems` | Task | custom EnergyPlus Python Plugin control/reporting logic (EMS) |
+| `file-transfer` | Task | move files to/from a remote server (signed upload/download URLs) |
 
 Workflow/task skills are invoked with `/name`; knowledge skills load automatically. Any MCP host can also discover these guides via the `list_skills()` and `get_skill(name)` tools (mount `-v ./.claude/skills:/skills:ro`).
 
@@ -736,7 +737,7 @@ CI runs the same pre-commit check in `.github/workflows/format_and_lint.yml`.
 
 - **Transport:** stdio (default) or streamable HTTP for [remote/multi-user](#remote--multi-user-http)
 - **Protocol:** MCP (JSON-RPC); in stdio prod mode, stdout is reserved for JSON-RPC and logs go to stderr
-- **Skills:** 27 skill modules under `mcp_server/skills/<name>/`, each with `tools.py` (MCP registration) + `operations.py` (business logic); they auto-register
+- **Skills:** 30+ skill modules under `mcp_server/skills/<name>/`, each with `tools.py` (MCP registration) + `operations.py` (business logic); they auto-register
 - **State:** per-session in-memory model via `model_manager`; runs under `/runs/<run_id>/` (or `/runs/<user>/<run_id>/` in HTTP mode)
 
 Set `OPENSTUDIO_MCP_MODE=prod` for MCP hosts (quiet logs, no banner). Full system diagram, security analysis, and hardening notes: **[docs/architecture.md](docs/architecture.md)**.
@@ -749,7 +750,7 @@ Set `OPENSTUDIO_MCP_MODE=prod` for MCP hosts (quiet logs, no banner). Full syste
 2. `operations.py` — pure logic, returns `{"ok": True/False, ...}`
 3. `tools.py` — exports `register(mcp)`, defines tool schemas
 4. Add `tests/test_<name>.py` and a CI step in `.github/workflows/ci.yml`
-5. Auto-registers via `skills/__init__.py`; add names to `EXPECTED_TOOLS` and bump counts in `tests/test_tool_baseline.py`
+5. Auto-registers via `skills/__init__.py`; add each tool name to `EXPECTED_TOOLS` in `tests/test_skill_registration.py` — the roster's single source of truth (never hardcode counts)
 
 **New Claude Code skill (workflow guide)**
 1. Create `.claude/skills/<name>/SKILL.md` with YAML frontmatter (`name`, `description`)

--- a/docs/testing/frameworks-summary.md
+++ b/docs/testing/frameworks-summary.md
@@ -142,7 +142,7 @@ backend.
 
 | Category | Files | What it tests |
 |---|---|---|
-| Registration | `test_skill_registration.py` | all 197 tools register; `EXPECTED_TOOLS` is the roster of record |
+| Registration | `test_skill_registration.py` | every tool registers; `EXPECTED_TOOLS` is the roster of record |
 | Skill docs | `test_skill_docs.py`, `test_skill_tools.py` | SKILL.md frontmatter, tool-name cross-references, skill discovery |
 | Protocol | `test_stdio_smoke.py` | raw JSON-RPC on stdio, no stdout pollution |
 | Security / isolation | `test_path_safety.py`, `test_measure_isolation.py` | path-traversal guards, per-user roots disjoint, cross-tenant denied |

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -1,0 +1,68 @@
+"""Normative docs must not hardcode exact tool counts.
+
+The roster's single source of truth is EXPECTED_TOOLS in
+tests/test_skill_registration.py; prose says "150+ tools". Exact literals
+("138 tools", "151 tools") go stale the moment a tool lands. Historical
+records (dated benchmarks, archived plans) keep their point-in-time numbers
+and are not covered here.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Living, normative docs — contributor guidance and current-state descriptions
+NORMATIVE_DOCS = [
+    "README.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/rules/testing.md",
+    ".claude/rules/api-reference.md",
+    ".claude/rules/component-types.md",
+    "docs/testing/README.md",
+    "docs/testing/testing.md",
+    "docs/testing/frameworks-summary.md",
+]
+
+# "151 tools" / "138 tools" are stale the day they land; "150+ tools" is the
+# sanctioned phrasing ("+" excluded by the lookbehind)
+_EXACT_TOOL_COUNT = re.compile(r"\b\d{3}(?<!\+)\s+tools\b")
+
+
+def test_normative_docs_use_150_plus_not_exact_tool_counts():
+    # Regression: AGENTS.md said "138 tools", the testing rule said "151
+    # tools" — both stale; doctrine is "150+ tools" with EXPECTED_TOOLS as
+    # the only exact roster (plan F3)
+    offenders = []
+    for rel in NORMATIVE_DOCS:
+        path = REPO / rel
+        if not path.exists():
+            continue
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            m = _EXACT_TOOL_COUNT.search(line)
+            if m:
+                offenders.append(f"{rel}:{i}: '{m.group().strip()}'")
+    assert not offenders, (
+        "exact tool-count literals in normative docs (use '150+ tools'; the "
+        "roster lives in EXPECTED_TOOLS):\n" + "\n".join(offenders)
+    )
+
+
+def test_contributor_docs_point_at_expected_tools_only():
+    # Regression: README's contributor section told people to "bump counts in
+    # tests/test_tool_baseline.py" — there are no counts to bump; the roster
+    # has ONE source of truth (plan F3)
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    assert "bump counts" not in readme, (
+        "contributor guidance must not instruct count-bumping — the roster "
+        "is EXPECTED_TOOLS in tests/test_skill_registration.py"
+    )
+    assert "EXPECTED_TOOLS" in readme, (
+        "contributor guidance must name EXPECTED_TOOLS as the roster source"
+    )


### PR DESCRIPTION
Part 6 of the skills-consistency plan. Builds on #143 (end of the stack: #139 → #141 → #142 → #143 → this).

## The problem

Prose kept exact tool counts that go stale every time a tool lands, and they had: AGENTS.md claimed "24 skills, 138 tools", a testing summary said "all 197 tools", and the README told contributors to "bump counts in tests/test_tool_baseline.py" — a file that has no counts to bump. The convention this repo already follows is: prose says "150+ tools", and the only exact roster is the EXPECTED_TOOLS set in tests/test_skill_registration.py.

## Changes

- Living docs (README, AGENTS.md, testing summaries) now use "150+" or count-free phrasing, and the contributor guidance names EXPECTED_TOOLS as the single place to edit when adding or removing a tool.
- The README's bundled-skills table gains the file-transfer skill added earlier in this stack.
- A small test (committed first, failing on the old text) scans the living docs and rejects exact "NNN tools" literals so this class of drift can't quietly return. Dated benchmark records keep their point-in-time numbers — they already sit under "comparability epoch" banners and are excluded.

## Deferred

Generating the README's per-group tool tables from the registration collector (built in #143) was considered and deferred — the tables are large, and the collector makes doing it later straightforward.