### PR TITLE
Add replace-in-place wiring recipe and surface the addToNode-after-remove hazard

### DIFF
--- a/.claude/skills/measure-authoring/SKILL.md
+++ b/.claude/skills/measure-authoring/SKILL.md
@@ -116,6 +116,19 @@ project convention:
     end
 ```
 
+Replace a supply-branch coil or fan in place (add first, THEN remove):
+```ruby
+    old_coil = model.getCoilCoolingDXSingleSpeedByName('Main Cooling Coil').get
+    inlet_node = old_coil.inletModelObject.get.to_Node.get
+    new_coil = OpenStudio::Model::CoilCoolingDXTwoSpeed.new(model)
+    raise 'addToNode failed' unless new_coil.addToNode(inlet_node)
+    old_name = old_coil.nameString
+    old_coil.remove
+    new_coil.setName(old_name)
+```
+
+WARNING: `remove()` deletes the component's outlet node. `addToNode` on a node handle captured before `remove()` segfaults the measure process (`[BUG] Segmentation fault`, exit 134, no Ruby exception). The terminal pattern above is safe only because `addBranchForZone` is keyed by zone, not node. `search_wiring_patterns("replace coil")` returns the full recipe.
+
 ### Zone Equipment
 ```ruby
     model.getThermalZones.each do |zone|
@@ -147,6 +160,7 @@ Python gotchas (different from Ruby):
 - `obj.name()` returns an OptionalString — use `str(obj.name())` or `obj.name().get()`, never bare `obj.name()`.
 - `runner.registerError("msg")` must be followed by `return False` (capital F; it does not halt).
 - Optionals: `opt = surface.construction()` then `if opt.is_initialized(): c = opt.get()`.
+- Dangling nodes crash Python too: `addToNode(node)` on a node captured before `component.remove()` segfaults the interpreter (exit 139, no exception), same as Ruby. Add the new component first, then remove.
 - Unit conversion: `openstudio.convert(val, "W/m^2", "Btu/hr*ft^2").get()` —
   full unit-string table: `get_skill_file(skill_name="measure-authoring", filename="unit-conversions.md")`.
 
@@ -169,6 +183,19 @@ Python gotchas (different from Ruby):
                 loop.removeBranchForZone(zone)
                 # create new terminal...
                 loop.addBranchForZone(zone, terminal.to_StraightComponent().get())
