### PR TITLE
Expose log_path and a crash-aware log_tail on measure failures

### DIFF
--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -57,6 +57,21 @@ returns, not a hardcoded one.
 apply_measure(measure_dir="/measures/<user>/custom/set_lights_8w")
 ```
 
+### When test_measure / apply_measure fail
+Both return `log_path` (the full log on disk), a `log_tail` excerpt, `exit_code`,
+and `crash_marker`. The excerpt is a window, not the whole story: read the full log
+before guessing.
+```
+read_file(file_path="<log_path from the failure response>")
+```
+- `crash_marker` set (e.g. `[BUG] Segmentation fault`, error mentions SIGABRT/SIGSEGV):
+  the Ruby/Python process died in native SDK code, not in a raised exception. The
+  excerpt shows the `-- Ruby level backtrace` with the `measure.rb` line. Almost
+  always a use-after-delete: `component.remove()` followed by `addToNode` on a node
+  that `remove()` deleted. Insert the replacement first, then remove the old one.
+- `crash_marker` null: an ordinary Ruby/Python error; the message and backtrace are in
+  `log_tail` / `test_output`.
+
 ### 4. Verify Results (Before/After Comparison)
 For rigorous validation, run a baseline simulation BEFORE applying the measure:
 ```

--- a/.claude/skills/troubleshoot/SKILL.md
+++ b/.claude/skills/troubleshoot/SKILL.md
@@ -60,6 +60,20 @@ query_timeseries(run_id=..., variable_name="Zone Mean Air Temperature",
     frequency="Hourly", key_value="Zone 1")
 ```
 
+## Measure Test / Apply Failed
+
+`test_measure` and `apply_measure` failures return `log_path`, `log_tail`, `exit_code`,
+and `crash_marker`. `log_tail` is an excerpt; read the whole log first:
+```
+read_file(file_path="<log_path from the failure response>")
+```
+
+| Signal | Cause | Fix |
+|---|---|---|
+| `crash_marker` = `[BUG] Segmentation fault`, error says SIGABRT/SIGSEGV | Native SDK crash inside the measure, usually `remove()` then `addToNode` on a node the removal deleted | Add the replacement component first, then remove the old one; re-run `test_measure` |
+| `crash_marker` null, backtrace names `measure.rb` / `measure.py` | Ordinary Ruby/Python error in `run_body` | Fix the line shown; see "Verify SDK Methods" for `NoMethodError` |
+| `Measure run timed out` | Measure loops or waits | Partial log at `log_path`; simplify the measure |
+
 ## Verify SDK Methods
 
 If a measure fails due to nonexistent API methods:

--- a/mcp_server/log_excerpt.py
+++ b/mcp_server/log_excerpt.py
@@ -1,0 +1,111 @@
+"""Crash-aware excerpts of subprocess logs (issue #150).
+
+When a measure run dies in native code (SDK segfault, e.g. ``remove()`` then
+``addToNode`` on a dead node), Ruby's crash handler prints a ``[BUG]`` report:
+marker line, control frames, the Ruby-level backtrace (with the measure.rb line
+number), loaded features, then a ``/proc/self/maps`` dump of several hundred
+lines. A plain "last 50 lines" tail shows only the memory map, so the agent
+never sees what crashed or where.
+
+Pure Python, no openstudio import — unit-tested in tests/test_log_excerpt.py.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcp_server.util import read_head_bounded, read_tail_bounded
+
+# Bound on how much of a failed run's log is read back for the excerpt (same
+# cap as gbxml_import). The full log stays on disk under log_path.
+LOG_TAIL_MAX_BYTES = 200_000
+
+# Native Ruby/Python crash signatures only. EnergyPlus ``**  Fatal  **`` is not
+# here on purpose: it never appears in measures-only runs and has its own parser.
+CRASH_MARKERS: tuple[str, ...] = (
+    "[BUG] ",              # Ruby crash handler, first line of the report
+    "Fatal Python error",  # CPython faulthandler
+    "Segmentation fault",
+    "SIGSEGV",
+    "SIGABRT",
+)
+
+
+def find_crash_marker(lines: list[str]) -> int | None:
+    """Index of the first line carrying any CRASH_MARKERS substring, else None."""
+    for i, line in enumerate(lines):
+        for marker in CRASH_MARKERS:
+            if marker in line:
+                return i
+    return None
+
+
+def excerpt_log(
+    text: str,
+    tail_lines: int = 50,
+    before: int = 5,
+    after: int = 40,
+) -> tuple[str, str | None]:
+    """Return ``(excerpt, crash_marker_line)`` for a log's text.
+
+    With a crash marker: the window ``[i-before, i+after]`` around the first
+    marker line (Ruby's control frames and Ruby-level backtrace, including the
+    measure.rb line, sit within ~25 lines after ``[BUG]``), followed by
+    ``... [N more lines]`` when the log continues past the window.
+
+    Without one: the last ``tail_lines`` lines, ``crash_marker_line`` None
+    (the pre-#150 behaviour).
+    """
+    if not text:
+        return "", None
+    lines = text.splitlines()
+    idx = find_crash_marker(lines)
+    if idx is None:
+        return "\n".join(lines[-tail_lines:]), None
+    start = max(0, idx - before)
+    end = min(len(lines), idx + after + 1)
+    window = lines[start:end]
+    remaining = len(lines) - end
+    if remaining > 0:
+        window.append(f"... [{remaining} more lines]")
+    return "\n".join(window), lines[idx]
+
+
+def excerpt_log_file(
+    path: Path,
+    max_bytes: int = LOG_TAIL_MAX_BYTES,
+    tail_lines: int = 50,
+) -> tuple[str, str | None, str]:
+    """Symlink-refusing, bounded excerpt of a log on disk.
+
+    Returns ``(excerpt, crash_marker_line, tail_text)``. ``tail_text`` is the
+    last ``max_bytes`` decoded (callers parse minitest/pytest summaries from
+    it). The crash scan runs on that tail first; if the tail was clipped and
+    carries no marker, the first ``max_bytes`` are scanned too, because Ruby's
+    ``[BUG]`` report puts the marker and backtrace at the top and the
+    memory-map dump — which can exceed the cap on its own — at the bottom.
+
+    Raises ``ValueError`` like the util readers (symlink, non-regular,
+    unreadable); callers turn that into a ``(log unreadable: …)`` excerpt.
+    """
+    tail_bytes = read_tail_bounded(path, max_bytes)
+    tail_text = tail_bytes.decode("utf-8", errors="replace")
+    excerpt, marker = excerpt_log(tail_text, tail_lines=tail_lines)
+    if marker is None and len(tail_bytes) >= max_bytes:
+        head_text = read_head_bounded(path, max_bytes).decode("utf-8", errors="replace")
+        head_excerpt, head_marker = excerpt_log(head_text, tail_lines=tail_lines)
+        if head_marker is not None:
+            return head_excerpt, head_marker, tail_text
+    return excerpt, marker, tail_text
+
+
+def describe_exit(returncode: int) -> str:
+    """Human-readable exit status for a failed subprocess.
+
+    Ruby's crash handler ends its ``[BUG]`` report with ``abort()`` (134, or -6
+    when the signal reaches Python directly); an unhandled segfault is 139/-11.
+    """
+    if returncode in (134, -6):
+        return "SIGABRT (native crash, see crash_marker)"
+    if returncode in (139, -11):
+        return "SIGSEGV (native crash, see crash_marker)"
+    return f"exit code {returncode}"

--- a/mcp_server/skills/measure_authoring/operations.py
+++ b/mcp_server/skills/measure_authoring/operations.py
@@ -22,6 +22,7 @@ from mcp_server.config import (
     user_custom_measures_dir,
     user_run_root,
 )
+from mcp_server.log_excerpt import describe_exit, excerpt_log_file
 from mcp_server.util import (
     create_run_dir,
     read_file_bounded,
@@ -1024,21 +1025,42 @@ def _test_reporting_measure_with_run(
     log_path = run_dir / "openstudio.log"
     run_env = sandbox.build_env(run_dir)
     sandbox.prepare_workdir(run_dir)
-    with log_path.open("w", encoding="utf-8") as log_f:
-        proc = subprocess.run(
-            sandbox.wrap_cmd(cmd, run_dir), cwd=str(run_dir),
-            stdout=log_f, stderr=subprocess.STDOUT,
-            env=run_env, timeout=120, check=False,
-        )
+    try:
+        with log_path.open("w", encoding="utf-8") as log_f:
+            proc = subprocess.run(
+                sandbox.wrap_cmd(cmd, run_dir), cwd=str(run_dir),
+                stdout=log_f, stderr=subprocess.STDOUT,
+                env=run_env, timeout=120, check=False,
+            )
+    except subprocess.TimeoutExpired:
+        # Caught here, not in test_measure_op: its run_dir/log_path are still
+        # None for this path, so the partial log would be lost (#150).
+        return {
+            "ok": False,
+            "error": "ReportingMeasure test timed out (120s)",
+            "run_dir": str(run_dir),
+            "log_path": str(log_path),
+            "log_hint": "Partial log: read_file(file_path=log_path)",
+        }
 
-    log_text = log_path.read_text(encoding="utf-8", errors="replace")
-    display = log_text[-2000:] if len(log_text) > 2000 else log_text
+    # Symlink-refusing read (PR #105): the log was written by the confined subprocess.
+    # #150: crash → window around the [BUG] line; otherwise the last 2000 chars.
+    try:
+        excerpt, crash_marker, log_text = excerpt_log_file(log_path)
+    except ValueError as e:
+        excerpt, crash_marker, log_text = "", None, f"(log unreadable: {e})"
+    display = excerpt if crash_marker is not None else log_text[-2000:]
 
     if proc.returncode != 0:
         return {
             "ok": False,
             "passed": 0, "failed": 1, "errors": 0,
-            "test_output": f"ReportingMeasure test failed (exit {proc.returncode}):\n{display}",
+            "test_output": f"ReportingMeasure test failed ({describe_exit(proc.returncode)}):\n{display}",
+            "exit_code": proc.returncode,
+            "crash_marker": crash_marker,
+            "log_path": str(log_path),
+            "run_dir": str(run_dir),
+            "log_hint": "Full log: read_file(file_path=log_path)",
         }
 
     from mcp_server.skills.measures.runner_messages import parse_runner_messages
@@ -1047,6 +1069,10 @@ def _test_reporting_measure_with_run(
         "ok": True,
         "passed": 1, "failed": 0, "errors": 0,
         "test_output": f"ReportingMeasure ran successfully via --postprocess_only:\n{display}",
+        "exit_code": 0,
+        "crash_marker": None,
+        "log_path": str(log_path),
+        "run_dir": str(run_dir),
     }
     # Surface the measure's registered messages (registerValue/Info/Final) —
     # the CLI log is often empty on success, which told the caller nothing
@@ -1085,6 +1111,8 @@ def test_measure_op(
     4. No test_model.osm → test template falls back to empty Model.new()
     """
     _private_copy: Path | None = None
+    run_dir: Path | None = None
+    log_path: Path | None = None
     try:
         mdir = Path(measure_dir)
         if not mdir.is_dir():
@@ -1155,21 +1183,34 @@ def test_measure_op(
         # pytest's capture uses an unlinked tempfile the bind mount can't keep open.
         # It's granted to Landlock as an extra writable root and HOME stays in mdir.
         tmp_dir = Path(tempfile.mkdtemp(prefix="osmcp_mtest_"))
+        # #150: the full test output goes to a retained log under the caller's run
+        # root (not the private copy, which is rmtree'd below) so read_file can
+        # fetch it after a failure. The parent owns the fd — no sandbox grant needed.
+        _test_run_id, run_dir = create_run_dir(user_run_root(), "measure_test", mdir.name)
+        log_path = run_dir / "test.log"
         try:
             env = sandbox.build_env(mdir)          # HOME=mdir (granted rw)
             env["TMPDIR"] = str(tmp_dir)           # off the bind mount, Landlock-granted below
             sandbox.prepare_workdir(mdir)
             sandbox.prepare_workdir(tmp_dir)
-            proc = subprocess.run(
-                sandbox.wrap_cmd(test_cmd, mdir, extra_rw=(str(tmp_dir),)),
-                cwd=str(mdir),
-                env=env,
-                capture_output=True, text=True, timeout=60, check=False,
-            )
+            with log_path.open("w", encoding="utf-8") as log_f:
+                proc = subprocess.run(
+                    sandbox.wrap_cmd(test_cmd, mdir, extra_rw=(str(tmp_dir),)),
+                    cwd=str(mdir),
+                    env=env,
+                    stdout=log_f, stderr=subprocess.STDOUT,
+                    timeout=60, check=False,
+                )
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
 
-        output = proc.stdout + proc.stderr
+        # Symlink-refusing, bounded read (PR #105). `output` is the tail (holds the
+        # minitest/pytest summary); `excerpt`/`crash_marker` come from a crash
+        # scan that also checks the head of an oversize log (#150).
+        try:
+            excerpt, crash_marker, output = excerpt_log_file(log_path)
+        except ValueError as e:
+            excerpt, crash_marker, output = "", None, f"(log unreadable: {e})"
         passed = failed = errors = 0
 
         if language == "Python":
@@ -1192,9 +1233,13 @@ def test_measure_op(
                 failed = int(m.group(2))
                 errors = int(m.group(3))
 
-        # Truncate for display but keep minitest summary if found
+        # Truncate for display but keep minitest summary if found. On a native
+        # crash (#150) the tail is Ruby's memory-map dump, so show the window
+        # around the [BUG] line (measure.rb backtrace) instead.
         display = output
-        if len(display) > 2000:
+        if crash_marker is not None:
+            display = excerpt
+        elif len(display) > 2000:
             # For Ruby, try to include the minitest summary line
             minitest_line = ""
             ml = re.search(r"^\d+ runs,.*$", output, re.MULTILINE)
@@ -1216,7 +1261,14 @@ def test_measure_op(
             "failed": failed,
             "errors": errors,
             "test_output": display,
+            "exit_code": proc.returncode,
+            "crash_marker": crash_marker,
+            "log_path": str(log_path),
+            "run_dir": str(run_dir),
         }
+        if proc.returncode != 0:
+            result["error"] = f"Measure test failed ({describe_exit(proc.returncode)})"
+            result["log_hint"] = "Full log: read_file(file_path=log_path)"
         try:
             _update_measure_xml(mdir, language)
         except RuntimeError as e:
@@ -1224,7 +1276,13 @@ def test_measure_op(
         return result
 
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "Test run timed out (60s)"}
+        result = {"ok": False, "error": "Test run timed out (60s)"}
+        if run_dir is not None:
+            result["run_dir"] = str(run_dir)
+        if log_path is not None:
+            result["log_path"] = str(log_path)
+            result["log_hint"] = "Partial log: read_file(file_path=log_path)"
+        return result
     except Exception as e:
         return {"ok": False, "error": f"Failed to test measure: {e}"}
     finally:

--- a/mcp_server/skills/measures/operations.py
+++ b/mcp_server/skills/measures/operations.py
@@ -34,6 +34,7 @@ from mcp_server.config import (
     user_measures_root,
     user_run_root,
 )
+from mcp_server.log_excerpt import describe_exit, excerpt_log_file
 from mcp_server.model_manager import get_model, load_model
 from mcp_server.skills.measures.osw_weather import resolve_osw_weather, stage_epw_into_run
 from mcp_server.skills.measures.runner_messages import parse_runner_messages
@@ -721,6 +722,8 @@ def apply_measure(
         arguments: Optional dict of argument_name -> value overrides
         run_id: Optional completed simulation run_id (for reporting measures)
     """
+    run_dir: Path | None = None
+    log_path: Path | None = None
     try:
         model = get_model()
         measure_path = Path(measure_dir)
@@ -874,14 +877,7 @@ def apply_measure(
             )
 
         if proc.returncode != 0:
-            # Read last 50 lines of log for error details
-            log_lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-            tail = "\n".join(log_lines[-50:])
-            return {
-                "ok": False,
-                "error": f"Measure run failed (exit code {proc.returncode})",
-                "log_tail": tail,
-            }
+            return _measure_failure(proc.returncode, run_dir, log_path)
 
         # Parse runner messages from out.osw
         runner_messages = parse_runner_messages(run_dir / "out.osw")
@@ -945,8 +941,43 @@ def apply_measure(
         return result
 
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "Measure run timed out (5 min)"}
+        # The partial log is on disk — point at it so the agent can see how far
+        # the measure got before the cap.
+        result: dict[str, Any] = {"ok": False, "error": "Measure run timed out (5 min)"}
+        if run_dir is not None:
+            result["run_dir"] = str(run_dir)
+        if log_path is not None:
+            result["log_path"] = str(log_path)
+            result["log_hint"] = "Partial log: read_file(file_path=log_path)"
+        return result
     except RuntimeError as e:
         return {"ok": False, "error": str(e)}
     except Exception as e:
         return {"ok": False, "error": f"Failed to apply measure: {e}"}
+
+
+def _measure_failure(returncode: int, run_dir: Path, log_path: Path) -> dict[str, Any]:
+    """Failure response for a non-zero `openstudio run` (issue #150).
+
+    Always carries `log_path` (readable via read_file — it lives under the
+    caller's run root) so the 50-line excerpt is never the only evidence. On a
+    native crash the excerpt is the window around the `[BUG]` line (measure.rb
+    backtrace) instead of the memory-map dump that ends Ruby's report, and
+    `crash_marker` / `exit_code` say so explicitly.
+    """
+    # log_tail goes back to the client verbatim — the log is written by the
+    # sandboxed subprocess, so the read must refuse a symlink swap (PR #105).
+    try:
+        tail, crash_marker, _full_tail = excerpt_log_file(log_path)
+    except ValueError as e:
+        tail, crash_marker = f"(log unreadable: {e})", None
+    return {
+        "ok": False,
+        "error": f"Measure run failed ({describe_exit(returncode)})",
+        "exit_code": returncode,
+        "crash_marker": crash_marker,
+        "log_tail": tail,
+        "log_path": str(log_path),
+        "run_dir": str(run_dir),
+        "log_hint": "Full log: read_file(file_path=log_path)",
+    }

--- a/mcp_server/util.py
+++ b/mcp_server/util.py
@@ -91,6 +91,18 @@ def read_tail_bounded(path: Path, max_bytes: int) -> bytes:
     Raises ``ValueError`` on a symlink, a non-regular file, or an unreadable
     path (same degradation notes as read_file_bounded on non-POSIX platforms).
     """
+    return _read_bounded(path, max_bytes, from_end=True)
+
+
+def read_head_bounded(path: Path, max_bytes: int) -> bytes:
+    """Read the FIRST ``max_bytes`` of a regular file with the same no-follow
+    guarantees as read_tail_bounded. Pairs with it when the interesting part
+    of an oversize log sits at the start (Ruby ``[BUG]`` reports put the
+    backtrace first and a memory-map dump last — issue #150)."""
+    return _read_bounded(path, max_bytes, from_end=False)
+
+
+def _read_bounded(path: Path, max_bytes: int, *, from_end: bool) -> bytes:
     flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
              | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_BINARY", 0))
     try:
@@ -101,7 +113,7 @@ def read_tail_bounded(path: Path, max_bytes: int) -> bytes:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             raise ValueError(f"not a regular file: {path}")
-        if st.st_size > max_bytes:
+        if from_end and st.st_size > max_bytes:
             os.lseek(fd, st.st_size - max_bytes, os.SEEK_SET)
         chunks: list[bytes] = []
         remaining = max_bytes

--- a/tests/test_log_excerpt.py
+++ b/tests/test_log_excerpt.py
@@ -1,0 +1,162 @@
+"""Unit tests for mcp_server/log_excerpt.py — crash-aware log windows (issue #150).
+
+Pure Python, no openstudio import.
+"""
+import os
+
+import pytest
+
+from mcp_server.log_excerpt import (
+    CRASH_MARKERS,
+    describe_exit,
+    excerpt_log,
+    excerpt_log_file,
+)
+from mcp_server.util import read_head_bounded
+
+pytestmark = pytest.mark.unit
+
+
+def _ruby_bug_report(map_lines: int = 250) -> str:
+    """Shape of a Ruby `[BUG]` report from `openstudio run --measures_only`:
+    marker, control frames, Ruby-level backtrace, loaded features, then a
+    `/proc/self/maps` dump that dwarfs everything else. Section offsets mirror the
+    real report (loaded features past line 40, map past line 50)."""
+    lines = ["[BUG] Segmentation fault at 0x0000000000000000",
+             "ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]",
+             "", "-- Control frame information "
+                 "-----------------------------------------------"]
+    lines += [f"c:{i:04d} p:---- s:{i:04d} e:000000 CFUNC  :addToNode" for i in range(12)]
+    lines += ["", "-- Ruby level backtrace information "
+                  "----------------------------------------",
+              "/runs/x/measures/replace_coil/measure.rb:42:in `addToNode'",
+              "/runs/x/measures/replace_coil/measure.rb:42:in `run'",
+              "", "-- C level backtrace information "
+                  "-------------------------------------------",
+              *[f"/lib/libc.so.6(0x{i:02x}) [0x{i:02x}]" for i in range(25)],
+              "", "* Loaded features:", "", "    0 enumerator.so", "    1 thread.rb",
+              "", "* Process memory map:", ""]
+    lines += [f"{i:012x}-{i + 1:012x} r--p 00000000 08:01 {i}  /opt/lib/libruby.so"
+              for i in range(map_lines)]
+    return "\n".join(lines)
+
+
+def test_bug_marker_window_replaces_memory_map_tail():
+    # Regression: #150 — a native crash log ended with 50 lines of memory map, hiding the
+    # [BUG] line and the measure.rb backtrace the agent needs to fix the measure
+    text = _ruby_bug_report()
+    excerpt, marker = excerpt_log(text, tail_lines=50, before=5, after=40)
+    assert marker == "[BUG] Segmentation fault at 0x0000000000000000"
+    lines = excerpt.splitlines()
+    assert lines[0] == marker, "marker sits at the top when nothing precedes it"
+    assert "-- Ruby level backtrace information" in excerpt
+    assert "/runs/x/measures/replace_coil/measure.rb:42:in `run'" in excerpt
+    assert "libruby.so" not in excerpt, "memory-map dump must not be in the excerpt"
+    assert lines[-1] == "... [264 more lines]", lines[-1]
+    assert len(lines) == 42, "marker + 40 after + trailer"
+
+
+def test_plain_log_returns_last_tail_lines_without_marker():
+    # Validates: no crash marker → unchanged behaviour, exactly the last tail_lines lines
+    text = "\n".join(f"line {i}" for i in range(80))
+    excerpt, marker = excerpt_log(text, tail_lines=50)
+    assert marker is None
+    lines = excerpt.splitlines()
+    assert len(lines) == 50
+    assert lines[0] == "line 30"
+    assert lines[-1] == "line 79"
+
+
+def test_marker_inside_tail_window_is_not_duplicated():
+    # Validates: marker near the end → window is clipped to the file, no trailer, no
+    # doubled lines
+    text = "\n".join([f"pre {i}" for i in range(10)] + ["Fatal Python error: Segmentation fault",
+                                                        "post 0", "post 1"])
+    excerpt, marker = excerpt_log(text, tail_lines=50, before=5, after=40)
+    assert marker == "Fatal Python error: Segmentation fault"
+    lines = excerpt.splitlines()
+    assert lines == ["pre 5", "pre 6", "pre 7", "pre 8", "pre 9", marker, "post 0", "post 1"]
+
+
+def test_empty_text_returns_empty_excerpt():
+    # Validates: an empty/unwritten log degrades to ("", None) rather than raising
+    assert excerpt_log("") == ("", None)
+
+
+def test_first_marker_wins():
+    # Validates: the earliest marker line anchors the window (Ruby prints [BUG] first, then
+    # "Segmentation fault" again in later sections)
+    text = "\n".join(["ok"] * 3 + ["[BUG] Segmentation fault at 0x1"] + ["x"] * 60
+                     + ["Segmentation fault (core dumped)"])
+    _excerpt, marker = excerpt_log(text)
+    assert marker == "[BUG] Segmentation fault at 0x1"
+
+
+def test_marker_list_covers_ruby_and_python_crashes():
+    # Validates: the roster is the contract the skill docs describe (native Ruby/Python
+    # crashes only — no EnergyPlus fatals, which never occur in measures-only runs)
+    assert CRASH_MARKERS == ("[BUG] ", "Fatal Python error", "Segmentation fault",
+                             "SIGSEGV", "SIGABRT")
+
+
+@pytest.mark.parametrize(("code", "expected"), [
+    (134, "SIGABRT (native crash, see crash_marker)"),
+    (-6, "SIGABRT (native crash, see crash_marker)"),
+    (139, "SIGSEGV (native crash, see crash_marker)"),
+    (-11, "SIGSEGV (native crash, see crash_marker)"),
+    (1, "exit code 1"),
+])
+def test_describe_exit(code, expected):
+    # Validates: Ruby's crash handler aborts (134/-6) and a raw segfault (139/-11) are
+    # named for the agent; ordinary failures keep the plain exit code
+    assert describe_exit(code) == expected
+
+
+def test_excerpt_log_file_finds_marker_at_head_of_oversize_log(tmp_path):
+    # Regression: #150 review — Ruby's memory-map dump can exceed the tail cap on its own;
+    # a tail-only scan then drops the [BUG] line at the top and falls back to the map
+    body = _ruby_bug_report(map_lines=20_000)  # ~1.4 MB of map lines after the report
+    path = tmp_path / "openstudio.log"
+    path.write_bytes(body.encode("utf-8"))
+    assert path.stat().st_size > 200_000
+    excerpt, marker, tail = excerpt_log_file(path, max_bytes=200_000)
+    assert marker == "[BUG] Segmentation fault at 0x0000000000000000"
+    assert "/runs/x/measures/replace_coil/measure.rb:42:in `run'" in excerpt
+    assert "libruby.so" not in excerpt
+    assert len(tail.encode("utf-8")) == 200_000, "tail is still the bounded last chunk"
+    assert tail.endswith("/opt/lib/libruby.so")
+
+
+def test_excerpt_log_file_small_log_reads_tail_only(tmp_path):
+    # Validates: a log under the cap is scanned once, no head re-read, plain tail when
+    # there is no marker
+    path = tmp_path / "test.log"
+    path.write_bytes("\n".join(f"line {i}" for i in range(80)).encode("utf-8"))
+    excerpt, marker, tail = excerpt_log_file(path, max_bytes=200_000, tail_lines=50)
+    assert marker is None
+    assert excerpt.splitlines()[0] == "line 30"
+    assert tail.startswith("line 0\n")
+
+
+def test_excerpt_log_file_refuses_symlink(tmp_path):
+    # Validates: the sandboxed subprocess could swap the log for a symlink; the reader
+    # must refuse it rather than leak the target (same guarantee as read_tail_bounded)
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("O_NOFOLLOW unavailable (Windows): no-follow is POSIX-only, CI covers it")
+    target = tmp_path / "secret"
+    target.write_text("[BUG] not yours", encoding="utf-8")
+    link = tmp_path / "openstudio.log"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable on this platform/user")
+    with pytest.raises(ValueError, match="symlink or unreadable"):
+        excerpt_log_file(link)
+
+
+def test_read_head_bounded_returns_first_bytes(tmp_path):
+    # Validates: head reader caps at max_bytes from offset 0 and returns a short file whole
+    path = tmp_path / "log"
+    path.write_bytes(b"0123456789" * 10)
+    assert read_head_bounded(path, 25) == b"0123456789012345678901234"
+    assert read_head_bounded(path, 1_000) == b"0123456789" * 10

