### PR TITLE
Test served skill routing and eval coverage

### DIFF
--- a/.claude/skills/ashrae-baseline-guide/SKILL.md
+++ b/.claude/skills/ashrae-baseline-guide/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ashrae-baseline-guide
 description: ASHRAE 90.1 Appendix G baseline system selection criteria. Use when recommending HVAC system types, creating baseline models, or answering questions about ASHRAE 90.1 compliance.
+eval-exempt: "reference knowledge; no discrete action-tool selection to assert"
 user-invocable: false
 ---
 

--- a/.claude/skills/attribute-space-types/eval.md
+++ b/.claude/skills/attribute-space-types/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Assign 90.1-2019 Office WholeBuilding - Sm Office to every conditioned space" | assign_space_type_simple | standards_template=90.1-2019, standards_building_type=Office, standards_space_type present |
+| "Attribute one standards space type to all conditioned spaces in this office" | assign_space_type_simple | standards_template present, standards_building_type present, standards_space_type present |
+| "Run the space type wizard for this mixed-use building" | start_space_type_wizard | — |
+| "Help me assign different standards space types to the conditioned spaces" | start_space_type_wizard | — |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "What space types already exist in the model?" | assign_space_type_simple, start_space_type_wizard, assign_space_type_batch | list_model_objects, get_space_type_details |
+| "Show the details for the Office Space Type" | assign_space_type_simple, start_space_type_wizard, assign_space_type_batch | get_space_type_details, list_model_objects |
+| "Create typical loads for this office building" | assign_space_type_simple, start_space_type_wizard, assign_space_type_batch | create_typical_building, create_people_definition, create_lights_definition |

--- a/.claude/skills/gbxml-import/eval.md
+++ b/.claude/skills/gbxml-import/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Import the provided Revit gbXML into an OpenStudio model without simulating it" | import_gbxml | gbxml_path present, epw_path present |
+| "Convert the available gbXML file to OSM using the project weather file" | import_gbxml | gbxml_path present, epw_path present |
+| "Repair and validate the loaded gbXML geometry" | repair_and_validate_gbxml_geometry | — |
+| "Check this imported gbXML model for overlaps and non-enclosed spaces" | repair_and_validate_gbxml_geometry | — |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "What spaces are in the currently loaded model?" | import_gbxml, repair_and_validate_gbxml_geometry | list_spaces, get_model_summary |
+| "Validate the current OSM before simulation" | import_gbxml, repair_and_validate_gbxml_geometry | validate_model, inspect_osm_summary |
+| "Import the FloorspaceJS floor plan at /inputs/sddc_office/floorplan.json" | import_gbxml, repair_and_validate_gbxml_geometry | import_floorspacejs |

--- a/.claude/skills/measure-authoring/eval.md
+++ b/.claude/skills/measure-authoring/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Write a Ruby OpenStudio measure named reduce_lpd that lowers lighting power density by ten percent" | create_measure | name=reduce_lpd, description present, run_body present, language present |
+| "Create a Python model measure named report_zone_count that reports how many thermal zones exist" | create_measure | name=report_zone_count, description present, run_body present, language present |
+| "Build a custom reporting measure named annual_peak_report for simulation results" | create_measure | name=annual_peak_report, measure_type=ReportingMeasure |
+| "Revise the existing reduce_lpd measure so its run method also logs the final lighting power" | edit_measure | measure_name=reduce_lpd, run_body present |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Apply the existing measure at /measures/ReduceLightingLoads to the loaded model" | create_measure, edit_measure | apply_measure |
+| "What custom measures have already been created?" | create_measure, edit_measure | list_custom_measures |
+| "Test the measure at /measures/custom/reduce_lpd against the loaded model" | create_measure, edit_measure | test_measure |

--- a/.claude/skills/openstudio-patterns/SKILL.md
+++ b/.claude/skills/openstudio-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: openstudio-patterns
 description: OpenStudio model object relationships, tool dependencies, and common error patterns. Use when building or modifying models to ensure correct tool ordering.
+eval-exempt: "reference knowledge; no discrete action-tool selection to assert"
 user-invocable: false
 ---
 