+```
+
+Replace a supply-branch coil or fan in place (add first, THEN remove):
+```python
+        old_coil = model.getCoilCoolingDXSingleSpeedByName("Main Cooling Coil").get()
+        inlet_node = old_coil.inletModelObject().get().to_Node().get()
+        new_coil = openstudio.model.CoilCoolingDXTwoSpeed(model)
+        if not new_coil.addToNode(inlet_node):
+            runner.registerError("addToNode failed")
+            return False
+        old_name = old_coil.nameString()
+        old_coil.remove()
+        new_coil.setName(old_name)
 ```
 
 ### Zone Equipment

--- a/.claude/skills/openstudio-patterns/SKILL.md
+++ b/.claude/skills/openstudio-patterns/SKILL.md
@@ -123,6 +123,7 @@ search_wiring_patterns("four pipe beam")     # get working connection code
 | Simulation fails, no results | Missing weather file or design days | `change_building_location` (sets EPW + DDY + climate zone) |
 | EUI = 0 or unreasonable | No loads, no HVAC, or no run period | Check `inspect_osm_summary` for missing objects |
 | `"Output directory is not allowed"` / `"... path not allowed"` | Path outside your allowed roots (over HTTP each user is scoped to `/runs/<user>/`) | Save with `save_osm_model(save_name=...)` and reuse the paths tools return; staged inputs are read-only |
+| `[BUG] Segmentation fault ... in addToNode`, measure process exits 134 (`crash_marker` set, no Ruby exception) | Node handle captured before `component.remove()`; `remove()` deletes the component's outlet node | `addToNode` the new component on the old one's inlet node first, then `remove()`; `search_wiring_patterns("replace coil")` |
 
 ## Save vs Simulate
 

--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Typed wrappers over ~79 bundled [common measures](https://github.com/NREL/openst
 | `get_skill` | Step-by-step instructions for a workflow |
 | `recommend_tools` | Recommend the relevant tool group for a task |
 | `search_api` | Look up OpenStudio SDK classes + methods (verify before calling) |
-| `search_wiring_patterns` | Ruby wiring recipes for HVAC (24 patterns) |
+| `search_wiring_patterns` | Ruby wiring recipes for HVAC, plus SDK crash hazards for remove/addToNode queries |
 | `get_server_status` | Server health check |
 | `get_versions` | OpenStudio, EnergyPlus, Ruby versions |
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# On bump: run `pytest -m sdk_probe tests/test_sdk_probes.py` in the new image (issue #149)
 ARG OPENSTUDIO_VERSION=3.11.0
 FROM nrel/openstudio:${OPENSTUDIO_VERSION}
 ARG OPENSTUDIO_VERSION

--- a/mcp_server/skills/api_reference/operations.py
+++ b/mcp_server/skills/api_reference/operations.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import re
 
+from .wiring_recipes import hazards_for_query
+
 
 def search_api_op(
     class_pattern: str,
@@ -103,7 +105,12 @@ def search_api_op(
             "other": other,
         })
 
-    return {"ok": True, "classes": results, "query": class_pattern}
+    out = {"ok": True, "classes": results, "query": class_pattern}
+    # #149: warn about addToNode-after-remove when the query mentions node/remove/etc.
+    hazards = hazards_for_query(f"{class_pattern} {method_pattern or ''}")
+    if hazards:
+        out["hazards"] = hazards
+    return out
 
 
 def search_wiring_patterns_op(
@@ -154,8 +161,13 @@ def search_wiring_patterns_op(
             "source": recipe.get("source", ""),
         })
 
-    return {
+    out = {
         "ok": True,
         "recipes": results,
         "available_recipes": sorted(RECIPES.keys()),
     }
+    # #149: only present when a query token hits a hazard trigger — shape unchanged otherwise
+    hazards = hazards_for_query(pattern)
+    if hazards:
+        out["hazards"] = hazards
+    return out

--- a/mcp_server/skills/api_reference/tools.py
+++ b/mcp_server/skills/api_reference/tools.py
@@ -56,18 +56,22 @@ def register(mcp):
         wire coils to plant loops, terminals to air loops, zone equipment to
         thermal zones, and setpoint managers to nodes.
 
-        24 recipes covering: four-pipe beam, cooled beam, VAV, PIU reheat,
+        Recipes cover: four-pipe beam, cooled beam, VAV, PIU reheat,
         fan coil, baseboard, PTAC, PTHP, WSHP, DOAS, VRF, unitary systems,
         plant loop heat pumps, absorption chillers, air loop construction,
-        hot water / chilled water / condenser plant loops.
+        hot water / chilled water / condenser plant loops, and replacing a
+        coil or fan in place on a supply branch.
 
         Use before authoring measures that create or modify HVAC systems.
+        Queries mentioning remove / replace / swap / node / addToNode also
+        return `hazards`: SDK sequences that crash the measure process.
 
         Examples:
           search_wiring_patterns("four pipe beam")
           search_wiring_patterns("boiler plant loop")
           search_wiring_patterns("DOAS")
           search_wiring_patterns("fan coil chilled water")
+          search_wiring_patterns("replace coil")
 
         Args:
             pattern: Component type or keyword (e.g. "four pipe beam",

--- a/mcp_server/skills/api_reference/wiring_recipes.py
+++ b/mcp_server/skills/api_reference/wiring_recipes.py
@@ -568,4 +568,91 @@ airloop.addBranchForZone(zone, atu)""",
                  "Water coils need plant loop demand connections.",
         "source": "airterminal_cooledbeam.rb",
     },
+
+    # ── In-place replacement (issue #149) ────────────────────────────────
+
+    "replace_supply_branch_component": {
+        "component_type": "AirLoopHVAC supply branch — swap a coil or fan in place (StraightComponent)",
+        "connections": [
+            "New component → old component's INLET node via addToNode() — BEFORE old.remove()",
+            "Old component → remove() AFTER the new one is attached (remove deletes the old outlet node)",
+            "Water coils → plant loop via addDemandBranchForComponent() before addToNode()",
+            "Name reuse → setName(old_name) after remove()",
+        ],
+        "ruby": """\
+old_coil = model.getCoilCoolingDXSingleSpeedByName('Main Cooling Coil').get
+inlet_node = old_coil.inletModelObject.get.to_Node.get
+new_coil = OpenStudio::Model::CoilCoolingDXTwoSpeed.new(model)
+# water coil? plant.addDemandBranchForComponent(new_coil) goes here, before addToNode
+raise 'addToNode failed' unless new_coil.addToNode(inlet_node)
+old_name = old_coil.nameString
+old_coil.remove
+new_coil.setName(old_name)""",
+        "notes": "ORDER MATTERS. remove() deletes the component's outlet node (its inlet node "
+                 "if it is last before supplyOutletNode) and any SetpointManager on it. A Node "
+                 "handle captured before remove() dangles; addToNode on it segfaults the "
+                 "embedded Ruby ([BUG] Segmentation fault ... in addToNode, SIGABRT = exit 134 "
+                 "in a shell / -6 from subprocess, no exception, no backtrace) and the Python "
+                 "bindings alike (SIGSEGV, exit 139 / -11). Always "
+                 "addToNode first, then remove. This order is safe whether the old component "
+                 "sits mid-branch or last before supplyOutletNode (the SDK splices the new "
+                 "component to the loop outlet and SetpointManagers there survive; verified "
+                 "both). Use to replace / swap / exchange / delete and re-add an existing coil "
+                 "or fan in place on an air loop or plant loop supply branch; for terminals use "
+                 "addBranchForZone (zone-keyed, remove-first is safe). "
+                 "Verified OpenStudio 3.11.0.",
+        "source": "verified in-repo 2026-09-06 (not from openstudio-resources)",
+    },
 }
+
+
+# ── Hazards ──────────────────────────────────────────────────────────────
+#
+# Surfaced by search_wiring_patterns AND search_api when a query hits a
+# trigger, so the agent meets the warning before writing the crashing code.
+# Kept here (not in operations.py) so PR #138's search_api rewrite does not
+# collide with it.
+#
+# `triggers` is a list of token sets; a hazard fires when ALL tokens of ANY set
+# appear in the query. Bare "node"/"remove"/"delete" do not fire on their own
+# ("setpoint manager node", "remove terminal for zone" are not this hazard);
+# they need a component-ish word alongside. "addtonode", "segfault" and
+# "crash" fire alone — those are the symptom words an agent searches after
+# the process died.
+
+_COMPONENT_WORDS = ("node", "component", "coil", "fan", "addtonode", "equipment")
+_ACTION_WORDS = ("remove", "delete", "replace", "swap", "exchange")
+
+HAZARDS: list[dict] = [
+    {
+        "id": "addToNode_after_remove",
+        "triggers": (
+            [frozenset({"addtonode"}), frozenset({"segfault"}), frozenset({"crash"})]
+            + [frozenset({a, c}) for a in _ACTION_WORDS for c in _COMPONENT_WORDS]
+        ),
+        "note": "Calling addToNode(node) on a Node handle captured before component.remove() "
+                "segfaults the process (Ruby: [BUG] Segmentation fault, exit 134; Python: "
+                "exit 139) — remove() deletes the component's outlet node. Attach the new "
+                "component to the OLD component's inlet node first, then remove() the old one.",
+        "recipe": "replace_supply_branch_component",
+    },
+]
+
+
+def hazards_for_query(text: str) -> list[dict]:
+    """Hazards whose trigger sets are satisfied by the query's tokens.
+
+    Tokens are [a-z0-9]+ runs, lower-cased, so "CoilCoolingDXSingleSpeed
+    addToNode" yields "addtonode" but a bare class name yields nothing. Each
+    hazard is returned at most once, in HAZARDS order.
+    """
+    import re
+
+    tokens = set(re.findall(r"[a-z0-9]+", (text or "").lower()))
+    if not tokens:
+        return []
+    return [
+        {"id": h["id"], "note": h["note"], "recipe": h["recipe"]}
+        for h in HAZARDS
+        if any(trigger <= tokens for trigger in h["triggers"])
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ markers = [
     "unit: pure Python tests, no Docker/OpenStudio needed",
     "integration: requires Docker + OpenStudio + MCP server",
     "llm: requires Claude CLI + MCP server",
+    "sdk_probe: manual SDK-behaviour probes, run by hand on an OPENSTUDIO_VERSION bump (never in CI)",
 ]
 
 [tool.mypy]

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -211,3 +211,19 @@ def test_search_api_via_mcp():
                 assert len(data["classes"]) == 1
 
     asyncio.run(_test())
+
+
+# ── #149: hazard surfacing ───────────────────────────────────────────────
+
+def test_search_api_surfaces_hazard_for_addToNode():
+    # Validates: search_api("...", method_pattern="addToNode") carries the addToNode-after-
+    # remove hazard so the agent learns the crash before writing the measure (#149)
+    search = _import_search_api_op()
+    result = search("CoilCoolingDXSingleSpeed", method_pattern="addToNode")
+    assert result["ok"]
+    assert result["hazards"][0]["id"] == "addToNode_after_remove"
+    assert result["hazards"][0]["recipe"] == "replace_supply_branch_component"
+
+    plain = search("CoilCoolingDXSingleSpeed")
+    assert plain["ok"]
+    assert "hazards" not in plain, "no trigger word → response shape unchanged"

--- a/tests/test_measure_authoring.py
+++ b/tests/test_measure_authoring.py
@@ -1379,3 +1379,102 @@ def test_uppercase_arg_name_rejected():
                 assert res["ok"] is False, f"uppercase arg name must be rejected: {res}"
                 assert "argument name" in res.get("error", "").lower(), res
     asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_replace_recipe_ruby_runs_via_apply_measure():
+    # Validates: #149 — the replace_supply_branch_component recipe is executable Ruby, not
+    # prose: it swaps a baseline DX single-speed coil for a two-speed one in place, keeps the
+    # supply-branch length, reuses the old name, and does not crash the measure process
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+    from mcp_server.skills.api_reference.wiring_recipes import RECIPES
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique("recipe149"))
+                zones = unwrap(await s.call_tool("list_thermal_zones", {"max_results": 1}))
+                zone = zones["thermal_zones"][0]["name"]
+                sys3 = unwrap(await s.call_tool("add_baseline_system", {
+                    "system_type": 3, "thermal_zone_names": [zone], "system_name": "PSZ Test",
+                }))
+                assert sys3["ok"] is True, sys3
+                before = unwrap(await s.call_tool("get_air_loop_details", {"air_loop_name": "PSZ Test"}))
+                assert before["ok"] is True, before
+                clg_before = before["air_loop"]["detailed_components"]["cooling_coils"]
+                assert [c["type"] for c in clg_before] == ["OS_Coil_Cooling_DX_SingleSpeed"], clg_before
+                n_supply_before = before["air_loop"]["num_supply_components"]
+
+                # Recipe verbatim; only the coil-name placeholder substituted
+                body = RECIPES["replace_supply_branch_component"]["ruby"]
+                body = body.replace("'Main Cooling Coil'", "'PSZ Test DX Cooling Coil'")
+                run_body = "\n".join("    " + line for line in body.splitlines())
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": _unique("swap_coil"),
+                    "description": "Swap DX coil in place (recipe #149)",
+                    "run_body": run_body, "language": "Ruby",
+                }))
+                assert create["ok"] is True, create
+                applied = unwrap(await s.call_tool("apply_measure", {"measure_dir": create["measure_dir"]}))
+                assert applied["ok"] is True, applied.get("log_tail") or applied
+
+                after = unwrap(await s.call_tool("get_air_loop_details", {"air_loop_name": "PSZ Test"}))
+                clg_after = after["air_loop"]["detailed_components"]["cooling_coils"]
+                assert [c["type"] for c in clg_after] == ["OS_Coil_Cooling_DX_TwoSpeed"], clg_after
+                assert clg_after[0]["name"] == "PSZ Test DX Cooling Coil", "old name must be reused"
+                assert after["air_loop"]["num_supply_components"] == n_supply_before, \
+                    "in-place swap must not add or drop nodes on the supply branch"
+    asyncio.run(_run())
+
+
+@pytest.mark.integration
+def test_replace_recipe_handles_last_component_via_apply_measure():
+    # Validates: #149 review edge case — when the old component is LAST before
+    # supplyOutletNode, remove() deletes its INLET node (the new component's outlet). The
+    # recipe's add-first order must still splice the new coil to the loop outlet, keep the
+    # outlet-node setpoint manager and the branch's node count, and not crash the process
+    if not integration_enabled():
+        pytest.skip("integration disabled")
+    from mcp_server.skills.api_reference.wiring_recipes import RECIPES
+
+    build = "\n".join([
+        "    loop = OpenStudio::Model::AirLoopHVAC.new(model); loop.setName('Edge Loop')",
+        "    s = model.alwaysOnDiscreteSchedule",
+        "    fan = OpenStudio::Model::FanConstantVolume.new(model, s); fan.setName('Edge Fan')",
+        "    htg = OpenStudio::Model::CoilHeatingElectric.new(model, s); htg.setName('Edge Htg')",
+        "    clg = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model); clg.setName('Main Cooling Coil')",
+        "    [fan, htg, clg].each { |c| c.addToNode(loop.supplyOutletNode) }  # coil ends up LAST",
+        "    sch = OpenStudio::Model::ScheduleConstant.new(model); sch.setValue(12.8)",
+        "    OpenStudio::Model::SetpointManagerScheduled.new(model, sch).addToNode(loop.supplyOutletNode)",
+    ])
+    recipe = RECIPES["replace_supply_branch_component"]["ruby"]
+    run_body = build + "\n" + "\n".join("    " + line for line in recipe.splitlines())
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await setup_example(s, _unique("recipe149last"))
+                create = unwrap(await s.call_tool("create_measure", {
+                    "name": _unique("swap_last"),
+                    "description": "Swap the last supply component in place (recipe #149)",
+                    "run_body": run_body, "language": "Ruby",
+                }))
+                assert create["ok"] is True, create
+                applied = unwrap(await s.call_tool("apply_measure", {"measure_dir": create["measure_dir"]}))
+                assert applied["ok"] is True, applied.get("log_tail") or applied
+
+                after = unwrap(await s.call_tool("get_air_loop_details", {"air_loop_name": "Edge Loop"}))
+                assert after["ok"] is True, after
+                supply = [c["type"] for c in after["air_loop"]["supply_components"]]
+                assert supply == [
+                    "OS_Node", "OS_Fan_ConstantVolume", "OS_Node", "OS_Coil_Heating_Electric",
+                    "OS_Node", "OS_Coil_Cooling_DX_TwoSpeed", "OS_Node",
+                ], supply
+                clg = after["air_loop"]["detailed_components"]["cooling_coils"]
+                assert [c["name"] for c in clg] == ["Main Cooling Coil"], "old name must be reused"
+                assert len(after["air_loop"]["setpoint_managers"]) == 1, \
+                    "SPM on the supply outlet node must survive the swap"
+    asyncio.run(_run())

--- a/tests/test_sdk_probes.py
+++ b/tests/test_sdk_probes.py
@@ -1,0 +1,124 @@
+"""Manual SDK-behaviour probes — NOT run in CI.
+
+Run by hand inside the Docker image when bumping OPENSTUDIO_VERSION
+(docker/Dockerfile, tests/test_versions.py):
+
+    pytest -m sdk_probe tests/test_sdk_probes.py -v
+
+These pin behaviour the served docs and wiring recipes describe as fact. If a
+probe stops behaving as asserted after a bump, update the text it guards, not
+the probe: `replace_supply_branch_component` in
+mcp_server/skills/api_reference/wiring_recipes.py (+ its HAZARDS entry),
+.claude/skills/measure-authoring/SKILL.md and
+.claude/skills/openstudio-patterns/SKILL.md (issue #149).
+
+Why not CI: the crash case is undefined behaviour (use-after-delete inside the
+SDK). It reproduced 2/2 on 3.11.0 but a flaky CI test is worse than none. The
+`integration` marker keeps it out of the unit job; no ci.yml shard lists it.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.sdk_probe]
+
+# Wrong order: capture the outlet node, remove() the coil (which deletes that
+# node), then addToNode on the dangling handle. From dev/issue149-probes/probe_crash.rb.
+CRASH_RB = """\
+require 'openstudio'
+m = OpenStudio::Model::Model.new
+loop = OpenStudio::Model::AirLoopHVAC.new(m)
+s = m.alwaysOnDiscreteSchedule
+fan = OpenStudio::Model::FanVariableVolume.new(m, s); fan.addToNode(loop.supplyInletNode)
+clg = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(m); clg.setName('Clg'); clg.addToNode(loop.supplyInletNode)
+outlet = clg.outletModelObject.get.to_Node.get
+clg.remove
+newc = OpenStudio::Model::CoilCoolingDXTwoSpeed.new(m)
+puts "MARK: calling addToNode on node captured before remove"
+$stdout.flush
+r = newc.addToNode(outlet)
+puts "MARK: survived, result=#{r}"
+"""
+
+# Safe order: the recipe body from wiring_recipes.py wrapped in a minimal loop.
+# `{seq}` is the append order, so the last name in it is last before
+# supplyOutletNode — the position where remove() deletes the INLET node instead.
+SAFE_RB_PREFIX = """\
+require 'openstudio'
+model = OpenStudio::Model::Model.new
+loop = OpenStudio::Model::AirLoopHVAC.new(model)
+loop.setName('Loop')
+s = model.alwaysOnDiscreteSchedule
+fan = OpenStudio::Model::FanVariableVolume.new(model, s); fan.setName('Fan')
+clg = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model); clg.setName('Main Cooling Coil')
+htg = OpenStudio::Model::CoilHeatingElectric.new(model, s); htg.setName('Htg')
+[{seq}].each { |c| c.addToNode(loop.supplyOutletNode) }
+sch = OpenStudio::Model::ScheduleConstant.new(model); sch.setValue(12.8)
+spm = OpenStudio::Model::SetpointManagerScheduled.new(model, sch); spm.addToNode(loop.supplyOutletNode)
+order = ->{ loop.supplyComponents.reject{|c| c.to_Node.is_initialized}.map{|c| c.nameString} }
+before = order.call
+"""
+SAFE_RB_SUFFIX = """
+after = order.call
+raise "order changed: #{before} -> #{after}" unless before == after
+raise "new coil not on loop" unless new_coil.airLoopHVAC.is_initialized
+raise "name not reused" unless new_coil.nameString == 'Main Cooling Coil'
+raise "inlet node lost" unless model.getObject(inlet_node.handle).is_initialized
+raise "new coil inlet moved" unless new_coil.inletModelObject.get.handle == inlet_node.handle
+raise "SPM on outlet lost" unless loop.supplyOutletNode.setpointManagers.size == 1
+ft = OpenStudio::EnergyPlus::ForwardTranslator.new
+ft.translateModel(model)
+raise "forward translate errors: #{ft.errors.map(&:logMessage)}" unless ft.errors.empty?
+puts "SAFE_OK"
+"""
+
+
+def _run_ruby(script: str) -> subprocess.CompletedProcess:
+    if shutil.which("openstudio") is None:
+        pytest.skip("openstudio CLI not on PATH — run inside the Docker image")
+    tmp = Path(tempfile.mkdtemp(prefix="sdk_probe_"))
+    try:
+        rb = tmp / "probe.rb"
+        rb.write_text(script, encoding="utf-8")
+        cmd = ["openstudio", "execute_ruby_script", str(rb)]  # noqa: S607 - CLI from the image's PATH
+        return subprocess.run(  # noqa: S603 - fixed argv
+            cmd,
+            capture_output=True, text=True, timeout=120, check=False,
+            cwd=str(tmp), env=os.environ.copy(),
+        )
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_addToNode_after_remove_crashes_ruby():
+    # Validates: the #149 hazard text ("[BUG] Segmentation fault ... exit 134, no exception")
+    # still describes what the SDK does; if this passes with exit 0 the warning is stale
+    proc = _run_ruby(CRASH_RB)
+    out = proc.stdout + proc.stderr
+    assert "MARK: calling addToNode" in out, out[-2000:]
+    assert "MARK: survived" not in out, "SDK no longer crashes — soften the #149 warnings"
+    # Ruby's crash handler abort()s: a shell reports 134, Python's subprocess reports the
+    # raw signal (-6). Both are SIGABRT.
+    assert proc.returncode in (-6, 134), f"expected SIGABRT from Ruby's crash handler, got {proc.returncode}"
+    assert "[BUG] Segmentation fault" in out
+    assert "addToNode" in out, "crash report should name addToNode in the control frames"
+
+
+@pytest.mark.parametrize("seq", ["fan, clg, htg", "fan, htg, clg"], ids=["coil_mid_branch", "coil_last"])
+def test_replace_recipe_safe_order_runs_clean(seq):
+    # Validates: the recipe body shipped in wiring_recipes.py runs verbatim with exit 0 in
+    # both branch positions — mid-branch (remove() deletes the old OUTLET node) and last
+    # before supplyOutletNode (remove() deletes the old INLET node, i.e. the new component's
+    # outlet; the SDK splices it to the loop outlet) — keeping order, name, the captured inlet
+    # node, the outlet-node SPM, and a clean forward translation
+    from mcp_server.skills.api_reference.wiring_recipes import RECIPES
+    body = RECIPES["replace_supply_branch_component"]["ruby"]
+    proc = _run_ruby(SAFE_RB_PREFIX.replace("{seq}", seq) + body + SAFE_RB_SUFFIX)
+    assert proc.returncode == 0, (proc.stdout + proc.stderr)[-2000:]
+    assert "SAFE_OK" in proc.stdout

--- a/tests/test_sdk_probes.py
+++ b/tests/test_sdk_probes.py
@@ -86,7 +86,7 @@ def _run_ruby(script: str) -> subprocess.CompletedProcess:
     try:
         rb = tmp / "probe.rb"
         rb.write_text(script, encoding="utf-8")
-        cmd = ["openstudio", "execute_ruby_script", str(rb)]  # noqa: S607 - CLI from the image's PATH
+        cmd = ["openstudio", "execute_ruby_script", str(rb)]  # CLI from the image's PATH
         return subprocess.run(  # noqa: S603 - fixed argv
             cmd,
             capture_output=True, text=True, timeout=120, check=False,

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -9,6 +9,8 @@ from mcp.client.stdio import stdio_client
 @pytest.mark.integration
 def test_get_versions_reports_openstudio_versions():
     # Validates: get_versions returns pinned OpenStudio 3.11.0 SDK + Python binding versions
+    # On an OPENSTUDIO_VERSION bump also run `pytest -m sdk_probe tests/test_sdk_probes.py` in
+    # Docker: the addToNode-after-remove crash (#149) is verified behaviour, not a contract.
     if not integration_enabled():
         pytest.skip("Set RUN_OPENSTUDIO_INTEGRATION=1 to enable MCP integration tests.")
 

--- a/tests/test_wiring_recipes.py
+++ b/tests/test_wiring_recipes.py
@@ -60,6 +60,11 @@ SEARCH_CASES = [
     ("VAV no reheat", "vav_no_reheat"),
     ("air loop from scratch", "air_loop_from_scratch"),
     ("water source heat pump zone", "water_to_air_heat_pump"),
+    # #149: swapping a coil/fan in place must be discoverable by intent AND by symptom
+    ("replace coil in place", "replace_supply_branch_component"),
+    ("swap fan on air loop", "replace_supply_branch_component"),
+    ("addToNode after remove", "replace_supply_branch_component"),
+    ("segfault", "replace_supply_branch_component"),
 ]
 
 
@@ -131,3 +136,59 @@ def test_zone_hvac_recipes_have_addToThermalZone():
         assert "addToThermalZone" in RECIPES[key]["ruby"], (
             f"Zone HVAC recipe '{key}' missing addToThermalZone"
         )
+
+
+# ── #149: replace-in-place recipe + addToNode/remove hazard ─────────────
+
+def test_replace_recipe_orders_addToNode_before_remove():
+    # Regression: #149 — remove() deletes the old component's outlet node; addToNode on a
+    # node handle captured before remove() segfaults Ruby (exit 134) and Python (139), so
+    # the recipe must attach the new component first and say why in the searchable notes
+    recipe = RECIPES["replace_supply_branch_component"]
+    ruby = recipe["ruby"]
+    assert "addToNode" in ruby and ".remove" in ruby
+    assert ruby.index("addToNode") < ruby.index(".remove"), "new.addToNode must precede old.remove"
+    assert "inletModelObject" in ruby, "recipe anchors on the OLD component's inlet node"
+    assert "setName(old_name)" in ruby, "recipe reuses the old name so downstream refs survive"
+    assert "[BUG]" in recipe["notes"] and "segfault" in recipe["notes"].lower()
+    assert "addBranchForZone" in recipe["notes"], "notes must route terminal swaps to addBranchForZone"
+    assert "3.11.0" in recipe["notes"], "verified-on version must be stated"
+
+
+@pytest.mark.parametrize("query", ["addToNode", "remove component", "swap coil", "delete node"])
+def test_hazards_surface_for_node_queries(query):
+    # Validates: the addToNode-after-remove hazard rides along with any node/remove/swap query
+    # so the agent sees it before writing the crashing code, not after a 134 exit
+    result = search_wiring_patterns_op(query)
+    assert result["ok"]
+    assert result["hazards"][0]["id"] == "addToNode_after_remove", result.get("hazards")
+    assert result["hazards"][0]["recipe"] == "replace_supply_branch_component"
+    assert "remove()" in result["hazards"][0]["note"]
+
+
+@pytest.mark.parametrize("query", [
+    "DOAS",
+    "setpoint manager node",          # bare "node" is not the hazard
+    "remove terminal for zone",       # removeBranchForZone is zone-keyed and safe
+    "delete construction layer",      # unrelated delete
+    "bug in schedule",                # bare "bug" no longer fires
+])
+def test_hazards_absent_for_unrelated_query(query):
+    # Validates: existing response shape is untouched when the query does not describe the
+    # dangerous sequence — bare node/remove/delete words must not spam the warning, or the
+    # agent learns to ignore it (review finding on #149)
+    result = search_wiring_patterns_op(query)
+    assert result["ok"]
+    assert "hazards" not in result, result["hazards"]
+
+
+def test_hazards_for_query_helper_tokenizes_and_dedupes():
+    # Validates: hazards_for_query matches whole tokens case-insensitively and returns each
+    # hazard once even when several triggers hit
+    from mcp_server.skills.api_reference.wiring_recipes import HAZARDS, hazards_for_query
+    hits = hazards_for_query("CoilCoolingDXSingleSpeed addToNode remove REPLACE")
+    assert [h["id"] for h in hits] == ["addToNode_after_remove"]
+    assert hazards_for_query("CoilCoolingDXSingleSpeed") == []
+    assert hazards_for_query("") == []
+    assert all({"id", "triggers", "note", "recipe"} <= set(h) for h in HAZARDS)
+    assert all(h["recipe"] in RECIPES for h in HAZARDS), "every hazard points at a real recipe"


### PR DESCRIPTION
Fixes #149.

## Verified (Docker, OpenStudio 3.11.0)
The report is real and worse than stated. `remove()` deletes a supply-branch component's outlet node (its inlet node when it is last before `supplyOutletNode`). `addToNode` on a Node handle captured before the removal segfaults the embedded Ruby (`[BUG] Segmentation fault ... CFUNC :addToNode`, SIGABRT, no exception, the log tail is a memory map) and the Python bindings alike (SIGSEGV, no exception). Server-side code must never do it; that drives the #148 design.

## What changed
- **Recipe `replace_supply_branch_component`**: attach the new component to the old one's inlet node first, then `remove()`, then reuse the name. Verified to keep branch order, the captured inlet node, and the outlet-node setpoint manager in both positions (mid-branch, and last before the loop outlet where the SDK splices the new component to `supplyOutletNode`), with a clean forward translation. Searchable by intent ("replace coil", "swap fan") and by symptom ("segfault", "addToNode after remove"); the 17 existing search cases still rank top-3.
- **Hazard surfacing**: `HAZARDS` + `hazards_for_query` in `wiring_recipes.py`. `search_wiring_patterns` and `search_api` add a `hazards` key only when the query names the dangerous sequence: `addToNode` / `segfault` / `crash` alone, or a remove/delete/replace/swap word together with a component word. Bare "node", "remove", "delete" do not fire ("setpoint manager node", "remove terminal for zone" stay clean), so the warning is not noise.
- **Skill docs**: measure-authoring gains the Ruby and Python replace-in-place snippets plus a WARNING under the HVAC pattern; openstudio-patterns gains an error-table row keyed on the `[BUG]` line / `crash_marker` from #151.
- **`tests/test_sdk_probes.py`**: manual, `sdk_probe` marker, never in a CI shard (undefined behaviour; reproduced 2/2 but a flaky CI test is worse than none). Pins the crash and the safe order in both positions. Comments at the two `OPENSTUDIO_VERSION` pins (Dockerfile, `test_versions.py`) say to run it on a bump.
- Hardcoded "24 recipes" dropped from the tool docstring and README.

## Tests
- Unit (`test_wiring_recipes.py`, no Docker): 4 new search cases, recipe ordering, hazard positive and negative cases. Red on develop (recipe absent, no `hazards` key).
- Integration (`test_measure_authoring.py`, shard 3; `test_api_reference.py`, shard 3; no ci.yml change): recipe runs verbatim through `apply_measure` on a System 3 loop; a second measure builds the coil-last layout with an SPM on the outlet and runs the recipe verbatim; `search_api(..., method_pattern="addToNode")` carries the hazard, a plain class query does not.
- Codex review: 3 findings. The "critical" one (recipe unsafe when the component is last) was probed and does not hold; it is now pinned by the second integration test and the parametrized probe. Trigger breadth and probe coverage findings addressed.

## Note for PR #138
`search_api` gained a 4-line hook at its return (`hazards_for_query`). #138 rewrites that return; whichever lands second keeps both.

## Follow-up
#148 adds the server-side supply-branch tools and will cross-link them from this recipe and the skills.