--- a/tests/test_measure_authoring.py
+++ b/tests/test_measure_authoring.py
@@ -358,8 +358,128 @@ def test_test_measure_reports_errors():
                 res = unwrap(await s.call_tool("test_measure", {
                     "measure_dir": create["measure_dir"],
                 }))
-                # Should report failures or errors
-                assert res["ok"] is False or res.get("failed", 0) > 0 or res.get("errors", 0) > 0
+                assert res["ok"] is False, res
+                assert res["failed"] + res["errors"] >= 1, res
+                # #150: the full test log must be on disk and readable through read_file
+                assert res["log_path"].endswith("test.log"), res["log_path"]
+                assert res["log_path"].startswith(res["run_dir"]), res
+                assert res["crash_marker"] is None, "a Ruby exception is not a native crash"
+                full = unwrap(await s.call_tool("read_file", {"file_path": res["log_path"]}))
+                assert full["ok"] is True, full
+                assert "intentional failure" in full["text"]
+                assert "intentional failure" in res["test_output"]
+    asyncio.run(_run())
+
+
+# Ruby body that kills the interpreter the way an SDK segfault does (issue #149
+# remove-then-addToNode): Ruby's crash handler prints a `[BUG]` report whose tail
+# is a memory map, then aborts (SIGABRT). Deterministic, no UB dependence.
+SEGV_BODY = '    Process.kill("SEGV", Process.pid)'
+
+
+@pytest.mark.integration
+def test_apply_measure_failure_exposes_log_path():
+    # Regression: #150 — apply_measure failures returned only a 50-line log_tail with no
+    # path, so the agent could not read the full openstudio.log via read_file
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique("apply_fail"))
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": _unique("apply_fail"),
+                    "description": "Failing measure",
+                    "run_body": '    raise "intentional failure"',
+                    "language": "Ruby",
+                }))
+                assert create["ok"] is True, create
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": create["measure_dir"],
+                }))
+                assert res["ok"] is False, res
+                assert res["exit_code"] == 1, res
+                assert res["error"] == "Measure run failed (exit code 1)"
+                assert res["crash_marker"] is None
+                assert res["log_path"].endswith("openstudio.log"), res["log_path"]
+                assert res["log_path"].startswith(res["run_dir"]), res
+                assert "intentional failure" in res["log_tail"]
+                assert res["log_hint"] == "Full log: read_file(file_path=log_path)"
+                full = unwrap(await s.call_tool("read_file", {"file_path": res["log_path"]}))
+                assert full["ok"] is True, full
+                assert "intentional failure" in full["text"]
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_apply_measure_native_crash_tail_shows_bug_marker():
+    # Regression: #150 — on a Ruby segfault the last 50 log lines are the process memory
+    # map, hiding the [BUG] line and the measure.rb backtrace
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique("apply_segv"))
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": _unique("apply_segv"),
+                    "description": "Crashing measure",
+                    "run_body": SEGV_BODY,
+                    "language": "Ruby",
+                }))
+                assert create["ok"] is True, create
+                res = unwrap(await s.call_tool("apply_measure", {
+                    "measure_dir": create["measure_dir"],
+                }))
+                assert res["ok"] is False, res
+                assert res["exit_code"] == -6, "SIGABRT reaches the server directly under sandbox.wrap_cmd"
+                assert res["error"] == "Measure run failed (SIGABRT (native crash, see crash_marker))"
+                assert "[BUG] Segmentation fault" in res["crash_marker"], res["crash_marker"]
+                assert "measure.rb:" in res["crash_marker"], "Ruby prefixes the marker with file:line"
+                assert "[BUG] Segmentation fault" in res["log_tail"]
+                assert "-- Ruby level backtrace information" in res["log_tail"]
+                assert "measure.rb" in res["log_tail"], "backtrace must point at the measure line"
+                assert "Process memory map" not in res["log_tail"]
+                assert res["log_path"].endswith("openstudio.log")
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_test_measure_native_crash_tail_shows_bug_marker():
+    # Regression: #150 — test_measure kept only the last 1500 chars of output, which on a
+    # segfault is the memory map; the [BUG] line and backtrace were lost and no log existed
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": _unique("test_segv"),
+                    "description": "Crashing measure",
+                    "run_body": SEGV_BODY,
+                    "language": "Ruby",
+                }))
+                assert create["ok"] is True, create
+                res = unwrap(await s.call_tool("test_measure", {
+                    "measure_dir": create["measure_dir"],
+                }))
+                assert res["ok"] is False, res
+                assert res["exit_code"] == -6, "SIGABRT reaches the server directly under sandbox.wrap_cmd"
+                assert "[BUG] Segmentation fault" in res["crash_marker"], res["crash_marker"]
+                assert "measure.rb:" in res["crash_marker"], "Ruby prefixes the marker with file:line"
+                assert "[BUG] Segmentation fault" in res["test_output"]
+                assert "measure.rb" in res["test_output"]
+                assert "Process memory map" not in res["test_output"]
+                assert res["log_path"].endswith("test.log")
+                full = unwrap(await s.call_tool("read_file", {"file_path": res["log_path"]}))
+                assert full["ok"] is True, full
+                assert "[BUG] Segmentation fault" in full["text"]
     asyncio.run(_run())
 
 