--- a/.claude/skills/osaf-analysis/eval.md
+++ b/.claude/skills/osaf-analysis/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Which OSAF algorithm should I use for a one-variable sampling sweep?" | openstudio_analysis_algorithms | category present |
+| "Create an OSA JSON configuration for a single-run office analysis" | openstudio_analysis_create_osa_json | output_path present, analysis_name present, analysis_type=single_run |
+| "Validate the OSA configuration at /inputs/office_analysis.json before submission" | openstudio_analysis_validate_osa_json | osa_json_path=/inputs/office_analysis.json |
+| "Submit /inputs/office_analysis.json to OpenStudio Server project project_123" | openstudio_analysis_submit | project_id=project_123, osa_json_path=/inputs/office_analysis.json |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "What is the current status of OpenStudio Server analysis analysis_123?" | openstudio_analysis_create_osa_json, openstudio_analysis_submit, openstudio_analysis_start | openstudio_analysis_status |
+| "Download the CSV results for analysis analysis_123 to /runs/osaf-results" | openstudio_analysis_create_osa_json, openstudio_analysis_submit, openstudio_analysis_start | openstudio_analysis_download_data |
+| "Run the loaded OSM through a local EnergyPlus simulation" | openstudio_analysis_create_osa_json, openstudio_analysis_submit, openstudio_analysis_start | run_simulation, save_osm_model |

--- a/.claude/skills/python-ems/eval.md
+++ b/.claude/skills/python-ems/eval.md
@@ -1,0 +1,14 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Add a Python EMS plugin that reports the volume-weighted average zone temperature" | create_python_plugin | name present, template=zone_metric_aggregate |
+| "Create a Python EMS night-setback controller for the heating setpoint schedule" | create_python_plugin | name present, template=schedule_override, schedule_name present |
+| "Add an outdoor-air reset Python plugin for the supply-air temperature" | create_python_plugin | name present, template=node_setpoint_reset |
+| "Replace the source code of the existing llm-test-sched-override Python plugin" | edit_python_plugin | name=llm-test-sched-override, code present |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "List the Python EMS plugins already in this model" | create_python_plugin, edit_python_plugin | get_python_plugin |
+| "Show me the source code for the llm-test-sched-override Python plugin" | create_python_plugin, edit_python_plugin | get_python_plugin |
+| "Run the loaded model with EnergyPlus" | create_python_plugin, edit_python_plugin | run_simulation, save_osm_model |

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tool-workflows
 description: Multi-tool recipes for common building energy modeling tasks. Use when chaining tools together for operations like adding windows, changing insulation, setting up HVAC, or running simulations.
+eval-exempt: "reference workflows; no single action-tool selection to assert"
 user-invocable: false
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ OpenStudio MCP server — 150+ tools across 30+ skill packages (exact roster: EX
 - Tool functions use `_tool` suffix internally, MCP name strips it
 - `list[str]` params use `list[str] | str` type + `parse_str_list()` from `osm_helpers.py` (MCP clients may send JSON strings)
 
+## Skill Eval Maintenance
+- Every served skill requires `.claude/skills/<name>/eval.md` with positive and negative routing cases, or a non-empty `eval-exempt` reason in `SKILL.md` frontmatter
+- Follow the machine-readable table grammar in `tests/llm/README.md#skill-eval-files`; malformed or prose-only rows fail deterministic tests
+- Keep `eval.md` as repository test data; it must not be served to runtime agents through `get_skill`
+- Run `pytest tests/test_skill_docs.py -k eval -v` after changing skill metadata or eval cases; live LLM execution remains opt-in and budgeted
+
 ## Review Focus
 When reviewing code, check for:
 1. **Error handling** — bare `except Exception: pass`, swallowed errors, missing error context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ docker run --rm \
 - Full suite only for final validation
 - Markers: `-m smoke` (12), `-m generic` (7), `-m progressive` (149); counts as of 2026-08-22
 - Benchmark results go in `docs/testing/llm-test-benchmark.md`
+- Served skills require `.claude/skills/<name>/eval.md` or a non-empty `eval-exempt` reason in `SKILL.md`; follow `tests/llm/README.md#skill-eval-files`
+- Treat `eval.md` as test data, not agent-facing skill content; validate changes with `pytest tests/test_skill_docs.py -k eval -v`
 
 ### Local Development
 - Lint: `ruff check mcp_server/`

--- a/docs/testing/frameworks-summary.md
+++ b/docs/testing/frameworks-summary.md
@@ -93,7 +93,7 @@ scripts the SDK directly). Benchmark sweeps pin one image and one harness commit
 |---|---|---|
 | `test_01_setup.py` | 8 | Creates the baseline / HVAC / example models and seed fixtures every later test loads |
 | `test_02_tool_selection.py` | 4 | Single-tool discovery with no model state |
