### PR TITLE
Return vertex coordinates from surface and subsurface tools

### DIFF
--- a/docs/examples/08_geometry_creation.md
+++ b/docs/examples/08_geometry_creation.md
@@ -61,6 +61,8 @@ An engineer wants to model a two-zone office from scratch: a west and east zone,
 
 **`create_surface`** is for advanced cases: non-rectangular surfaces, skylights, or explicit control over boundary conditions.
 
+**Reading geometry back.** `get_surface_details`, `list_surfaces(detailed=True)` and `list_subsurfaces(detailed=True)` return `vertices` as `[[x, y, z], ...]` metres in the parent space's local frame — the same frame `create_surface` / `create_subsurface` accept, so a wall's vertices can be edited and fed straight back in. For building coordinates apply the space transformation (origin and `direction_of_relative_north_deg` from `get_space_details`); adding the origin alone is only right for unrotated spaces.
+
 ## Integration Test
 
 See `tests/test_example_workflows.py::test_workflow_geometry_from_scratch`

--- a/mcp_server/skills/geometry/operations.py
+++ b/mcp_server/skills/geometry/operations.py
@@ -7,6 +7,7 @@ FloorspaceJS import uses the SDK-native FloorspaceReverseTranslator.
 """
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -20,13 +21,27 @@ from mcp_server.osm_helpers import (
     fetch_object,
     list_paginated,
     optional_name,
+    parse_str_list,
 )
+
+
+def _vertices_to_list(vertices) -> list[list[float]]:
+    """Point3dVector → [[x, y, z], ...] in metres, space-local frame (#147).
+
+    Rounded to 1e-6 m (sub-micron, keeps the payload small); values feed
+    _to_point3d_vector back without a transform, since Surface(poly, model) +
+    setSpace() stores the same frame vertices() reads. Coordinates with more
+    than 6 decimals round-trip to within 1e-6 m, not bit-exactly.
+    """
+    return [[round(p.x(), 6), round(p.y(), 6), round(p.z(), 6)] for p in vertices]
 
 
 def _extract_surface(model, surface, detailed: bool = True) -> dict[str, Any]:
     """Extract surface attributes to dict.
 
     Brief: name, surface_type, gross_area, space, outside_boundary_condition.
+    Detailed adds `vertices` (space-local [[x,y,z],...]) — brief stays
+    vertex-free so default list responses stay inside the size budget.
     """
     result = {
         "name": surface.nameString(),
@@ -37,9 +52,9 @@ def _extract_surface(model, surface, detailed: bool = True) -> dict[str, Any]:
     }
     if not detailed:
         return result
+    vertices = surface.vertices()
     result.update({
         "handle": str(surface.handle()),
-        "outside_boundary_condition": surface.outsideBoundaryCondition(),
         "sun_exposure": surface.sunExposure(),
         "wind_exposure": surface.windExposure(),
         "construction": optional_name(surface.construction()),
@@ -47,18 +62,21 @@ def _extract_surface(model, surface, detailed: bool = True) -> dict[str, Any]:
         "net_area_m2": float(surface.netArea()),
         "azimuth_deg": float(surface.azimuth()) * 180.0 / 3.14159,
         "tilt_deg": float(surface.tilt()) * 180.0 / 3.14159,
-        "num_vertices": len(surface.vertices()),
+        "num_vertices": len(vertices),
+        "vertices": _vertices_to_list(vertices),
         "num_subsurfaces": len(surface.subSurfaces()),
     })
     return result
 
 
-def _extract_subsurface(model, subsurface) -> dict[str, Any]:
+def _extract_subsurface(model, subsurface, detailed: bool = False) -> dict[str, Any]:
     """Extract subsurface (window/door) attributes to dict.
 
     Fields mirror OpenStudio-Toolkit's get_subsurface_object_as_dict().
+    Detailed adds `vertices` (space-local [[x,y,z],...], #147).
     """
-    return {
+    vertices = subsurface.vertices()
+    result = {
         "handle": str(subsurface.handle()),
         "name": subsurface.nameString(),
         "subsurface_type": subsurface.subSurfaceType(),
@@ -66,8 +84,11 @@ def _extract_subsurface(model, subsurface) -> dict[str, Any]:
         "surface": optional_name(subsurface.surface()),
         "multiplier": float(subsurface.multiplier()),
         "gross_area_m2": float(subsurface.grossArea()),
-        "num_vertices": len(subsurface.vertices()),
+        "num_vertices": len(vertices),
     }
+    if detailed:
+        result["vertices"] = _vertices_to_list(vertices)
+    return result
 
 
 def list_surfaces(
@@ -133,6 +154,7 @@ def list_subsurfaces(
     space_name: str | None = None,
     subsurface_type: str | None = None,
     max_results: int = 10,
+    detailed: bool = False,
 ) -> dict[str, Any]:
     """List subsurfaces with server-side filtering and pagination.
 
@@ -140,6 +162,8 @@ def list_subsurfaces(
     - Windows on a surface: surface_name="Wall 1"
     - Windows in a space: space_name="Office 1"
     - All doors: subsurface_type="Door"
+
+    detailed=True adds `vertices` ([[x,y,z],...] metres, space-local frame).
     """
     try:
         model = get_model()
@@ -162,7 +186,7 @@ def list_subsurfaces(
 
         items, total = list_paginated(
             model, "getSubSurfaces", _extract_subsurface,
-            max_results=max_results, obj_filter_fn=filt,
+            detailed=detailed, max_results=max_results, obj_filter_fn=filt,
         )
         return build_list_response("subsurfaces", items, total, max_results)
     except RuntimeError as e:
@@ -172,6 +196,32 @@ def list_subsurfaces(
 
 
 # ---- Geometry creation ----
+
+
+def _parse_vertices(
+    value: list[list[float]] | str, param: str = "vertices",
+) -> tuple[list[list[float]] | None, str | None]:
+    """Coerce a vertex list that may arrive as a JSON string (CLAUDE.md rule 13).
+
+    Returns (vertices, None) or (None, error). Nested lists survive json.loads
+    intact, so the result feeds _to_point3d_vector unchanged.
+    """
+    try:
+        parsed = parse_str_list(value)
+    except json.JSONDecodeError as e:
+        return None, f"Invalid JSON for {param}: {e}"
+    if not isinstance(parsed, list):
+        return None, f"Invalid {param}: expected a list of [x, y, z] points, got {type(parsed).__name__}"
+    # Validate each point here so a bad entry names the parameter and the point
+    # instead of dying inside _to_point3d_vector with a generic "Failed to create".
+    for i, point in enumerate(parsed):
+        if not isinstance(point, (list, tuple)) or len(point) not in (2, 3):
+            return None, f"Invalid {param}: point {i} must be [x, y] or [x, y, z], got {point!r}"
+        try:
+            [float(c) for c in point]
+        except (TypeError, ValueError):
+            return None, f"Invalid {param}: point {i} must be numeric, got {point!r}"
+    return parsed, None
 
 
 def _to_point3d_vector(vertices: list[list[float]]) -> openstudio.Point3dVector:
@@ -195,7 +245,9 @@ def create_surface(
 
     Args:
         name: Surface name
-        vertices: [[x,y,z], ...] — at least 3 points
+        vertices: [[x,y,z], ...] — at least 3 points, space-local frame (the
+            frame get_surface_details / list_surfaces(detailed=True) return);
+            a JSON string of the same list is accepted
         space_name: Name of existing space to contain the surface
         surface_type: "Wall", "Floor", "RoofCeiling" — auto-detected from tilt if None
         outside_boundary_condition: "Outdoors", "Ground", "Surface" — default "Outdoors"
@@ -206,6 +258,9 @@ def create_surface(
         if space is None:
             return {"ok": False, "error": f"Space '{space_name}' not found"}
 
+        vertices, err = _parse_vertices(vertices)
+        if err:
+            return {"ok": False, "error": err}
         poly = _to_point3d_vector(vertices)
         surface = openstudio.model.Surface(poly, model)
         surface.setName(name)
@@ -232,7 +287,8 @@ def create_subsurface(
 
     Args:
         name: Subsurface name
-        vertices: [[x,y,z], ...] — at least 3 points, coplanar with parent
+        vertices: [[x,y,z], ...] — at least 3 points, coplanar with parent,
+            space-local frame; a JSON string of the same list is accepted
         parent_surface_name: Name of existing parent surface
         subsurface_type: "FixedWindow", "OperableWindow", "Door", "GlassDoor"
     """
@@ -242,13 +298,16 @@ def create_subsurface(
         if parent is None:
             return {"ok": False, "error": f"Surface '{parent_surface_name}' not found"}
 
+        vertices, err = _parse_vertices(vertices)
+        if err:
+            return {"ok": False, "error": err}
         poly = _to_point3d_vector(vertices)
         sub = openstudio.model.SubSurface(poly, model)
         sub.setName(name)
         sub.setSurface(parent)
         sub.setSubSurfaceType(subsurface_type)
 
-        return {"ok": True, "subsurface": _extract_subsurface(model, sub)}
+        return {"ok": True, "subsurface": _extract_subsurface(model, sub, detailed=True)}
     except RuntimeError as e:
         return {"ok": False, "error": str(e)}
     except Exception as e:
@@ -270,13 +329,17 @@ def create_space_from_floor_print(
 
     Args:
         name: Space name
-        floor_vertices: [[x,y], ...] or [[x,y,z], ...] — floor polygon
+        floor_vertices: [[x,y], ...] or [[x,y,z], ...] — floor polygon; a JSON
+            string of the same list is accepted
         floor_to_ceiling_height: Height in meters
         building_story_name: Optional existing building story to assign
         thermal_zone_name: Optional existing thermal zone to assign
     """
     try:
         model = get_model()
+        floor_vertices, err = _parse_vertices(floor_vertices, "floor_vertices")
+        if err:
+            return {"ok": False, "error": err}
         poly = _to_point3d_vector(floor_vertices)
 
         # fromFloorPrint requires outward normal pointing down (clockwise

--- a/mcp_server/skills/geometry/tools.py
+++ b/mcp_server/skills/geometry/tools.py
@@ -40,7 +40,12 @@ def register(mcp):
         - Surfaces in a space: space_name="Office 1"
 
         Args:
-            detailed: Return all fields (construction, orientation, vertices, subsurfaces)
+            detailed: Return all fields (construction, orientation, subsurface count) plus
+                vertices = [[x, y, z], ...] metres in the parent space's local frame — the
+                same frame create_surface accepts, so values feed straight back in. For
+                building coordinates apply the space transformation (origin and
+                direction_of_relative_north from get_space_details); adding the origin
+                alone is only right for unrotated spaces.
             space_name: Filter by parent space name
             surface_type: Filter by type — "Wall", "Floor", "RoofCeiling"
             boundary: Filter by outside boundary — "Outdoors", "Ground", "Surface"
@@ -55,6 +60,12 @@ def register(mcp):
     def get_surface_details_tool(surface_name: str):
         """Get surface details — vertices, area, tilt, azimuth, construction, adjacent surface.
 
+        vertices = [[x, y, z], ...] metres in the parent space's local frame — the same
+        frame create_surface / create_subsurface accept, so values feed straight back in.
+        For building coordinates apply the space transformation (origin and
+        direction_of_relative_north from get_space_details); adding the origin alone is
+        only right for unrotated spaces.
+
         Args:
             surface_name: Name of the surface to retrieve
         """
@@ -66,6 +77,7 @@ def register(mcp):
         space_name: str | None = None,
         subsurface_type: str | None = None,
         max_results: int = 10,
+        detailed: bool = False,
     ):
         """List subsurfaces — windows, doors, skylights, glass doors.
         Default 10 results; use filters to narrow.
@@ -80,15 +92,18 @@ def register(mcp):
             space_name: Filter by parent space (transitive: subsurface→surface→space)
             subsurface_type: Filter — "FixedWindow", "OperableWindow", "Door", "GlassDoor"
             max_results: Max items to return (default 10, 0=unlimited)
+            detailed: Add vertices = [[x, y, z], ...] metres in the parent space's local
+                frame (same frame create_subsurface accepts)
         """
         mr = None if max_results == 0 else max_results
         return list_subsurfaces(surface_name=surface_name, space_name=space_name,
-                               subsurface_type=subsurface_type, max_results=mr)
+                               subsurface_type=subsurface_type, max_results=mr,
+                               detailed=detailed)
 
     @mcp.tool(tags={"geometry"}, name="create_surface")
     def create_surface_tool(
         name: str,
-        vertices: list[list[float]],
+        vertices: list[list[float]] | str,
         space_name: str,
         surface_type: str | None = None,
         outside_boundary_condition: str | None = None,
@@ -97,7 +112,8 @@ def register(mcp):
 
         Args:
             name: Surface name
-            vertices: List of [x,y,z] vertex coordinates (at least 3)
+            vertices: List of [x,y,z] vertex coordinates (at least 3), metres in the
+                space's local frame; a JSON string of the list is accepted
             space_name: Name of existing space to contain the surface
             surface_type: "Wall", "Floor", or "RoofCeiling" (auto-detected from tilt if omitted)
             outside_boundary_condition: "Outdoors", "Ground", or "Surface" (default "Outdoors")
@@ -112,7 +128,7 @@ def register(mcp):
     @mcp.tool(tags={"geometry"}, name="create_subsurface")
     def create_subsurface_tool(
         name: str,
-        vertices: list[list[float]],
+        vertices: list[list[float]] | str,
         parent_surface_name: str,
         subsurface_type: str = "FixedWindow",
     ):
@@ -120,7 +136,8 @@ def register(mcp):
 
         Args:
             name: Subsurface name
-            vertices: List of [x,y,z] vertex coordinates (coplanar with parent)
+            vertices: List of [x,y,z] vertex coordinates (coplanar with parent), metres
+                in the space's local frame; a JSON string of the list is accepted
             parent_surface_name: Name of existing parent surface
             subsurface_type: "FixedWindow", "OperableWindow", "Door", or "GlassDoor"
 
@@ -134,7 +151,7 @@ def register(mcp):
     @mcp.tool(tags={"geometry"}, name="create_space_from_floor_print")
     def create_space_from_floor_print_tool(
         name: str,
-        floor_vertices: list[list[float]],
+        floor_vertices: list[list[float]] | str,
         floor_to_ceiling_height: float,
         building_story_name: str | None = None,
         thermal_zone_name: str | None = None,
@@ -146,7 +163,8 @@ def register(mcp):
 
         Args:
             name: Space name
-            floor_vertices: List of [x,y] or [x,y,z] floor polygon vertices
+            floor_vertices: List of [x,y] or [x,y,z] floor polygon vertices; a JSON
+                string of the list is accepted
             floor_to_ceiling_height: Extrusion height in meters
             building_story_name: Optional existing building story to assign
             thermal_zone_name: Optional existing thermal zone to assign

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import uuid
 
@@ -1807,4 +1808,261 @@ def test_set_window_to_wall_ratio_invalid_ratio():
                     "ratio": 1.5,
                 }))
                 assert res["ok"] is False
+    asyncio.run(_run())
+
+
+# ---- #147: vertex coordinates out, JSON-string vertices in ----
+
+WALL_VERTS = [[0, 0, 0], [10, 0, 0], [10, 0, 3], [0, 0, 3]]
+WINDOW_VERTS = [[2, 0, 1], [4, 0, 1], [4, 0, 2], [2, 0, 2]]
+
+
+def _assert_points(actual, expected):
+    assert len(actual) == len(expected), f"vertex count {len(actual)} != {len(expected)}"
+    for got, exp in zip(actual, expected):
+        assert got == pytest.approx(exp, abs=1e-6), f"vertex {got} != {exp}"
+
+
+@pytest.mark.integration
+def test_get_surface_details_returns_vertices():
+    # Regression: #147 — get_surface_details promised vertices in its docstring but returned
+    # only num_vertices, so an agent could not read geometry back out of the model
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                sp_name = _unique_name("sp")
+                await _setup_with_space(s, _unique_name(), sp_name)
+                created = unwrap(await s.call_tool("create_surface", {
+                    "name": "VertWall", "vertices": WALL_VERTS,
+                    "space_name": sp_name, "surface_type": "Wall",
+                }))
+                assert created["ok"] is True, created
+                _assert_points(created["surface"]["vertices"], WALL_VERTS)
+
+                res = unwrap(await s.call_tool("get_surface_details", {"surface_name": "VertWall"}))
+                assert res["ok"] is True, res
+                surf = res["surface"]
+                _assert_points(surf["vertices"], WALL_VERTS)
+                assert surf["num_vertices"] == 4 == len(surf["vertices"])
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_list_surfaces_brief_omits_vertices_detailed_includes():
+    # Validates: brief list_surfaces stays inside the 10k default response budget (no vertex
+    # arrays); detailed=True carries the coordinates
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                sp_name = _unique_name("sp")
+                await _setup_with_space(s, _unique_name(), sp_name)
+                unwrap(await s.call_tool("create_surface", {
+                    "name": "BriefWall", "vertices": WALL_VERTS,
+                    "space_name": sp_name, "surface_type": "Wall",
+                }))
+                brief = unwrap(await s.call_tool("list_surfaces", {"space_name": sp_name}))
+                assert brief["ok"] is True and brief["count"] == 1, brief
+                assert "vertices" not in brief["surfaces"][0]
+                assert "num_vertices" not in brief["surfaces"][0]
+
+                det = unwrap(await s.call_tool("list_surfaces", {"space_name": sp_name, "detailed": True}))
+                assert det["count"] == 1, det
+                _assert_points(det["surfaces"][0]["vertices"], WALL_VERTS)
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_list_subsurfaces_detailed_returns_vertices():
+    # Regression: #147 — no tool returned window/door coordinates; list_subsurfaces had no
+    # detailed switch at all
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                sp_name = _unique_name("sp")
+                await _setup_with_space(s, _unique_name(), sp_name)
+                unwrap(await s.call_tool("create_surface", {
+                    "name": "WinWall", "vertices": WALL_VERTS,
+                    "space_name": sp_name, "surface_type": "Wall",
+                }))
+                created = unwrap(await s.call_tool("create_subsurface", {
+                    "name": "Win1", "vertices": WINDOW_VERTS,
+                    "parent_surface_name": "WinWall", "subsurface_type": "FixedWindow",
+                }))
+                assert created["ok"] is True, created
+                _assert_points(created["subsurface"]["vertices"], WINDOW_VERTS)
+
+                brief = unwrap(await s.call_tool("list_subsurfaces", {"surface_name": "WinWall"}))
+                assert brief["count"] == 1, brief
+                assert "vertices" not in brief["subsurfaces"][0]
+                assert brief["subsurfaces"][0]["num_vertices"] == 4
+
+                det = unwrap(await s.call_tool("list_subsurfaces", {
+                    "surface_name": "WinWall", "detailed": True,
+                }))
+                assert det["count"] == 1, det
+                _assert_points(det["subsurfaces"][0]["vertices"], WINDOW_VERTS)
+                assert det["subsurfaces"][0]["gross_area_m2"] == pytest.approx(2.0, rel=1e-6)
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_surface_vertices_round_trip_into_create_surface():
+    # Validates: the issue's core ask — vertices read from one surface feed create_surface
+    # unchanged (same space-local frame) and reproduce area, azimuth and tilt exactly
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique_name())
+                walls = unwrap(await s.call_tool("list_surfaces", {
+                    "surface_type": "Wall", "boundary": "Outdoors",
+                    "detailed": True, "max_results": 1,
+                }))
+                assert walls["count"] == 1, walls
+                src = walls["surfaces"][0]
+                assert len(src["vertices"]) == src["num_vertices"] >= 3
+
+                clone = unwrap(await s.call_tool("create_surface", {
+                    "name": "RoundTripWall", "vertices": src["vertices"],
+                    "space_name": src["space"], "surface_type": "Wall",
+                }))
+                assert clone["ok"] is True, clone
+                dst = clone["surface"]
+                assert dst["gross_area_m2"] == pytest.approx(src["gross_area_m2"], rel=1e-6)
+                assert dst["azimuth_deg"] == pytest.approx(src["azimuth_deg"], rel=1e-6)
+                assert dst["tilt_deg"] == pytest.approx(src["tilt_deg"], rel=1e-6)
+                _assert_points(dst["vertices"], src["vertices"])
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("tool", ["create_surface", "create_subsurface", "create_space_from_floor_print"])
+def test_create_geometry_accepts_json_string_vertices(tool):
+    # Regression: rule 13 — MCP clients send list params as JSON strings; a string vertex
+    # list failed deep inside _to_point3d_vector with a generic "Failed to create ..." error
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                sp_name = _unique_name("sp")
+                await _setup_with_space(s, _unique_name(), sp_name)
+                if tool == "create_surface":
+                    res = unwrap(await s.call_tool(tool, {
+                        "name": "JsonWall", "vertices": json.dumps(WALL_VERTS),
+                        "space_name": sp_name, "surface_type": "Wall",
+                    }))
+                    assert res["ok"] is True, res
+                    _assert_points(res["surface"]["vertices"], WALL_VERTS)
+                elif tool == "create_subsurface":
+                    unwrap(await s.call_tool("create_surface", {
+                        "name": "JsonHost", "vertices": WALL_VERTS,
+                        "space_name": sp_name, "surface_type": "Wall",
+                    }))
+                    res = unwrap(await s.call_tool(tool, {
+                        "name": "JsonWin", "vertices": json.dumps(WINDOW_VERTS),
+                        "parent_surface_name": "JsonHost",
+                    }))
+                    assert res["ok"] is True, res
+                    _assert_points(res["subsurface"]["vertices"], WINDOW_VERTS)
+                else:
+                    res = unwrap(await s.call_tool(tool, {
+                        "name": "JsonSpace",
+                        "floor_vertices": json.dumps([[0, 0], [10, 0], [10, 10], [0, 10]]),
+                        "floor_to_ceiling_height": 3.0,
+                    }))
+                    assert res["ok"] is True, res
+                    assert res["num_surfaces"] == 6
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(("bad", "expected_error"), [
+    ("[[0,0", "Invalid JSON for vertices: "),
+    ("123", "Invalid vertices: expected a list of [x, y, z] points, got int"),
+    ('{"x": 1}', "Invalid vertices: expected a list of [x, y, z] points, got dict"),
+    ('[[0, "bad", 1], [1, 0, 0], [1, 1, 0]]', "Invalid vertices: point 0 must be numeric, got [0, 'bad', 1]"),
+    ("[[0], [1, 0, 0], [1, 1, 0]]", "Invalid vertices: point 0 must be [x, y] or [x, y, z], got [0]"),
+])
+def test_create_surface_rejects_bad_vertices(bad, expected_error):
+    # Validates: malformed JSON, a non-list JSON value, and malformed points each produce an
+    # error naming the parameter and the offending point, not a generic "Failed to create"
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                sp_name = _unique_name("sp")
+                await _setup_with_space(s, _unique_name(), sp_name)
+                res = unwrap(await s.call_tool("create_surface", {
+                    "name": "BadVerts", "vertices": bad, "space_name": sp_name,
+                }))
+                assert res["ok"] is False
+                assert res["error"].startswith(expected_error), res["error"]
+                surfs = unwrap(await s.call_tool("list_surfaces", {"space_name": sp_name}))
+                assert surfs["count"] == 0, "rejected input must not leave a surface behind"
+    asyncio.run(_run())
+
+
+FRAC_VERTS = [[0.1234567, 0.7654321, 0.0], [5.5555555, 0.7654321, 0.0],
+              [5.5555555, 0.7654321, 2.9999999], [0.1234567, 0.7654321, 2.9999999]]
+
+
+@pytest.mark.integration
+def test_surface_vertices_are_space_local_in_transformed_space():
+    # Validates: vertices come back in the space's local frame even when the space has an
+    # origin offset and rotation (example/gbXML models do), so the documented "feed straight
+    # back into create_surface" contract holds; fractional inputs round-trip within 1e-6 m
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                sp_name = _unique_name("sp")
+                await _setup_with_space(s, _unique_name(), sp_name)
+                for prop, val in (("setXOrigin", 10.0), ("setYOrigin", 20.0),
+                                  ("setDirectionofRelativeNorth", 90.0)):
+                    res = unwrap(await s.call_tool("set_object_property", {
+                        "object_type": "Space", "object_name": sp_name,
+                        "property_name": prop, "value": val,
+                    }))
+                    assert res["ok"] is True, res
+                space = unwrap(await s.call_tool("get_space_details", {"space_name": sp_name}))
+                assert space["space"]["x_origin_m"] == pytest.approx(10.0)
+                assert space["space"]["direction_of_relative_north_deg"] == pytest.approx(90.0)
+
+                created = unwrap(await s.call_tool("create_surface", {
+                    "name": "LocalWall", "vertices": FRAC_VERTS,
+                    "space_name": sp_name, "surface_type": "Wall",
+                }))
+                assert created["ok"] is True, created
+                res = unwrap(await s.call_tool("get_surface_details", {"surface_name": "LocalWall"}))
+                verts = res["surface"]["vertices"]
+                _assert_points(verts, FRAC_VERTS)
+                # Not translated by the origin: a building-frame answer would start at x≈10.
+                assert verts[0][0] == pytest.approx(0.1234567, abs=1e-6)
+                assert all(len(v) == 3 for v in verts)
+                assert res["surface"]["gross_area_m2"] == pytest.approx(
+                    (5.5555555 - 0.1234567) * 2.9999999, rel=1e-6)
     asyncio.run(_run())


### PR DESCRIPTION
Fixes #147.

## What changed
- `get_surface_details`, `list_surfaces(detailed=True)` and the new `list_subsurfaces(detailed=True)` return `vertices` as `[[x, y, z], ...]` metres in the parent space's local frame. That is the frame `create_surface` / `create_subsurface` accept, so values feed straight back in (round-trip test reproduces area, azimuth and tilt to 1e-6). `create_subsurface` echoes vertices too.
- Brief list responses stay vertex-free, so the default response budget in `tests/test_response_sizes.py` is unaffected (re-run, green).
- 6-decimal rounding (sub-micron) keeps the payload small.
- Dropped the duplicated `outside_boundary_condition` key in the detailed surface dict.
- Rule 13 fold-in: `vertices` / `floor_vertices` on `create_surface`, `create_subsurface`, `create_space_from_floor_print` accept a JSON string. Each point is validated up front, so malformed input reports the parameter and point index instead of a generic "Failed to create" error.
- Docstrings state the frame explicitly. Building coordinates need the full space transformation (origin plus direction of relative north), not just the origin. First-class `world_coordinates` option is tracked in #152.

## Verified
Red-green in Docker: the 8 new integration tests fail on develop (KeyError / generic error) and pass here. A transformed-space test (origin 10,20 and 90 degree rotation via `set_object_property`) pins that vertices stay space-local. Full run of `test_geometry.py`, `test_response_sizes.py`, `test_create_constructions.py`: 94 passed, 1 skipped, then the 17 vertex/JSON tests re-run green after review fixes.

Codex review: 5 findings (frame wording, rounding claim, point validation, transformed-space test, error-path coverage), all addressed.

No new tool, so no roster / router / eval changes. `tests/test_geometry.py` is already on amd64 shard 2.

## Out of scope
- #152: building-frame coordinates with a `coordinate_frame` field.
- `get_subsurface_details` tool; shading-surface listing.