### PR DESCRIPTION
Fixes #150.

## Correction to the issue
The quoted snippet is `apply_measure` (measures/operations.py), not `test_measure`. `test_measure` had a worse variant: no log file at all (`capture_output`), only the last 1500 chars returned, and the private copy deleted afterward. Both are fixed, plus the reporting-measure test path.

## What changed
- New `mcp_server/log_excerpt.py`: `excerpt_log` (window around the first crash marker, else last 50 lines), `excerpt_log_file` (no-follow bounded read; scans the head too when the tail was clipped without a marker, since Ruby's memory-map dump can exceed the 200 KB cap by itself), `describe_exit` (134/-6 → SIGABRT, 139/-11 → SIGSEGV).
- `apply_measure`, `test_measure`, reporting-measure test: failures return `log_path`, `run_dir`, `exit_code`, `crash_marker`, `log_hint` alongside `log_tail`/`test_output`. Timeouts return the partial log's path.
- `test_measure` writes `run_dir/test.log` under the caller's run root on every call (uniform shape; retention-managed).
- `util.read_head_bounded` added, sharing `read_tail_bounded`'s open/fstat guard.
- Skills: measure-authoring gains a "when test/apply fail" section; troubleshoot gains a "Measure Test / Apply Failed" table.

## Verified
Red-green in Docker: the four new integration tests fail with `KeyError` on develop and pass here. Native crash fixture is `Process.kill("SEGV", Process.pid)` in `run_body`, which produces the same `[BUG]` report shape as the real remove-then-addToNode segfault (#149) without depending on undefined behaviour. Observed exit code under the sandbox wrapper is -6 (signal reaches the server directly), pinned in the tests.

Tests: `tests/test_log_excerpt.py` (unit, 14 + 1 Windows-skip), `tests/test_measure_authoring.py` (+3 tests, 1 tightened; already in amd64 shard 3 / arm64 shard 2, no ci.yml change). Codex review: 2 findings (head-scan for oversize logs, reporting-path timeout), both fixed.

## Out of scope
Same smell, separate follow-up: `python_ems/actuators.py` returns `log_tail` without a path; `simulation/operations.py::_tail_text` is not symlink-hardened.