-| `test_03_eval_cases.py` | 26 | Auto-parsed from `.claude/skills/*/eval.md` "Should trigger" tables |
+| `test_03_eval_cases.py` | auto | Positive and negative action-routing cases auto-parsed from `.claude/skills/*/eval.md`, plus explicit served-guide routing cases |
 | `test_04_workflows.py` | 37 | Multi-step chains: load → weather → HVAC → simulate → extract |
 | `test_05_guardrails.py` | 3 | The agent must not bypass MCP with Bash / Edit / Write |
 | `test_06_progressive.py` | 149 | **The core diagnostic**: operations posed at L1 (vague), L2 (moderate), L3 (tool named); the benchmark's 16-task hard set is a `-k` subset of this file |
@@ -125,7 +125,7 @@ backend.
 - Rare in the ecosystem: an automated, outcome-graded agent benchmark with L1/L2/L3 prompts that separates "wrong description" from "cannot discover" from "broken tool".
 - Reproducible: pinned image + harness commit per sweep, per-leg provenance in every result file, an aggregator that refuses to pool mismatched legs, and a frozen dataset deposited with the release.
 - Cross-vendor (Claude and GPT via Codex) and ablation-ready (arms) without changing tests.
-- Eval cases auto-discovered from skill `eval.md` files stay co-located with the skills they test.
+- Eval cases auto-discovered from skill `eval.md` files stay co-located with the skills they test; the authoring contract is documented in [`tests/llm/README.md`](../../tests/llm/README.md#skill-eval-files).
 
 ### Weaknesses
 
@@ -214,7 +214,7 @@ LLM_TESTS_ENABLED=1 pytest tests/llm/ -v                 # everything, hours
 | `tests/llm/conftest.py` | LLM markers, flaky list, budget, benchmark collection |
 | `tests/llm/runner.py` | `run_agent()` / `run_claude()`, NDJSON parsing, `AgentResult` |
 | `tests/llm/grading/` | gate-2 graders (`container_grader.py`, `host.py`, `rubric.py`) |
-| `tests/llm/eval_parser.py` | turns skill `eval.md` tables into tests |
+| `tests/llm/eval_parser.py` | turns skill `eval.md` positive and negative routing tables into tests; see the [authoring contract](../../tests/llm/README.md#skill-eval-files) |
 | `scripts/benchmark_sweep.py`, `benchmark_check_leg.py`, `benchmark_aggregate.py`, `benchmark_build_t600_dataset.py` | sweep driver, contamination screen, aggregator, 600 s merge builder |
 | `.github/workflows/ci.yml`, `security.yml` | CI shards and the sandbox workflow |
 | `docs/testing/llm-test-benchmark.md` | current benchmark numbers and run history |

--- a/docs/testing/llm-testing-methodology.md
+++ b/docs/testing/llm-testing-methodology.md
@@ -73,7 +73,7 @@ pytest (tests/llm/conftest.py)
 | Benchmark collection | `conftest.py` `pytest_runtest_logreport` / `pytest_sessionfinish` | Stores per-test metrics; session end writes `benchmark.json` / `benchmark.md` / `benchmark_history.json`. |
 | Failure classification | conftest (`fail_with_mode`) | `timeout` · `no_mcp_tool` · `wrong_tool` · `wrong_args` · `tool_error` · `outcome_mismatch` (+ `recovered` tag). |
 | Prompt budget | `conftest.py` `LLM_TESTS_MAX_PROMPTS` (default 300) | Hard cap prevents runaway cost during iteration. |
-| Skill eval auto-discovery | `eval_parser.py` `load_should_trigger()` / `load_should_not_trigger()` | Scrapes "Should trigger" / "Should NOT trigger" tables from `.claude/skills/*/eval.md`. |
+| Skill eval auto-discovery | `eval_parser.py` `load_should_trigger()` / `load_should_not_trigger()` | Parses machine-checkable positive and negative routing tables from `.claude/skills/*/eval.md`; see the [authoring contract](../../tests/llm/README.md#skill-eval-files). |
 
 ### Environment knobs
 
@@ -96,13 +96,15 @@ pytest (tests/llm/conftest.py)
 
 ## 3. Test taxonomy
 
-Eleven test files (259 tests collected on 2026-08-22), organized by what the agent is asked to do.
+Eleven test files, organized by what the agent is asked to do. Counts are snapshots
+except for auto-discovered cases; use `pytest tests/llm --collect-only -q` for the
+current collection.
 
 | File | Tier | Count | Purpose | Pass‑rate signal |
 |---|---|---|---|---|
 | `test_01_setup.py` | setup | 8 | Creates baseline/HVAC/example models and seed fixtures in `/runs`. All other tests depend on these. Prompts use explicit tool names to minimize non-determinism. | Dependency gate |
 | `test_02_tool_selection.py` | tier1 | 4 | Single-tool discovery, **no model state** (e.g., "What is the server status?"). Fastest tests. | Baseline discovery |
-| `test_03_eval_cases.py` | tier3 | 26 | Auto-parsed from `.claude/skills/*/eval.md` "Should trigger" tables. Keeps tests DRY and co-located with skill definitions. | Skill discovery |
+| `test_03_eval_cases.py` | tier1 | auto | Positive and negative action-routing cases parsed from `.claude/skills/*/eval.md`, plus explicit `get_skill` guide-routing cases. Keeps tests DRY and co-located with skill definitions. | Skill and tool routing |
 | `test_04_workflows.py` | tier2 | 37 | Multi-step chains (3-5 MCP calls): load → weather → HVAC → simulate → extract. | Multi-step composition |
 | `test_05_guardrails.py` | tier4 | 3 | **Regression gate**: agent must **NOT** use `Bash`/`Edit`/`Write` to bypass MCP tools. | Safety/bypass |
 | `test_06_progressive.py` | progressive | 149 | **The core diagnostic.** Operations posed at L1 and L2, plus L3 for the `L3_KEEP` subset; the benchmark's 16-task hard set is a `-k` selection from this file. | Tool description quality |

--- a/tests/llm/README.md
+++ b/tests/llm/README.md
@@ -57,6 +57,72 @@ LLM_TESTS_ENABLED=1 LLM_TESTS_RETRIES=2 pytest tests/llm/ -v
 | `nohost` | host tools (Bash/Edit/Write/…) | claude only; codex sandbox cancels MCP calls if host tools are cut |
 | `codegen` | the MCP server itself | Arm C: agent scripts the SDK in a bare container (`test_11_codegen_arm.py`); opt-in, outcome-only grading |
 
+## Skill Eval Files
+
+Files at `.claude/skills/<skill>/eval.md` are repository-specific, machine-readable
+test fixtures for skill routing. They are not part of the Agent Skills format and
+are not instructions for the runtime modeling agent. `get_skill` deliberately does
+not serve them; the LLM test harness reads them directly from the repository.
+
+Every served skill must have either:
+
+- an `eval.md` with at least one positive and one negative routing case; or
+- a non-empty `eval-exempt` reason in `SKILL.md` frontmatter when the skill is
+  reference knowledge without a discrete action-tool choice to assert.
+
+Use `eval-exempt` narrowly. Action-oriented skills should remain covered by
+machine-checkable cases.
+
+### Required format
+
+Positive cases assert that at least one expected tool is called. The column names
+and order are required:
+
+```markdown
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Assign an office space type to every conditioned space" | assign_space_type_simple | standards_template=90.1-2019, standards_space_type present |
+```
+
+- `Expected tools` contains exact MCP registry names separated by commas or `OR`.
+  Wildcards and prose are invalid.
+- `Critical params` is comma-separated. Each item is `name`, `name present`, or
+  `name=value`; use an em dash or an empty cell when no parameter assertion applies.
+- Critical parameters are checked only on expected tools whose schemas define that
+  parameter. Numeric values compare numerically; other values compare as strings.
+
+Negative cases assert that no forbidden tool is called and at least one declared
+alternative is called. The older `Query | Why` format is not executable and fails
+validation.
+
+```markdown
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "What space types already exist?" | assign_space_type_simple | list_model_objects, get_space_type_details |
+```
+
+Keep queries natural and behavior-focused. Action routing in `eval.md` is distinct
+from guide retrieval through `get_skill`; guide-routing coverage belongs in
+`GUIDE_ROUTING_CASES` in `test_03_eval_cases.py`.
+
+### Validation
+
+```bash
+# Fast, deterministic format/coverage checks; no LLM calls
+pytest tests/test_skill_docs.py -k eval -v
+
+# Confirm generated case collection without spending model tokens
+pytest tests/llm/test_03_eval_cases.py --collect-only -q
+
+# Execute the generated routing cases (uses the configured provider)
+LLM_TESTS_ENABLED=1 LLM_TESTS_TIER=1 pytest tests/llm/test_03_eval_cases.py -v
+```
+
+The parser and exact accepted grammar live in `eval_parser.py`. Parser errors fail
+the deterministic documentation tests rather than silently dropping malformed rows.
+
 ## Reproducing the paper benchmark
 
 The Section 3.2 benchmark is a multi-leg sweep, not a single `pytest` run.
@@ -77,13 +143,13 @@ python scripts/benchmark_aggregate.py results/paper-v1.2.1     # aggregate table
 
 Frozen numbers and provenance: [`../../docs/testing/llm-test-benchmark.md`](../../docs/testing/llm-test-benchmark.md).
 
-## Test Files (259 tests total, counts from `pytest tests/llm --co`)
+## Test Files
 
 | File | Count | Description |
 |------|-------|-------------|
 | `test_01_setup.py` | 8 | Creates models, seeds `my_measure` + EMS plugin model, runs baseline+retrofit sims |
 | `test_02_tool_selection.py` | 4 | Single tool selection |
-| `test_03_eval_cases.py` | 26 | Skill eval prompts |
+| `test_03_eval_cases.py` | auto | Positive, negative, and guide-routing skill eval prompts |
 | `test_04_workflows.py` | 37 | Multi-step tool chains (full chains assert pinned EUI) |
 | `test_05_guardrails.py` | 3 | Safety/refusal tests |
 | `test_06_progressive.py` | 149 | 60 operations; L1/L2 all, L3 only for `L3_KEEP` (29) |

--- a/tests/llm/test_03_eval_cases.py
+++ b/tests/llm/test_03_eval_cases.py
@@ -1,6 +1,6 @@
 """Tier 1 tests auto-generated from eval.md files.
 
-Parses "should trigger" tables from 8 skill eval.md files
+Parses "should trigger" tables from skill eval.md files
 (.claude/skills/<skill>/eval.md). Each row maps a natural-language prompt
 to one or more expected MCP tool names.
 
@@ -11,8 +11,8 @@ Key design decisions:
     reasonable context-gathering responses (e.g. list_thermal_zones before
     adding HVAC). This prevents false failures when the agent does useful
     work but doesn't reach the exact target tool within the turn limit.
-  - SLOW_SKILLS get 180s timeout instead of 120s because model creation
-    operations (create_baseline_osm) take 30-60s each.
+  - SLOW_SKILLS get 180s timeout instead of 120s because model creation and
+    gbXML import operations can take 30-60s each.
   - Wildcard tool names (e.g. "add_*_system") are filtered out at import
     since we can't match them reliably.
   - All prompts get " Use MCP tools only." appended to discourage the
@@ -23,7 +23,14 @@ from __future__ import annotations
 import pytest
 from doc_contract_lib import load_tool_registry
 
-from .conftest import BASELINE_MODEL, baseline_model_exists, get_sim_run_id, get_tier
+from .conftest import (
+    BASELINE_MODEL,
+    EMS_MODEL,
+    baseline_model_exists,
+    ems_model_exists,
+    get_sim_run_id,
+    get_tier,
+)
 from .eval_parser import (
     check_critical_params,
     load_should_not_trigger,
@@ -64,7 +71,8 @@ EVAL_CASES = [
 # Without model state, the agent wastes turns on creation instead of
 # exercising the target tool.
 NEEDS_MODEL = {"add-hvac", "simulate", "energy-report", "retrofit",
-               "qaqc", "troubleshoot", "view"}
+               "qaqc", "troubleshoot", "view", "attribute-space-types",
+               "python-ems"}
 
 # Skills whose target tools need a COMPLETED simulation run_id, not just a
 # loaded model (get_run_logs, run_qaqc_checks) — they get the run-id prefix.
@@ -73,6 +81,24 @@ NEEDS_RUN_ID = {"troubleshoot", "qaqc"}
 LOAD_PREFIX = (
     f"First load the model at {BASELINE_MODEL} using load_osm_model. Then "
 )
+EMS_LOAD_PREFIX = (
+    f"First load the model at {EMS_MODEL} using load_osm_model. Then "
+)
+SKILL_CONTEXT_PREFIX = {
+    "gbxml-import": (
+        "The source gbXML is at /inputs/gbxml/25_SpacesOneZE.xml and the "
+        "project EPW is at /opt/comstock-measures/ChangeBuildingLocation/tests/"
+        "USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw. "
+    ),
+}
+GBXML_MODEL_TOOLS = {
+    "repair_and_validate_gbxml_geometry",
+    "list_spaces",
+    "get_model_summary",
+    "validate_model",
+    "inspect_osm_summary",
+}
+
 
 def _run_id_prefix() -> str:
     """Prompt prefix including a completed-simulation run_id if available."""
@@ -123,11 +149,75 @@ EXTRA_EXPECTED = {
 }
 
 # Skills that need longer timeout because their tools involve heavyweight
-# operations (model creation ~30-60s, simulation ~60-120s)
-SLOW_SKILLS = {"new-building": 180, "retrofit": 180}
+# operations (model creation/import ~30-60s, simulation ~60-120s)
+SLOW_SKILLS = {"new-building": 180, "retrofit": 180, "gbxml-import": 180}
 
 # Appended to all prompts to discourage raw file/script creation
 SUFFIX = " Use MCP tools only."
+
+
+GUIDE_ROUTING_CASES = [
+    {
+        "skill": "attribute-space-types",
+        "prompt": (
+            "Load the workflow guide for assigning standards space types to "
+            "conditioned spaces in a mixed-use model."
+        ),
+    },
+    {
+        "skill": "gbxml-import",
+        "prompt": (
+            "Load the workflow guide for importing a Revit gbXML file and "
+            "repairing its geometry."
+        ),
+    },
+    {
+        "skill": "python-ems",
+        "prompt": (
+            "Load the workflow guide for adding EnergyPlus Python Plugin EMS "
+            "controls."
+        ),
+    },
+    {
+        "skill": "measure-authoring",
+        "prompt": (
+            "Load the workflow guide for writing and testing a custom "
+            "OpenStudio measure."
+        ),
+    },
+    {
+        "skill": "osaf-analysis",
+        "prompt": (
+            "Load the workflow guide for OpenStudio Server sampling and OSA "
+            "JSON analyses."
+        ),
+    },
+]
+
+
+def _prepare_prompt(case: dict) -> str:
+    """Add only the model/file context required by an action-routing case."""
+    skill = case["skill"]
+    prompt = case["prompt"]
+    routed_tools = set(case.get("expected_tools", case.get("alternatives", [])))
+    needs_model = (
+        skill in NEEDS_MODEL
+        or (skill == "gbxml-import" and bool(routed_tools & GBXML_MODEL_TOOLS))
+    )
+    if needs_model:
+        if skill == "python-ems":
+            if not ems_model_exists():
+                pytest.skip("EMS model not found — run test_01_setup first")
+            prompt = EMS_LOAD_PREFIX + prompt.lower()
+        else:
+            if not baseline_model_exists():
+                pytest.skip("Baseline model not found — run test_01_setup first")
+            prompt = LOAD_PREFIX + prompt.lower()
+    context = (
+        SKILL_CONTEXT_PREFIX.get(skill, "")
+        if "import_gbxml" in case.get("expected_tools", []) else ""
+    )
+    return context + prompt + SUFFIX
 
 
 def _case_id(case: dict) -> str:
@@ -142,16 +232,9 @@ def test_eval_tool_selection(case):
     if tier not in ("all", "1"):
         pytest.skip("Tier 1 not selected")
 
-    # Prepend model load for skills that need model state
-    prompt = case["prompt"]
-    if case["skill"] in NEEDS_MODEL:
-        if not baseline_model_exists():
-            pytest.skip("Baseline model not found — run test_01_setup first")
-        if case["skill"] in NEEDS_RUN_ID:
-            prompt = _run_id_prefix() + prompt.lower()
-        else:
-            prompt = LOAD_PREFIX + prompt.lower()
-    prompt += SUFFIX
+    prompt = _prepare_prompt(case)
+    if case["skill"] in NEEDS_RUN_ID:
+        prompt = _run_id_prefix() + case["prompt"].lower() + SUFFIX
 
     timeout = SLOW_SKILLS.get(case["skill"], 120)
     result = run_claude(prompt, timeout=timeout)
@@ -196,15 +279,9 @@ def test_eval_negative_routing(case):
     if tier not in ("all", "1"):
         pytest.skip("Tier 1 not selected")
 
-    prompt = case["prompt"]
-    if case["skill"] in NEEDS_MODEL:
-        if not baseline_model_exists():
-            pytest.skip("Baseline model not found — run test_01_setup first")
-        if case["skill"] in NEEDS_RUN_ID:
-            prompt = _run_id_prefix() + prompt.lower()
-        else:
-            prompt = LOAD_PREFIX + prompt.lower()
-    prompt += SUFFIX
+    prompt = _prepare_prompt(case)
+    if case["skill"] in NEEDS_RUN_ID:
+        prompt = _run_id_prefix() + case["prompt"].lower() + SUFFIX
 
     result = run_claude(prompt, timeout=180)
     called = set(result.tool_names)
@@ -218,4 +295,29 @@ def test_eval_negative_routing(case):
         f"[{case['skill']}] none of the declared alternatives "
         f"{case['alternatives']} called for '{case['prompt']}'; got: "
         f"{sorted(called)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    GUIDE_ROUTING_CASES,
+    ids=[f"guide:{case['skill']}" for case in GUIDE_ROUTING_CASES],
+)
+def test_served_guide_routing(case):
+    """Verify natural-language guide requests retrieve the intended served skill."""
+    # Validates: guide-seeking prompts route through get_skill with the exact
+    # served skill name rather than passing via an unrelated action tool
+    tier = get_tier()
+    if tier not in ("all", "1"):
+        pytest.skip("Tier 1 not selected")
+
+    result = run_claude(case["prompt"] + SUFFIX, timeout=120)
+    requested = [
+        call["input"].get("name")
+        for call in normalize_calls(result)
+        if call["tool"] == "get_skill"
+    ]
+    assert case["skill"] in requested, (
+        f"Expected get_skill(name={case['skill']!r}), got names {requested}; "
+        f"tools: {result.tool_names}"
     )

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -196,6 +196,40 @@ def test_every_eval_file_has_negative_cases():
     )
 
 
+def test_every_served_skill_is_evaluated_or_exempt():
+    # Validates: every served skill has machine-checkable eval coverage or an
+    # explicit, reviewable reason why action-tool routing does not apply
+    missing: list[str] = []
+    invalid_reasons: list[str] = []
+    for skill_md in sorted(SERVED_SKILLS_DIR.glob("*/SKILL.md")):
+        if (skill_md.parent / "eval.md").is_file():
+            continue
+        fm, _ = _parse_skill_md(skill_md)
+        reason = fm.get("eval-exempt")
+        if reason is None:
+            missing.append(skill_md.parent.name)
+        elif not isinstance(reason, str) or not reason.strip():
+            invalid_reasons.append(skill_md.parent.name)
+
+    assert not missing, f"served skills missing eval.md or eval-exempt: {missing}"
+    assert not invalid_reasons, (
+        "served skills with empty/non-string eval-exempt reasons: "
+        f"{invalid_reasons}"
+    )
+
+
+def test_every_eval_file_has_positive_cases():
+    # Validates: an empty or negative-only eval.md cannot satisfy served-skill
+    # coverage without contributing an asserted action-tool routing case
+    parsed = parse_eval_files()
+    skills_with_pos = {c["skill"] for c in parsed["cases"]}
+    eval_files = {p.parent.name for p in SERVED_SKILLS_DIR.rglob("eval.md")}
+    missing = eval_files - skills_with_pos
+    assert not missing, (
+        f"eval.md files with no machine-checkable positive cases: {sorted(missing)}"
+    )
+
+
 # ---- cross-surface consistency (C1/C2) --------------------------------------
 
 


### PR DESCRIPTION
## Summary
- require every served skill to provide machine-checkable routing cases or an explicit `eval-exempt` reason
- add positive and negative eval coverage for newly served action skills, plus guide-routing checks for `get_skill`
- document the eval fixture grammar, validation commands, and runtime-serving boundary

## Testing
- `pytest tests/test_skill_docs.py -k eval -v` (4 passed)
- `pytest tests/llm/test_03_eval_cases.py --collect-only -q` (100 tests collected)
- `pytest tests/llm/test_03_eval_cases.py -q` (100 skipped as expected with live LLM tests disabled)