### PR TITLE
Add add_setpoint_manager and remove_setpoint_manager tools

### DIFF
--- a/.claude/skills/add-hvac/SKILL.md
+++ b/.claude/skills/add-hvac/SKILL.md
@@ -68,6 +68,18 @@ Setpoint managers on a deleted node are moved to the surviving node and listed i
 These are for coils and fans; plant equipment uses `add_supply_equipment`, terminals use
 `replace_zone_terminal`.
 
+Setpoint managers (supply air temperature control) get their own pair:
+```
+add_setpoint_manager(spm_type="SetpointManagerOutdoorAirReset", name="SAT Reset",
+    air_loop_name="PSZ-AC 1", replace_existing=True)      # swaps the builder's outlet SPM
+set_setpoint_manager_properties(setpoint_name="SAT Reset",
+    properties={"setpoint_at_outdoor_low_temperature": 15.6, "setpoint_at_outdoor_high_temperature": 12.8})
+remove_setpoint_manager(name="SAT Reset")
+```
+A node that already has a same-control-variable setpoint manager is refused unless
+`replace_existing=True`; the SDK would otherwise delete the old one silently. Placement:
+`node="supply_outlet"` (default) / `"supply_inlet"` / `"mixed_air"`, or `after_component=<coil>`.
+
 ## Custom HVAC Wiring
 
 For custom HVAC configurations beyond the baseline templates:

--- a/.claude/skills/add-hvac/eval.md
+++ b/.claude/skills/add-hvac/eval.md
@@ -7,6 +7,8 @@
 | "Add a VAV reheat system with a chiller and boiler plant" | add_baseline_system | system_type=7 |
 | "Swap the DX coil on the air loop for a two-speed coil" | replace_air_loop_supply_component | air_loop_name, component_name, new_component_type=CoilCoolingDXTwoSpeed |
 | "Put a hot water preheat coil upstream of the cooling coil on the VAV loop" | add_air_loop_supply_component | component_type=CoilHeatingWater, insert_before, plant_loop_name |
+| "Add an outdoor air reset setpoint manager to the VAV loop" | add_setpoint_manager | spm_type=SetpointManagerOutdoorAirReset, air_loop_name, replace_existing |
+| "Add a scheduled setpoint manager to the hot water loop" | add_setpoint_manager | spm_type=SetpointManagerScheduled, plant_loop_name, schedule_name |
 
 ## Should NOT trigger
 | Query | Forbidden tools | Expected alternatives |

--- a/.claude/skills/tool-workflows/SKILL.md
+++ b/.claude/skills/tool-workflows/SKILL.md
@@ -92,6 +92,21 @@ set_component_properties(component_name="PSZ-AC 1 DX Cooling Coil",
 relative to an existing one; `remove_air_loop_supply_component` drops one and moves the
 setpoint managers off the deleted node. Water coils need `plant_loop_name`.
 
+## Supply Air Temperature Reset
+
+Swap a loop's outlet setpoint manager for an outdoor-air reset and tune it:
+```
+get_air_loop_details(air_loop_name="VAV 1")            # setpoint_managers on the outlet
+add_setpoint_manager(spm_type="SetpointManagerOutdoorAirReset", name="VAV 1 SAT Reset",
+    air_loop_name="VAV 1", replace_existing=True)
+set_setpoint_manager_properties(setpoint_name="VAV 1 SAT Reset",
+    properties={"setpoint_at_outdoor_low_temperature": 15.6, "outdoor_low_temperature": 10.0,
+                "setpoint_at_outdoor_high_temperature": 12.8, "outdoor_high_temperature": 21.0})
+```
+Without `replace_existing=True` the call is refused when the node already has a Temperature
+setpoint manager (the SDK would delete it silently). `remove_setpoint_manager(name=...)` warns
+if a loop outlet is left with no Temperature control.
+
 ## Tune Component Properties
 
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           case ${{ matrix.shard }} in
             1)
               # Mirrors amd64 shard 1: SEB4 sim + component/weather + loop ops + skill_retrofit
-              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py"
+              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_add_setpoint_manager.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py"
               EXTRA_ENV="-e MCP_OSW_PATH=tests/assets/SEB_model/SEB4_baseboard/workflow.osw -e EXPECTED_EUI=1.8750760248144998 -e EXPECTED_EUI_RTOL=0.02 -e EXPECTED_EUI_ATOL=0.0"
               ;;
             2)
@@ -285,7 +285,7 @@ jobs:
               # sim test + component/weather + loop ops + skill_retrofit
               # + load/save model & file listing tools (moved from shard 4 to balance runtime)
               # + merge_coplanar_sliver_surfaces real-fixture regression (moved from shard 4, see timing note above)
-              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py tests/test_load_save_model.py tests/test_gbxml_import.py::test_geometry_repair_pipeline_on_austin_apartment_fixture"
+              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_add_setpoint_manager.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py tests/test_load_save_model.py tests/test_gbxml_import.py::test_geometry_repair_pipeline_on_austin_apartment_fixture"
               EXTRA_ENV="-e MCP_OSW_PATH=tests/assets/SEB_model/SEB4_baseboard/workflow.osw -e EXPECTED_EUI=1.8750760248144998 -e EXPECTED_EUI_RTOL=0.02 -e EXPECTED_EUI_ATOL=0.0"
               ;;
             2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           case ${{ matrix.shard }} in
             1)
               # Mirrors amd64 shard 1: SEB4 sim + component/weather + loop ops + skill_retrofit
-              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_add_setpoint_manager.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py"
+              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_add_setpoint_manager.py tests/test_add_setpoint_manager_placement.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py"
               EXTRA_ENV="-e MCP_OSW_PATH=tests/assets/SEB_model/SEB4_baseboard/workflow.osw -e EXPECTED_EUI=1.8750760248144998 -e EXPECTED_EUI_RTOL=0.02 -e EXPECTED_EUI_ATOL=0.0"
               ;;
             2)
@@ -285,7 +285,7 @@ jobs:
               # sim test + component/weather + loop ops + skill_retrofit
               # + load/save model & file listing tools (moved from shard 4 to balance runtime)
               # + merge_coplanar_sliver_surfaces real-fixture regression (moved from shard 4, see timing note above)
-              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_add_setpoint_manager.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py tests/test_load_save_model.py tests/test_gbxml_import.py::test_geometry_repair_pipeline_on_austin_apartment_fixture"
+              FILES="tests/test_air_loop_supply.py tests/test_air_loop_supply_topology.py tests/test_add_setpoint_manager.py tests/test_add_setpoint_manager_placement.py tests/test_example_workflows.py tests/test_component_properties.py tests/test_comstock.py tests/test_weather.py tests/test_weather_files.py tests/test_mcp_seb4.py tests/test_create_constructions.py tests/test_loop_operations.py tests/test_plant_loop_demand.py tests/test_sizing_properties.py tests/test_skill_retrofit.py tests/test_integration.py tests/test_load_save_model.py tests/test_gbxml_import.py::test_geometry_repair_pipeline_on_austin_apartment_fixture"
               EXTRA_ENV="-e MCP_OSW_PATH=tests/assets/SEB_model/SEB4_baseboard/workflow.osw -e EXPECTED_EUI=1.8750760248144998 -e EXPECTED_EUI_RTOL=0.02 -e EXPECTED_EUI_ATOL=0.0"
               ;;
             2)

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ List components via `list_model_objects("BoilerHotWater")`, loop detail tools, e
 </details>
 
 <details>
-<summary><b>Plant loops, air-loop supply branches & zone equipment</b> — 12 tools</summary>
+<summary><b>Plant loops, air-loop supply branches, setpoint managers & zone equipment</b> — 14 tools</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -467,6 +467,8 @@ List components via `list_model_objects("BoilerHotWater")`, loop detail tools, e
 | `add_air_loop_supply_component` | Add a coil or fan to an air loop's supply branch (append or insert before/after) |
 | `remove_air_loop_supply_component` | Remove a coil or fan from an air loop, keeping its setpoint managers |
 | `replace_air_loop_supply_component` | Swap a coil or fan in place (add-first order, avoids the SDK segfault) |
+| `add_setpoint_manager` | Put one of 7 setpoint manager types on a loop node; refuses silent same-control-variable collisions |
+| `remove_setpoint_manager` | Delete a setpoint manager; warns when a loop outlet loses temperature control |
 | `add_zone_equipment` | Add baseboard/unit heater to a zone |
 | `remove_zone_equipment` | Remove zone equipment |
 | `remove_all_zone_equipment` | Batch-remove all equipment from zones |

--- a/mcp_server/skills/component_properties/operations.py
+++ b/mcp_server/skills/component_properties/operations.py
@@ -506,9 +506,11 @@ def get_sizing_zone_properties(zone_name: str) -> dict:
 # Registry of supported SPM types: getter method, get/set functions.
 
 def _get_spm_single_zone_reheat_props(spm) -> dict:
+    zone = spm.controlZone()  # OptionalThermalZone; read-only here (add_setpoint_manager sets it)
     return {
         "minimum_supply_air_temperature_c": {"value": float(spm.minimumSupplyAirTemperature()), "unit": "C"},
         "maximum_supply_air_temperature_c": {"value": float(spm.maximumSupplyAirTemperature()), "unit": "C"},
+        "control_zone": {"value": zone.get().nameString() if zone.is_initialized() else None, "unit": None},
     }
 
 def _set_spm_single_zone_reheat_props(spm, properties: dict) -> tuple[dict, list]:

--- a/mcp_server/skills/component_properties/operations.py
+++ b/mcp_server/skills/component_properties/operations.py
@@ -660,12 +660,14 @@ def _get_spm_scheduled_dual_setpoint_props(spm) -> dict:
     high_sched = spm.highSetpointSchedule()
     low_sched = spm.lowSetpointSchedule()
     return {
+        # OptionalSchedule: .get() before .nameString() (crashed the tool on every
+        # dual-setpoint SPM until add_setpoint_manager's tests created one)
         "high_setpoint_schedule": {
-            "value": high_sched.nameString() if high_sched.is_initialized() else None,
+            "value": high_sched.get().nameString() if high_sched.is_initialized() else None,
             "unit": None,
         },
         "low_setpoint_schedule": {
-            "value": low_sched.nameString() if low_sched.is_initialized() else None,
+            "value": low_sched.get().nameString() if low_sched.is_initialized() else None,
             "unit": None,
         },
     }

--- a/mcp_server/skills/loop_operations/setpoint_managers.py
+++ b/mcp_server/skills/loop_operations/setpoint_managers.py
@@ -1,0 +1,302 @@
+"""Create and remove setpoint managers on loop nodes (follow-up to #148).
+
+Setpoint managers (SPMs) were only ever created inside whole-system builders;
+removing or replacing a supply-branch component (#148) can move one, but
+nothing could put a new one on a chosen node. These two tools close that gap.
+
+SDK facts this rests on (dev/issue149-probes/probe_spm_collision.py, OpenStudio
+3.11.0):
+- SetpointManager.addToNode(node) returns True and, when `node` already carries
+  an SPM with the same controlVariable(), silently DELETES that SPM from the
+  model. There is no return-value signal, so the collision guard lives here.
+- Different control variables coexist on one node (Temperature + HumidityRatio).
+- The SDK does validate loop type: an air-loop-only type (Warmest, Coldest,
+  SingleZoneReheat) returns False on a plant node and attaches nothing.
+- spm.remove() deletes just that SPM; other SPMs on the node stay.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import openstudio
+
+from mcp_server.model_manager import get_model
+from mcp_server.osm_helpers import fetch_object
+from mcp_server.skills.component_properties.operations import SPM_TYPES
+from mcp_server.skills.loop_operations.air_loop_supply import _air_ports, _find_on_supply
+
+# The 7 types get_/set_setpoint_manager_properties already understand. A new
+# type needs a constructor branch in _construct_spm AND a lookup branch in
+# _find_spm (see .claude/rules/component-types.md).
+SPM_CONSTRUCTOR_TYPES: tuple[str, ...] = tuple(SPM_TYPES.keys())
+AIR_LOOP_ONLY_TYPES = frozenset({
+    "SetpointManagerSingleZoneReheat", "SetpointManagerWarmest", "SetpointManagerColdest",
+})
+NODE_CHOICES = ("supply_outlet", "supply_inlet", "mixed_air")
+
+
+# ── lookup ───────────────────────────────────────────────────────────────
+
+def _find_spm(model, name: str):
+    """(spm, spm_type) for the named SPM across the 7 supported types, else None.
+
+    Explicit calls, one per type (CLAUDE.md rule 12: no getattr dispatch).
+    """
+    r = model.getSetpointManagerSingleZoneReheatByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerSingleZoneReheat"
+    r = model.getSetpointManagerScheduledByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerScheduled"
+    r = model.getSetpointManagerWarmestByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerWarmest"
+    r = model.getSetpointManagerColdestByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerColdest"
+    r = model.getSetpointManagerFollowOutdoorAirTemperatureByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerFollowOutdoorAirTemperature"
+    r = model.getSetpointManagerOutdoorAirResetByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerOutdoorAirReset"
+    r = model.getSetpointManagerScheduledDualSetpointByName(name)
+    if r.is_initialized():
+        return r.get(), "SetpointManagerScheduledDualSetpoint"
+    return None
+
+
+def _resolve_loop(model, air_loop_name: str | None, plant_loop_name: str | None):
+    """(loop, "air"|"plant", None) or (None, None, error)."""
+    if (air_loop_name is None) == (plant_loop_name is None):
+        return None, None, "Pass exactly one of air_loop_name or plant_loop_name"
+    if air_loop_name is not None:
+        loop = fetch_object(model, "AirLoopHVAC", name=air_loop_name)
+        if loop is None:
+            return None, None, f"Air loop '{air_loop_name}' not found"
+        return loop, "air", None
+    loop = fetch_object(model, "PlantLoop", name=plant_loop_name)
+    if loop is None:
+        return None, None, f"Plant loop '{plant_loop_name}' not found"
+    return loop, "plant", None
+
+
+def _resolve_node(loop, kind: str, node: str, after_component: str | None):
+    """(Node, None) or (None, error) for the placement the caller asked for."""
+    if after_component is not None:
+        comp = _find_on_supply(loop, after_component)
+        if comp is None:
+            return None, f"'{after_component}' not found on the supply side of '{loop.nameString()}'"
+        ports = _air_ports(comp)
+        if ports is None or ports[2] is None:
+            return None, f"'{after_component}' has no outlet node to place a setpoint manager on"
+        return ports[2], None
+    if node == "supply_outlet":
+        return loop.supplyOutletNode(), None
+    if node == "supply_inlet":
+        return loop.supplyInletNode(), None
+    if node == "mixed_air":
+        if kind != "air":
+            return None, "node='mixed_air' only exists on an air loop"
+        oa = loop.airLoopHVACOutdoorAirSystem()
+        if not oa.is_initialized():
+            return None, f"Air loop '{loop.nameString()}' has no outdoor air system, so no mixed-air node"
+        mixed = oa.get().mixedAirModelObject()
+        if not mixed.is_initialized() or not mixed.get().to_Node().is_initialized():
+            return None, "Outdoor air system has no mixed-air node"
+        return mixed.get().to_Node().get(), None
+    return None, f"Unknown node '{node}'. Valid: {list(NODE_CHOICES)} or after_component=<name>"
+
+
+# ── construction ─────────────────────────────────────────────────────────
+
+def _schedule(model, param: str, schedule_name: str | None, spm_type: str):
+    """(schedule, None) or (None, error) — required-arg check plus lookup."""
+    if schedule_name is None:
+        return None, f"{spm_type} requires {param}"
+    sched = fetch_object(model, "Schedule", name=schedule_name)
+    if sched is None:
+        return None, f"Schedule '{schedule_name}' not found"
+    return sched, None
+
+
+def _construct_spm(model, spm_type: str, loop, kind: str, *, schedule_name, cooling_schedule_name,
+                   heating_schedule_name, control_zone_name, control_variable):
+    """(spm, None) or (None, error). Explicit branches per type (rule 12)."""
+    if spm_type == "SetpointManagerScheduled":
+        sched, err = _schedule(model, "schedule_name", schedule_name, spm_type)
+        if err:
+            return None, err
+        # Both constructor forms throw (SystemError) when the schedule's type limits do not
+        # fit the control variable, or the variable is unknown — and the half-built SPM is
+        # left in the model (probe_spm_ctor_orphan.py). Snapshot, then roll back on failure.
+        before = {o.handle() for o in model.getSetpointManagerScheduleds()}
+        try:
+            if control_variable is None:
+                spm = openstudio.model.SetpointManagerScheduled(model, sched)  # (model, schedule)
+            else:
+                spm = openstudio.model.SetpointManagerScheduled(model, control_variable, sched)
+        except Exception:
+            for o in model.getSetpointManagerScheduleds():
+                if o.handle() not in before:
+                    o.remove()
+            cv = control_variable or "Temperature"
+            return None, (f"Schedule '{schedule_name}' has type limits incompatible with control "
+                          f"variable '{cv}' (or '{cv}' is not a valid control variable for {spm_type})")
+        return spm, None
+    if spm_type == "SetpointManagerScheduledDualSetpoint":
+        high, err = _schedule(model, "cooling_schedule_name", cooling_schedule_name, spm_type)
+        if err:
+            return None, err
+        low, err = _schedule(model, "heating_schedule_name", heating_schedule_name, spm_type)
+        if err:
+            return None, err
+        spm = openstudio.model.SetpointManagerScheduledDualSetpoint(model)
+        # Setters return False (and leave the slot empty) for non-temperature type limits
+        if not spm.setHighSetpointSchedule(high):   # cooling side
+            spm.remove()
+            return None, f"Schedule '{cooling_schedule_name}' is not a temperature schedule (cooling_schedule_name)"
+        if not spm.setLowSetpointSchedule(low):     # heating side
+            spm.remove()
+            return None, f"Schedule '{heating_schedule_name}' is not a temperature schedule (heating_schedule_name)"
+        return spm, None
+    if spm_type == "SetpointManagerSingleZoneReheat":
+        if control_zone_name is None:
+            return None, f"{spm_type} requires control_zone_name"
+        zone = fetch_object(model, "ThermalZone", name=control_zone_name)
+        if zone is None:
+            return None, f"Thermal zone '{control_zone_name}' not found"
+        if kind != "air" or not any(z.handle() == zone.handle() for z in loop.thermalZones()):
+            return None, f"Zone '{control_zone_name}' is not served by air loop '{loop.nameString()}'"
+        spm = openstudio.model.SetpointManagerSingleZoneReheat(model)
+        spm.setControlZone(zone)
+        return spm, None
+    if control_variable is not None:
+        return None, f"control_variable is only settable on SetpointManagerScheduled, not {spm_type}"
+    if spm_type == "SetpointManagerWarmest":
+        return openstudio.model.SetpointManagerWarmest(model), None
+    if spm_type == "SetpointManagerColdest":
+        return openstudio.model.SetpointManagerColdest(model), None
+    if spm_type == "SetpointManagerFollowOutdoorAirTemperature":
+        return openstudio.model.SetpointManagerFollowOutdoorAirTemperature(model), None
+    if spm_type == "SetpointManagerOutdoorAirReset":
+        return openstudio.model.SetpointManagerOutdoorAirReset(model), None
+    return None, f"Unknown spm_type '{spm_type}'. Valid: {list(SPM_CONSTRUCTOR_TYPES)}"
+
+
+# ── tools ────────────────────────────────────────────────────────────────
+
+def add_setpoint_manager(
+    spm_type: str,
+    name: str,
+    air_loop_name: str | None = None,
+    plant_loop_name: str | None = None,
+    node: str = "supply_outlet",
+    after_component: str | None = None,
+    schedule_name: str | None = None,
+    cooling_schedule_name: str | None = None,
+    heating_schedule_name: str | None = None,
+    control_zone_name: str | None = None,
+    control_variable: str | None = None,
+    replace_existing: bool = False,
+) -> dict[str, Any]:
+    """Create a setpoint manager and attach it to a loop node, refusing silent collisions."""
+    try:
+        model = get_model()
+        if spm_type not in SPM_CONSTRUCTOR_TYPES:
+            return {"ok": False, "error": f"Unknown spm_type '{spm_type}'. Valid: {list(SPM_CONSTRUCTOR_TYPES)}"}
+        if _find_spm(model, name) is not None:
+            return {"ok": False, "error": f"A setpoint manager named '{name}' already exists"}
+        loop, kind, err = _resolve_loop(model, air_loop_name, plant_loop_name)
+        if err:
+            return {"ok": False, "error": err}
+        if kind == "plant" and spm_type in AIR_LOOP_ONLY_TYPES:
+            return {"ok": False, "error": f"{spm_type} is air-loop only; it cannot go on plant loop "
+                                          f"'{loop.nameString()}'"}
+        target, err = _resolve_node(loop, kind, node, after_component)
+        if err:
+            return {"ok": False, "error": err}
+
+        spm, err = _construct_spm(
+            model, spm_type, loop, kind, schedule_name=schedule_name,
+            cooling_schedule_name=cooling_schedule_name, heating_schedule_name=heating_schedule_name,
+            control_zone_name=control_zone_name, control_variable=control_variable,
+        )
+        if err:
+            return {"ok": False, "error": err}
+        spm.setName(name)
+        cv = spm.controlVariable()
+
+        # The SDK gives no signal for this: addToNode would delete `existing` silently.
+        existing = [s for s in target.setpointManagers() if s.controlVariable() == cv]
+        if existing and not replace_existing:
+            spm.remove()
+            desc = ", ".join(f"'{s.nameString()}' ({s.iddObjectType().valueName()})" for s in existing)
+            return {"ok": False, "error": f"Node '{target.nameString()}' already has a {cv} setpoint "
+                                          f"manager: {desc}. Pass replace_existing=True to replace it"}
+        replaced = [s.nameString() for s in existing]
+        if not spm.addToNode(target):
+            spm.remove()
+            hint = " (this type is air-loop only)" if kind == "plant" else ""
+            return {"ok": False, "error": f"{spm_type} was refused on {kind} loop '{loop.nameString()}' "
+                                          f"node '{target.nameString()}'{hint}"}
+        return {
+            "ok": True,
+            "name": spm.nameString(),
+            "spm_type": spm_type,
+            "control_variable": cv,
+            "loop": loop.nameString(),
+            "loop_type": kind,
+            "node_name": target.nameString(),
+            "replaced": replaced[0] if len(replaced) == 1 else (replaced or None),
+            "setpoint_managers_on_node": [s.nameString() for s in target.setpointManagers()],
+        }
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to add setpoint manager: {e}"}
+
+
+def remove_setpoint_manager(name: str) -> dict[str, Any]:
+    """Delete one setpoint manager; warn when a loop outlet is left without temperature control."""
+    try:
+        model = get_model()
+        found = _find_spm(model, name)
+        if found is None:
+            return {"ok": False, "error": f"Setpoint manager '{name}' not found. Supported types: "
+                                          f"{list(SPM_CONSTRUCTOR_TYPES)}"}
+        spm, spm_type = found
+        node_opt = spm.setpointNode()
+        node = node_opt.get() if node_opt.is_initialized() else None
+        node_name = node.nameString() if node is not None else None
+        cv = spm.controlVariable()
+        spm.remove()
+
+        result: dict[str, Any] = {
+            "ok": True,
+            "removed": name,
+            "spm_type": spm_type,
+            "node_name": node_name,
+            "remaining_on_node": [s.nameString() for s in node.setpointManagers()] if node is not None else [],
+        }
+        if node is not None and cv == "Temperature":
+            loop_outlet = None
+            air = node.airLoopHVAC()
+            plant = node.plantLoop()
+            if air.is_initialized() and air.get().supplyOutletNode().handle() == node.handle():
+                loop_outlet = air.get().nameString()
+            elif plant.is_initialized() and plant.get().supplyOutletNode().handle() == node.handle():
+                loop_outlet = plant.get().nameString()
+            if loop_outlet is not None and not any(
+                s.controlVariable() == "Temperature" for s in node.setpointManagers()
+            ):
+                result["warnings"] = [
+                    f"'{node_name}' is the supply outlet of '{loop_outlet}' and now has no Temperature "
+                    "setpoint manager; EnergyPlus will not simulate the loop until one is added "
+                    "(add_setpoint_manager)",
+                ]
+        return result
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to remove setpoint manager: {e}"}

--- a/mcp_server/skills/loop_operations/setpoint_managers.py
+++ b/mcp_server/skills/loop_operations/setpoint_managers.py
@@ -168,9 +168,9 @@ def _construct_spm(model, spm_type: str, loop, kind: str, *, schedule_name, cool
             return None, f"Thermal zone '{control_zone_name}' not found"
         if kind != "air" or not any(z.handle() == zone.handle() for z in loop.thermalZones()):
             return None, f"Zone '{control_zone_name}' is not served by air loop '{loop.nameString()}'"
-        spm = openstudio.model.SetpointManagerSingleZoneReheat(model)
-        spm.setControlZone(zone)
-        return spm, None
+        # The control zone is applied AFTER addToNode (see _apply_control_zone): attaching
+        # resets it to the loop's first zone (probe_szr_control_zone.py)
+        return openstudio.model.SetpointManagerSingleZoneReheat(model), None
     if control_variable is not None:
         return None, f"control_variable is only settable on SetpointManagerScheduled, not {spm_type}"
     if spm_type == "SetpointManagerWarmest":
@@ -182,6 +182,21 @@ def _construct_spm(model, spm_type: str, loop, kind: str, *, schedule_name, cool
     if spm_type == "SetpointManagerOutdoorAirReset":
         return openstudio.model.SetpointManagerOutdoorAirReset(model), None
     return None, f"Unknown spm_type '{spm_type}'. Valid: {list(SPM_CONSTRUCTOR_TYPES)}"
+
+
+def _apply_control_zone(spm, model, control_zone_name: str) -> tuple[str | None, str | None]:
+    """(zone name, None) or (None, error) — set the SingleZoneReheat control zone post-attach.
+
+    SetpointManagerSingleZoneReheat.addToNode overwrites the control zone with the
+    loop's FIRST demand-side zone, so a zone set before attaching is silently lost
+    on a multi-zone loop (probe_szr_control_zone.py). Set it afterwards and read back.
+    """
+    zone = fetch_object(model, "ThermalZone", name=control_zone_name)
+    szr = spm.to_SetpointManagerSingleZoneReheat().get()
+    got = szr.controlZone() if szr.setControlZone(zone) else None
+    if got is None or not got.is_initialized() or got.get().handle() != zone.handle():
+        return None, f"Could not set control zone '{control_zone_name}' on {spm.nameString()}"
+    return got.get().nameString(), None
 
 
 # ── tools ────────────────────────────────────────────────────────────────
@@ -240,11 +255,18 @@ def add_setpoint_manager(
             hint = " (this type is air-loop only)" if kind == "plant" else ""
             return {"ok": False, "error": f"{spm_type} was refused on {kind} loop '{loop.nameString()}' "
                                           f"node '{target.nameString()}'{hint}"}
+        control_zone = None
+        if spm_type == "SetpointManagerSingleZoneReheat":
+            control_zone, err = _apply_control_zone(spm, model, control_zone_name)
+            if err:
+                spm.remove()
+                return {"ok": False, "error": err}
         return {
             "ok": True,
             "name": spm.nameString(),
             "spm_type": spm_type,
             "control_variable": cv,
+            "control_zone": control_zone,
             "loop": loop.nameString(),
             "loop_type": kind,
             "node_name": target.nameString(),

--- a/mcp_server/skills/loop_operations/tools.py
+++ b/mcp_server/skills/loop_operations/tools.py
@@ -5,7 +5,8 @@ import json
 from typing import TYPE_CHECKING
 
 from mcp_server.osm_helpers import parse_str_list
-from mcp_server.skills.loop_operations import air_loop_supply, operations
+from mcp_server.skills.loop_operations import operations
+from mcp_server.skills.loop_operations.tools_air_loop import register_air_loop_tools
 
 if TYPE_CHECKING:
     from mcp import FastMCP
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 
 def register(mcp: FastMCP) -> None:
     """Register loop operations tools with MCP server."""
+    register_air_loop_tools(mcp)  # air-loop supply branch + setpoint managers (split for file size)
 
     @mcp.tool(tags={"hvac"}, name="create_plant_loop")
     def create_plant_loop_tool(
@@ -130,116 +132,6 @@ def register(mcp: FastMCP) -> None:
         """
         return json.dumps(operations.remove_supply_equipment(
             plant_loop_name, equipment_name,
-        ), indent=2)
-
-    @mcp.tool(tags={"hvac"}, name="add_air_loop_supply_component")
-    def add_air_loop_supply_component_tool(
-        air_loop_name: str,
-        component_type: str,
-        component_name: str,
-        insert_before: str | None = None,
-        insert_after: str | None = None,
-        plant_loop_name: str | None = None,
-    ) -> str:
-        """Create a coil or fan and put it on an existing air loop's supply branch.
-
-        Appends at the downstream end (just before the supply outlet node) unless
-        insert_before / insert_after names an existing coil or fan on the loop.
-        Tune the new component afterwards with set_component_properties.
-
-        Supported component_type: FanConstantVolume, FanVariableVolume, FanOnOff,
-        CoilHeatingElectric, CoilHeatingGas, CoilHeatingWater, CoilHeatingDXSingleSpeed,
-        CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilCoolingWater.
-        Water coils need plant_loop_name (joined to that loop's demand side first).
-
-        Examples:
-          add_air_loop_supply_component("VAV 1", "CoilHeatingWater", "Preheat Coil",
-                                        insert_before="VAV 1 Cooling Coil", plant_loop_name="HW Loop")
-          add_air_loop_supply_component("PSZ 1", "CoilHeatingElectric", "Reheat Booster")
-
-        Args:
-            air_loop_name: Existing AirLoopHVAC name (see list_air_loops)
-            component_type: One of the supported types above
-            component_name: Name for the new component (must not already be on the loop)
-            insert_before: Put the new component immediately upstream of this component
-            insert_after: Put the new component immediately downstream of this component
-            plant_loop_name: Required for CoilHeatingWater / CoilCoolingWater
-
-        Returns:
-            JSON: air_loop, component_name, component_type, plant_loop, supply_order
-            (full ordered list of {name, type} on the supply branch)
-        """
-        return json.dumps(air_loop_supply.add_air_loop_supply_component(
-            air_loop_name=air_loop_name, component_type=component_type,
-            component_name=component_name, insert_before=insert_before,
-            insert_after=insert_after, plant_loop_name=plant_loop_name,
-        ), indent=2)
-
-    @mcp.tool(tags={"hvac"}, name="remove_air_loop_supply_component")
-    def remove_air_loop_supply_component_tool(
-        air_loop_name: str,
-        component_name: str,
-    ) -> str:
-        """Remove a coil or fan from an air loop's supply branch.
-
-        Safer than delete_object: checks the component is on THIS loop, and keeps
-        any setpoint manager that sat on the node the removal deletes by moving it
-        to the surviving neighbour node (reported in moved_setpoint_managers; a
-        same-control-variable collision leaves it behind and is reported in
-        dropped_setpoint_managers + warnings). Water coils leave their plant loop
-        automatically. Outdoor air systems and terminals are refused.
-
-        Args:
-            air_loop_name: Existing AirLoopHVAC name
-            component_name: Exact name of the coil or fan on that loop's supply side
-
-        Returns:
-            JSON: removed {name, type}, moved_setpoint_managers,
-            dropped_setpoint_managers, supply_order
-        """
-        return json.dumps(air_loop_supply.remove_air_loop_supply_component(
-            air_loop_name=air_loop_name, component_name=component_name,
-        ), indent=2)
-
-    @mcp.tool(tags={"hvac"}, name="replace_air_loop_supply_component")
-    def replace_air_loop_supply_component_tool(
-        air_loop_name: str,
-        component_name: str,
-        new_component_type: str,
-        new_component_name: str | None = None,
-        plant_loop_name: str | None = None,
-    ) -> str:
-        """Swap a coil or fan on an air loop's supply branch for a new type, in place.
-
-        Keeps the branch position and, by default, the old name (so downstream
-        references and reports still resolve). A water-coil-for-water-coil swap
-        reuses the old coil's plant loop unless plant_loop_name says otherwise;
-        DX-to-water needs plant_loop_name. Setpoint managers on the old
-        component's outlet node move to the new component's outlet node.
-        Prefer this over a hand-written measure for simple swaps: it performs
-        the add-first / remove-second sequence that avoids the SDK segfault
-        (search_wiring_patterns("replace coil") explains).
-
-        Examples:
-          replace_air_loop_supply_component("PSZ 1", "PSZ 1 DX Cooling Coil", "CoilCoolingDXTwoSpeed")
-          replace_air_loop_supply_component("PSZ 1", "PSZ 1 Supply Fan", "FanVariableVolume",
-                                            new_component_name="VAV Fan")
-
-        Args:
-            air_loop_name: Existing AirLoopHVAC name
-            component_name: Exact name of the coil or fan to replace
-            new_component_type: One of the types add_air_loop_supply_component supports
-            new_component_name: Name for the replacement (default: reuse the old name)
-            plant_loop_name: Plant loop for a new water coil (default: inherit from the old coil)
-
-        Returns:
-            JSON: removed {name, type}, added {name, type}, plant_loop,
-            moved_setpoint_managers, dropped_setpoint_managers, supply_order
-        """
-        return json.dumps(air_loop_supply.replace_air_loop_supply_component(
-            air_loop_name=air_loop_name, component_name=component_name,
-            new_component_type=new_component_type, new_component_name=new_component_name,
-            plant_loop_name=plant_loop_name,
         ), indent=2)
 
     @mcp.tool(tags={"hvac"}, name="add_zone_equipment")

--- a/mcp_server/skills/loop_operations/tools_air_loop.py
+++ b/mcp_server/skills/loop_operations/tools_air_loop.py
@@ -1,0 +1,211 @@
+"""MCP tool registrations for air-loop supply branches and setpoint managers.
+
+Split out of tools.py (plant / zone equipment) to keep both files under the
+~400-line limit. Called from tools.py::register.
+"""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from mcp_server.skills.loop_operations import air_loop_supply, setpoint_managers
+
+if TYPE_CHECKING:
+    from mcp import FastMCP
+
+
+def register_air_loop_tools(mcp: FastMCP) -> None:
+    """Register add/remove/replace supply-component and setpoint-manager tools."""
+
+    @mcp.tool(tags={"hvac"}, name="add_air_loop_supply_component")
+    def add_air_loop_supply_component_tool(
+        air_loop_name: str,
+        component_type: str,
+        component_name: str,
+        insert_before: str | None = None,
+        insert_after: str | None = None,
+        plant_loop_name: str | None = None,
+    ) -> str:
+        """Create a coil or fan and put it on an existing air loop's supply branch.
+
+        Appends at the downstream end (just before the supply outlet node) unless
+        insert_before / insert_after names an existing coil or fan on the loop.
+        Tune the new component afterwards with set_component_properties.
+
+        Supported component_type: FanConstantVolume, FanVariableVolume, FanOnOff,
+        CoilHeatingElectric, CoilHeatingGas, CoilHeatingWater, CoilHeatingDXSingleSpeed,
+        CoilCoolingDXSingleSpeed, CoilCoolingDXTwoSpeed, CoilCoolingWater.
+        Water coils need plant_loop_name (joined to that loop's demand side first).
+
+        Examples:
+          add_air_loop_supply_component("VAV 1", "CoilHeatingWater", "Preheat Coil",
+                                        insert_before="VAV 1 Cooling Coil", plant_loop_name="HW Loop")
+          add_air_loop_supply_component("PSZ 1", "CoilHeatingElectric", "Reheat Booster")
+
+        Args:
+            air_loop_name: Existing AirLoopHVAC name (see list_air_loops)
+            component_type: One of the supported types above
+            component_name: Name for the new component (must not already be on the loop)
+            insert_before: Put the new component immediately upstream of this component
+            insert_after: Put the new component immediately downstream of this component
+            plant_loop_name: Required for CoilHeatingWater / CoilCoolingWater
+
+        Returns:
+            JSON: air_loop, component_name, component_type, plant_loop, supply_order
+            (full ordered list of {name, type} on the supply branch)
+        """
+        return json.dumps(air_loop_supply.add_air_loop_supply_component(
+            air_loop_name=air_loop_name, component_type=component_type,
+            component_name=component_name, insert_before=insert_before,
+            insert_after=insert_after, plant_loop_name=plant_loop_name,
+        ), indent=2)
+
+    @mcp.tool(tags={"hvac"}, name="remove_air_loop_supply_component")
+    def remove_air_loop_supply_component_tool(
+        air_loop_name: str,
+        component_name: str,
+    ) -> str:
+        """Remove a coil or fan from an air loop's supply branch.
+
+        Safer than delete_object: checks the component is on THIS loop, and keeps
+        any setpoint manager that sat on the node the removal deletes by moving it
+        to the surviving neighbour node (reported in moved_setpoint_managers; a
+        same-control-variable collision leaves it behind and is reported in
+        dropped_setpoint_managers + warnings). Water coils leave their plant loop
+        automatically. Outdoor air systems and terminals are refused.
+
+        Args:
+            air_loop_name: Existing AirLoopHVAC name
+            component_name: Exact name of the coil or fan on that loop's supply side
+
+        Returns:
+            JSON: removed {name, type}, moved_setpoint_managers,
+            dropped_setpoint_managers, supply_order
+        """
+        return json.dumps(air_loop_supply.remove_air_loop_supply_component(
+            air_loop_name=air_loop_name, component_name=component_name,
+        ), indent=2)
+
+    @mcp.tool(tags={"hvac"}, name="replace_air_loop_supply_component")
+    def replace_air_loop_supply_component_tool(
+        air_loop_name: str,
+        component_name: str,
+        new_component_type: str,
+        new_component_name: str | None = None,
+        plant_loop_name: str | None = None,
+    ) -> str:
+        """Swap a coil or fan on an air loop's supply branch for a new type, in place.
+
+        Keeps the branch position and, by default, the old name (so downstream
+        references and reports still resolve). A water-coil-for-water-coil swap
+        reuses the old coil's plant loop unless plant_loop_name says otherwise;
+        DX-to-water needs plant_loop_name. Setpoint managers on the old
+        component's outlet node move to the new component's outlet node.
+        Prefer this over a hand-written measure for simple swaps: it performs
+        the add-first / remove-second sequence that avoids the SDK segfault
+        (search_wiring_patterns("replace coil") explains).
+
+        Examples:
+          replace_air_loop_supply_component("PSZ 1", "PSZ 1 DX Cooling Coil", "CoilCoolingDXTwoSpeed")
+          replace_air_loop_supply_component("PSZ 1", "PSZ 1 Supply Fan", "FanVariableVolume",
+                                            new_component_name="VAV Fan")
+
+        Args:
+            air_loop_name: Existing AirLoopHVAC name
+            component_name: Exact name of the coil or fan to replace
+            new_component_type: One of the types add_air_loop_supply_component supports
+            new_component_name: Name for the replacement (default: reuse the old name)
+            plant_loop_name: Plant loop for a new water coil (default: inherit from the old coil)
+
+        Returns:
+            JSON: removed {name, type}, added {name, type}, plant_loop,
+            moved_setpoint_managers, dropped_setpoint_managers, supply_order
+        """
+        return json.dumps(air_loop_supply.replace_air_loop_supply_component(
+            air_loop_name=air_loop_name, component_name=component_name,
+            new_component_type=new_component_type, new_component_name=new_component_name,
+            plant_loop_name=plant_loop_name,
+        ), indent=2)
+
+    @mcp.tool(tags={"hvac"}, name="add_setpoint_manager")
+    def add_setpoint_manager_tool(
+        spm_type: str,
+        name: str,
+        air_loop_name: str | None = None,
+        plant_loop_name: str | None = None,
+        node: str = "supply_outlet",
+        after_component: str | None = None,
+        schedule_name: str | None = None,
+        cooling_schedule_name: str | None = None,
+        heating_schedule_name: str | None = None,
+        control_zone_name: str | None = None,
+        control_variable: str | None = None,
+        replace_existing: bool = False,
+    ) -> str:
+        """Create a setpoint manager on an air loop or plant loop node.
+
+        Placement: node="supply_outlet" (default) | "supply_inlet" | "mixed_air"
+        (air loops with an OA system), or after_component=<coil/fan name> for that
+        component's outlet node. Tune setpoints/reset curves afterwards with
+        set_setpoint_manager_properties.
+
+        spm_type and its required extra arg:
+        - SetpointManagerScheduled: schedule_name (optional control_variable, e.g.
+          "HumidityRatio"; default Temperature)
+        - SetpointManagerScheduledDualSetpoint: cooling_schedule_name + heating_schedule_name
+        - SetpointManagerSingleZoneReheat: control_zone_name (zone served by that air loop)
+        - SetpointManagerWarmest / SetpointManagerColdest (air loops only),
+          SetpointManagerFollowOutdoorAirTemperature, SetpointManagerOutdoorAirReset: none
+
+        A node already holding a setpoint manager with the same control variable is
+        refused (the SDK would silently delete the old one); pass replace_existing=True
+        to replace it, and the response reports `replaced`.
+
+        Examples:
+          add_setpoint_manager("SetpointManagerOutdoorAirReset", "SAT Reset", air_loop_name="VAV 1",
+                               replace_existing=True)
+          add_setpoint_manager("SetpointManagerScheduled", "HW Setpoint", plant_loop_name="HW Loop",
+                               schedule_name="HW Temp Sched")
+
+        Args:
+            spm_type: One of the 7 types above
+            name: Name for the new setpoint manager (must be unique)
+            air_loop_name: Target air loop (exactly one of air_loop_name / plant_loop_name)
+            plant_loop_name: Target plant loop
+            node: "supply_outlet" | "supply_inlet" | "mixed_air"
+            after_component: Place on this supply component's outlet node instead of `node`
+            schedule_name: SetpointManagerScheduled setpoint schedule
+            cooling_schedule_name: Dual setpoint high (cooling) schedule
+            heating_schedule_name: Dual setpoint low (heating) schedule
+            control_zone_name: SingleZoneReheat control zone
+            control_variable: Scheduled only — "Temperature" (default), "HumidityRatio", ...
+            replace_existing: Replace a same-control-variable SPM already on the node
+
+        Returns:
+            JSON: name, spm_type, control_variable, loop, loop_type, node_name, replaced,
+            setpoint_managers_on_node
+        """
+        return json.dumps(setpoint_managers.add_setpoint_manager(
+            spm_type=spm_type, name=name, air_loop_name=air_loop_name,
+            plant_loop_name=plant_loop_name, node=node, after_component=after_component,
+            schedule_name=schedule_name, cooling_schedule_name=cooling_schedule_name,
+            heating_schedule_name=heating_schedule_name, control_zone_name=control_zone_name,
+            control_variable=control_variable, replace_existing=replace_existing,
+        ), indent=2)
+
+    @mcp.tool(tags={"hvac"}, name="remove_setpoint_manager")
+    def remove_setpoint_manager_tool(name: str) -> str:
+        """Delete a setpoint manager by name (any of the 7 supported types).
+
+        Other setpoint managers on the same node are untouched. If the node is a
+        loop's supply outlet and no Temperature setpoint manager remains, the
+        response carries a warning: EnergyPlus will not simulate that loop until
+        add_setpoint_manager puts one back.
+
+        Args:
+            name: Exact setpoint manager name (see get_air_loop_details / list_model_objects)
+
+        Returns:
+            JSON: removed, spm_type, node_name, remaining_on_node, warnings
+        """
+        return json.dumps(setpoint_managers.remove_setpoint_manager(name=name), indent=2)

--- a/tests/doc_contract_lib.py
+++ b/tests/doc_contract_lib.py
@@ -82,7 +82,9 @@ def parse_tools_source(src: str, package: str) -> list[ToolSig]:
 def load_tool_registry() -> dict[str, ToolSig]:
     """Registry of every MCP tool, AST-parsed from mcp_server/skills."""
     registry: dict[str, ToolSig] = {}
-    for tools_py in sorted(SKILLS_SRC.glob("*/tools.py")):
+    # tools*.py: a skill may split registrations across sibling modules
+    # (loop_operations/tools_air_loop.py) to stay under the file-size limit
+    for tools_py in sorted(SKILLS_SRC.glob("*/tools*.py")):
         for sig in parse_tools_source(
             tools_py.read_text(encoding="utf-8"), tools_py.parent.name,
         ):

--- a/tests/eval_tool_selection.py
+++ b/tests/eval_tool_selection.py
@@ -24,11 +24,12 @@ def _load_all_tool_docstrings() -> dict[str, str]:
     """Load all tool names and docstrings from skills."""
     tools: dict[str, str] = {}
     skills_dir = Path(__file__).resolve().parent.parent / "mcp_server" / "skills"
-    for tools_py in sorted(skills_dir.rglob("tools.py")):
-        text = tools_py.read_text()
-        # Extract @mcp.tool(name="...") and following docstring
+    # tools*.py: registrations may be split across sibling modules; the decorator's
+    # keyword order varies (tags first is the common form), so match name= anywhere
+    for tools_py in sorted(skills_dir.rglob("tools*.py")):
+        text = tools_py.read_text(encoding="utf-8")
         for m in re.finditer(
-            r'@mcp\.tool\(name="([^"]+)"\)\s*\n\s*def \w+\([^)]*\)(?:\s*->[^:]+)?:\s*\n\s*"""(.*?)"""',
+            r'@mcp\.tool\([^)]*name="([^"]+)"[^)]*\)\s*\n\s*def \w+\([^)]*\)(?:\s*->[^:]+)?:\s*\n\s*"""(.*?)"""',
             text,
             re.DOTALL,
         ):
@@ -141,6 +142,8 @@ EVAL_CASES = [
     ("add a heating coil to the air loop supply branch", "add_air_loop_supply_component"),
     ("remove the fan from the air loop", "remove_air_loop_supply_component"),
     ("replace the cooling coil on the air loop", "replace_air_loop_supply_component"),
+    ("add a setpoint manager to the loop supply outlet", "add_setpoint_manager"),
+    ("remove a setpoint manager", "remove_setpoint_manager"),
     ("remove zone equipment", "remove_zone_equipment"),
     ("remove all zone equipment batch", "remove_all_zone_equipment"),
     # Object management

--- a/tests/test_add_setpoint_manager.py
+++ b/tests/test_add_setpoint_manager.py
@@ -1,0 +1,411 @@
+"""Integration tests for add_setpoint_manager / remove_setpoint_manager (follow-up to #148).
+
+stdio through the MCP server for the tool contract; in-process for node-placement
+assertions that need the SPM's setpointNode() handle.
+
+SDK facts (dev/issue149-probes/probe_spm_collision.py, OpenStudio 3.11.0):
+SetpointManager.addToNode silently deletes a same-control-variable SPM already on the
+node; different control variables coexist; air-loop-only types return False on a
+plant node and attach nothing; spm.remove() leaves the node's other SPMs alone.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from conftest import create_baseline_and_load, integration_enabled, server_params, unwrap
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not integration_enabled(), reason="integration disabled"),
+]
+
+
+def _unique(prefix: str = "spm") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+async def _sys7(s, name: str) -> tuple[list[str], str, str]:
+    """Baseline 10-zone model + System 7 (VAV, CHW + HW + condenser). Returns (zones, hw, chw)."""
+    zones = await create_baseline_and_load(s, name)
+    res = unwrap(await s.call_tool("add_baseline_system", {
+        "system_type": 7, "thermal_zone_names": zones, "system_name": "VAV7",
+    }))
+    assert res["ok"] is True, res
+    loops = unwrap(await s.call_tool("list_plant_loops", {}))["plant_loops"]
+    names = [pl["name"] for pl in loops]
+    hw = next(n for n in names if "hot" in n.lower() or "hw" in n.lower())
+    chw = next(n for n in names if "chilled" in n.lower() or "chw" in n.lower())
+    return zones, hw, chw
+
+
+async def _schedule(s, name: str, value: float, schedule_type: str = "Temperature") -> str:
+    res = unwrap(await s.call_tool("create_schedule_ruleset", {
+        "name": name, "schedule_type": schedule_type, "default_value": value,
+    }))
+    assert res["ok"] is True, res
+    return name
+
+
+async def _outlet_spms(s, loop_name: str) -> list[dict]:
+    res = unwrap(await s.call_tool("get_air_loop_details", {"air_loop_name": loop_name}))
+    assert res["ok"] is True, res
+    return res["air_loop"]["setpoint_managers"]
+
+
+# ── add: every supported type ────────────────────────────────────────────
+
+AIR_TYPES = [
+    ("SetpointManagerScheduled", {"schedule_name": "SAT Sched"}),
+    ("SetpointManagerScheduledDualSetpoint",
+     {"cooling_schedule_name": "SAT Sched", "heating_schedule_name": "SAT Sched"}),
+    ("SetpointManagerSingleZoneReheat", {"control_zone_name": "<zone0>"}),
+    ("SetpointManagerWarmest", {}),
+    ("SetpointManagerColdest", {}),
+    ("SetpointManagerFollowOutdoorAirTemperature", {}),
+    ("SetpointManagerOutdoorAirReset", {}),
+]
+
+
+@pytest.mark.parametrize(("spm_type", "extra"), AIR_TYPES, ids=[t for t, _ in AIR_TYPES])
+def test_add_each_type_on_air_loop_supply_inlet(spm_type, extra):
+    # Validates: all 7 types construct with their required args, land on the requested node,
+    # and are readable back through get_setpoint_manager_properties as that type
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                zones, _hw, _chw = await _sys7(s, _unique())
+                await _schedule(s, "SAT Sched", 12.8)
+                args = {k: (zones[0] if v == "<zone0>" else v) for k, v in extra.items()}
+                res = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": spm_type, "name": "New SPM", "air_loop_name": "VAV7",
+                    "node": "supply_inlet", **args,
+                }))
+                assert res["ok"] is True, res
+                assert res["spm_type"] == spm_type
+                assert res["loop"] == "VAV7" and res["loop_type"] == "air"
+                assert res["control_variable"] == "Temperature"
+                assert res["replaced"] is None
+                assert res["setpoint_managers_on_node"] == ["New SPM"]
+                props = unwrap(await s.call_tool("get_setpoint_manager_properties", {"setpoint_name": "New SPM"}))
+                assert props["ok"] is True, props
+                assert props["type"] == spm_type
+                # The builder's outlet SPM is untouched
+                assert len(await _outlet_spms(s, "VAV7")) == 1
+    asyncio.run(_run())
+
+
+def test_add_scheduled_on_plant_loop_inlet():
+    # Validates: plant loops accept Scheduled SPMs on any of their nodes and the response
+    # names the plant loop; loop_type distinguishes it from air loops
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                _zones, hw, _chw = await _sys7(s, _unique())
+                await _schedule(s, "HW Sched", 60.0)
+                res = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerScheduled", "name": "HW Inlet SPM",
+                    "plant_loop_name": hw, "node": "supply_inlet", "schedule_name": "HW Sched",
+                }))
+                assert res["ok"] is True, res
+                assert res["loop"] == hw and res["loop_type"] == "plant"
+                assert res["setpoint_managers_on_node"] == ["HW Inlet SPM"]
+    asyncio.run(_run())
+
+
+def test_add_on_mixed_air_node():
+    # Validates: node="mixed_air" resolves the OA system's mixed-air node. The baseline
+    # builders put the OA system LAST on the branch, so on System 7 that node is the supply
+    # outlet itself and already carries the builder's Temperature SPM: a Temperature SPM is
+    # refused by name, while a HumidityRatio SPM lands beside it without a flag
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _sys7(s, _unique())
+                await _schedule(s, "Hum Sched", 0.008, "Fractional")
+                outlet_spm = (await _outlet_spms(s, "VAV7"))[0]["name"]
+                refused = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerOutdoorAirReset", "name": "Mixed Air SPM",
+                    "air_loop_name": "VAV7", "node": "mixed_air",
+                }))
+                assert refused["ok"] is False, refused
+                assert outlet_spm in refused["error"], refused["error"]
+
+                res = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerScheduled", "name": "Mixed Air Hum SPM",
+                    "air_loop_name": "VAV7", "node": "mixed_air", "schedule_name": "Hum Sched",
+                    "control_variable": "HumidityRatio",
+                }))
+                assert res["ok"] is True, res
+                assert res["control_variable"] == "HumidityRatio" and res["replaced"] is None
+                assert "Mixed Air Hum SPM" in res["setpoint_managers_on_node"]
+                assert len(res["setpoint_managers_on_node"]) == 2, res["setpoint_managers_on_node"]
+    asyncio.run(_run())
+
+
+# ── collision guard ──────────────────────────────────────────────────────
+
+def test_collision_refused_by_default_then_replaced_with_flag():
+    # Regression: SDK addToNode silently deletes a same-control-variable SPM on the target
+    # node — the tool must refuse first (nothing deleted, nothing created), then replace
+    # only when asked and report what it replaced
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _sys7(s, _unique())
+                before = await _outlet_spms(s, "VAV7")
+                assert len(before) == 1, before
+                old_name = before[0]["name"]
+
+                refused = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerOutdoorAirReset", "name": "SAT Reset",
+                    "air_loop_name": "VAV7",
+                }))
+                assert refused["ok"] is False, refused
+                assert old_name in refused["error"] and "replace_existing=True" in refused["error"]
+                assert await _outlet_spms(s, "VAV7") == before, "refusal must not touch the node"
+                orphan = unwrap(await s.call_tool("list_model_objects", {
+                    "object_type": "SetpointManagerOutdoorAirReset", "max_results": 0,
+                }))
+                assert orphan["objects"] == [], "refusal must not leave a detached SPM behind"
+
+                replaced = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerOutdoorAirReset", "name": "SAT Reset",
+                    "air_loop_name": "VAV7", "replace_existing": True,
+                }))
+                assert replaced["ok"] is True, replaced
+                assert replaced["replaced"] == old_name
+                after = await _outlet_spms(s, "VAV7")
+                assert after == [{"type": "OS_SetpointManager_OutdoorAirReset", "name": "SAT Reset"}]
+                gone = unwrap(await s.call_tool("get_setpoint_manager_properties", {"setpoint_name": old_name}))
+                assert gone["ok"] is False and "not found" in gone["error"]
+    asyncio.run(_run())
+
+
+def test_different_control_variables_coexist_without_flag():
+    # Validates: a HumidityRatio SPM next to the Temperature SPM needs no replace_existing —
+    # only same-control-variable pairs collide
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _sys7(s, _unique())
+                await _schedule(s, "Hum Sched", 0.008, "Fractional")
+                before = await _outlet_spms(s, "VAV7")
+                res = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerScheduled", "name": "Hum SPM",
+                    "air_loop_name": "VAV7", "schedule_name": "Hum Sched",
+                    "control_variable": "HumidityRatio",
+                }))
+                assert res["ok"] is True, res
+                assert res["control_variable"] == "HumidityRatio"
+                assert res["replaced"] is None
+                assert sorted(res["setpoint_managers_on_node"]) == sorted([before[0]["name"], "Hum SPM"])
+    asyncio.run(_run())
+
+
+# ── refusals ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(("args", "needle"), [
+    ({"spm_type": "SetpointManagerScheduled", "air_loop_name": "VAV7", "node": "supply_inlet"},
+     "requires schedule_name"),
+    ({"spm_type": "SetpointManagerScheduledDualSetpoint", "air_loop_name": "VAV7", "node": "supply_inlet",
+      "cooling_schedule_name": "SAT Sched"}, "requires heating_schedule_name"),
+    ({"spm_type": "SetpointManagerSingleZoneReheat", "air_loop_name": "VAV7", "node": "supply_inlet"},
+     "requires control_zone_name"),
+    ({"spm_type": "SetpointManagerWarmest", "plant_loop_name": "<hw>"}, "air-loop only"),
+    ({"spm_type": "SetpointManagerScheduled", "schedule_name": "SAT Sched"}, "exactly one of"),
+    ({"spm_type": "SetpointManagerScheduled", "schedule_name": "SAT Sched", "air_loop_name": "VAV7",
+      "plant_loop_name": "<hw>"}, "exactly one of"),
+    ({"spm_type": "SetpointManagerScheduled", "schedule_name": "Nope", "air_loop_name": "VAV7",
+      "node": "supply_inlet"}, "Schedule 'Nope' not found"),
+    ({"spm_type": "SetpointManagerOutdoorAirReset", "plant_loop_name": "<hw>", "node": "mixed_air"},
+     "only exists on an air loop"),
+    ({"spm_type": "SetpointManagerOutdoorAirReset", "air_loop_name": "VAV7", "after_component": "Nope"},
+     "not found on the supply side"),
+    ({"spm_type": "SetpointManagerBogus", "air_loop_name": "VAV7"}, "Unknown spm_type"),
+    ({"spm_type": "SetpointManagerWarmest", "air_loop_name": "VAV7", "node": "supply_inlet",
+      "control_variable": "HumidityRatio"}, "only settable on SetpointManagerScheduled"),
+])
+def test_add_refusals_name_the_problem(args, needle):
+    # Validates: every refusal names the missing arg / bad target, and creates nothing
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                _zones, hw, _chw = await _sys7(s, _unique())
+                await _schedule(s, "SAT Sched", 12.8)
+                call = {"name": "Bad SPM", **{k: (hw if v == "<hw>" else v) for k, v in args.items()}}
+                res = unwrap(await s.call_tool("add_setpoint_manager", call))
+                assert res["ok"] is False, res
+                assert needle in res["error"], res["error"]
+                gone = unwrap(await s.call_tool("get_setpoint_manager_properties", {"setpoint_name": "Bad SPM"}))
+                assert gone["ok"] is False, "refusal must not create the SPM"
+    asyncio.run(_run())
+
+
+# ── remove ───────────────────────────────────────────────────────────────
+
+def test_remove_leaves_other_spms_on_node():
+    # Validates: removing one SPM reports the node and the exact survivors; no warning when a
+    # Temperature SPM still controls the outlet
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _sys7(s, _unique())
+                await _schedule(s, "Hum Sched", 0.008, "Fractional")
+                keep = (await _outlet_spms(s, "VAV7"))[0]["name"]
+                unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerScheduled", "name": "Hum SPM", "air_loop_name": "VAV7",
+                    "schedule_name": "Hum Sched", "control_variable": "HumidityRatio",
+                }))
+                res = unwrap(await s.call_tool("remove_setpoint_manager", {"name": "Hum SPM"}))
+                assert res["ok"] is True, res
+                assert res["removed"] == "Hum SPM" and res["spm_type"] == "SetpointManagerScheduled"
+                assert res["remaining_on_node"] == [keep]
+                assert "warnings" not in res
+                assert [m["name"] for m in await _outlet_spms(s, "VAV7")] == [keep]
+    asyncio.run(_run())
+
+
+def test_remove_only_temperature_spm_on_outlet_warns():
+    # Validates: deleting the last Temperature SPM on a loop supply outlet succeeds but warns —
+    # EnergyPlus refuses to simulate a loop without one
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _sys7(s, _unique())
+                only = (await _outlet_spms(s, "VAV7"))[0]["name"]
+                res = unwrap(await s.call_tool("remove_setpoint_manager", {"name": only}))
+                assert res["ok"] is True, res
+                assert res["remaining_on_node"] == []
+                assert "no Temperature setpoint manager" in res["warnings"][0]
+                assert "VAV7" in res["warnings"][0]
+                assert await _outlet_spms(s, "VAV7") == []
+                missing = unwrap(await s.call_tool("remove_setpoint_manager", {"name": only}))
+                assert missing["ok"] is False and "not found" in missing["error"]
+    asyncio.run(_run())
+
+
+# ── in-process: node placement ───────────────────────────────────────────
+
+@pytest.fixture
+def inproc_loop(tmp_path: Path):
+    """Empty model in model_manager + air loop  Clg → Htg → Fan  with a coil to anchor on."""
+    if not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"):
+        pytest.skip("requires OpenStudio")
+    import openstudio
+
+    from mcp_server.model_manager import clear_model, load_model
+
+    osm = tmp_path / "spm.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(osm)), True)
+    model = load_model(osm)
+    loop = openstudio.model.AirLoopHVAC(model)
+    loop.setName("Loop")
+    always_on = model.alwaysOnDiscreteSchedule()
+    clg = openstudio.model.CoilCoolingDXSingleSpeed(model)
+    clg.setName("Clg")
+    htg = openstudio.model.CoilHeatingElectric(model, always_on)
+    htg.setName("Htg")
+    fan = openstudio.model.FanVariableVolume(model, always_on)
+    fan.setName("Fan")
+    for comp in (clg, htg, fan):
+        assert comp.addToNode(loop.supplyOutletNode())
+    yield model, loop
+    clear_model()
+
+
+def test_after_component_places_spm_on_that_outlet_node(inproc_loop):
+    # Validates: after_component=<coil> resolves the coil's OUTLET node (the node between it
+    # and the next component), not the loop outlet
+    from mcp_server.skills.loop_operations.setpoint_managers import add_setpoint_manager
+    model, loop = inproc_loop
+    clg = model.getCoilCoolingDXSingleSpeedByName("Clg").get()
+    clg_outlet = clg.outletModelObject().get().to_Node().get()
+
+    res = add_setpoint_manager("SetpointManagerOutdoorAirReset", "Coil Leaving SPM",
+                               air_loop_name="Loop", after_component="Clg")
+
+    assert res["ok"] is True, res
+    assert res["node_name"] == clg_outlet.nameString()
+    spm = model.getSetpointManagerOutdoorAirResetByName("Coil Leaving SPM").get()
+    assert spm.setpointNode().get().handle() == clg_outlet.handle()
+    assert loop.supplyOutletNode().setpointManagers().__len__() == 0, "loop outlet untouched"
+
+
+def test_replace_existing_deletes_exactly_the_colliding_spm(inproc_loop):
+    # Regression: the SDK deletes the colliding SPM from the MODEL, not just the node; the
+    # tool must report it and leave a different-control-variable neighbour alone
+    import openstudio
+
+    from mcp_server.skills.loop_operations.setpoint_managers import add_setpoint_manager
+    model, loop = inproc_loop
+    outlet = loop.supplyOutletNode()
+    sch = openstudio.model.ScheduleConstant(model)
+    sch.setValue(12.8)
+    temp = openstudio.model.SetpointManagerScheduled(model, sch)
+    temp.setName("Old Temp")
+    assert temp.addToNode(outlet)
+    hum = openstudio.model.SetpointManagerScheduled(model, sch)
+    hum.setName("Hum")
+    assert hum.setControlVariable("HumidityRatio") and hum.addToNode(outlet)
+
+    res = add_setpoint_manager("SetpointManagerWarmest", "Warmest", air_loop_name="Loop",
+                               replace_existing=True)
+
+    assert res["ok"] is True, res
+    assert res["replaced"] == "Old Temp"
+    assert sorted(res["setpoint_managers_on_node"]) == ["Hum", "Warmest"]
+    assert not model.getObject(temp.handle()).is_initialized(), "old Temperature SPM is gone"
+    assert model.getObject(hum.handle()).is_initialized(), "HumidityRatio neighbour survives"
+
+
+# ── refusals must not leave orphans (review finding) ─────────────────────
+
+@pytest.mark.parametrize(("call", "needle", "obj_type"), [
+    ({"spm_type": "SetpointManagerScheduled", "schedule_name": "Frac Sched"},
+     "type limits incompatible with control variable 'Temperature'", "SetpointManagerScheduled"),
+    ({"spm_type": "SetpointManagerScheduled", "schedule_name": "SAT Sched", "control_variable": "Bogus"},
+     "not a valid control variable", "SetpointManagerScheduled"),
+    ({"spm_type": "SetpointManagerScheduledDualSetpoint", "cooling_schedule_name": "Frac Sched",
+      "heating_schedule_name": "SAT Sched"},
+     "'Frac Sched' is not a temperature schedule (cooling_schedule_name)", "SetpointManagerScheduledDualSetpoint"),
+    ({"spm_type": "SetpointManagerScheduledDualSetpoint", "cooling_schedule_name": "SAT Sched",
+      "heating_schedule_name": "Frac Sched"},
+     "'Frac Sched' is not a temperature schedule (heating_schedule_name)", "SetpointManagerScheduledDualSetpoint"),
+])
+def test_schedule_type_refusals_leave_no_orphan_spm(call, needle, obj_type):
+    # Regression: SetpointManagerScheduled's constructor throws on a schedule whose type limits
+    # do not fit the control variable and leaves the half-built SPM in the model; the dual
+    # setpoint setters return False and leave the slot empty (probe_spm_ctor_orphan.py). The
+    # tool must roll back so a refusal leaves the SPM count unchanged
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                await _sys7(s, _unique())
+                await _schedule(s, "SAT Sched", 12.8)
+                await _schedule(s, "Frac Sched", 0.5, "Fractional")
+                before = unwrap(await s.call_tool("list_model_objects", {"object_type": obj_type, "max_results": 0}))
+                res = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "name": "Orphan?", "air_loop_name": "VAV7", "node": "supply_inlet", **call,
+                }))
+                assert res["ok"] is False, res
+                assert needle in res["error"], res["error"]
+                after = unwrap(await s.call_tool("list_model_objects", {"object_type": obj_type, "max_results": 0}))
+                assert after["count"] == before["count"], (
+                    f"refusal left {after['count'] - before['count']} orphan {obj_type}(s)"
+                )
+    asyncio.run(_run())

--- a/tests/test_add_setpoint_manager.py
+++ b/tests/test_add_setpoint_manager.py
@@ -1,7 +1,8 @@
 """Integration tests for add_setpoint_manager / remove_setpoint_manager (follow-up to #148).
 
-stdio through the MCP server for the tool contract; in-process for node-placement
-assertions that need the SPM's setpointNode() handle.
+stdio through the MCP server for the tool contract. The in-process node-placement
+assertions (which need the SPM's setpointNode() handle) live in
+test_add_setpoint_manager_placement.py.
 
 SDK facts (dev/issue149-probes/probe_spm_collision.py, OpenStudio 3.11.0):
 SetpointManager.addToNode silently deletes a same-control-variable SPM already on the
@@ -11,9 +12,7 @@ plant node and attach nothing; spm.remove() leaves the node's other SPMs alone.
 from __future__ import annotations
 
 import asyncio
-import os
 import uuid
-from pathlib import Path
 
 import pytest
 from conftest import create_baseline_and_load, integration_enabled, server_params, unwrap
@@ -64,7 +63,7 @@ AIR_TYPES = [
     ("SetpointManagerScheduled", {"schedule_name": "SAT Sched"}),
     ("SetpointManagerScheduledDualSetpoint",
      {"cooling_schedule_name": "SAT Sched", "heating_schedule_name": "SAT Sched"}),
-    ("SetpointManagerSingleZoneReheat", {"control_zone_name": "<zone0>"}),
+    ("SetpointManagerSingleZoneReheat", {"control_zone_name": "<zone_last>"}),
     ("SetpointManagerWarmest", {}),
     ("SetpointManagerColdest", {}),
     ("SetpointManagerFollowOutdoorAirTemperature", {}),
@@ -82,7 +81,7 @@ def test_add_each_type_on_air_loop_supply_inlet(spm_type, extra):
                 await s.initialize()
                 zones, _hw, _chw = await _sys7(s, _unique())
                 await _schedule(s, "SAT Sched", 12.8)
-                args = {k: (zones[0] if v == "<zone0>" else v) for k, v in extra.items()}
+                args = {k: (zones[-1] if v == "<zone_last>" else v) for k, v in extra.items()}
                 res = unwrap(await s.call_tool("add_setpoint_manager", {
                     "spm_type": spm_type, "name": "New SPM", "air_loop_name": "VAV7",
                     "node": "supply_inlet", **args,
@@ -93,6 +92,8 @@ def test_add_each_type_on_air_loop_supply_inlet(spm_type, extra):
                 assert res["control_variable"] == "Temperature"
                 assert res["replaced"] is None
                 assert res["setpoint_managers_on_node"] == ["New SPM"]
+                expected_zone = zones[-1] if spm_type == "SetpointManagerSingleZoneReheat" else None
+                assert res["control_zone"] == expected_zone, res
                 props = unwrap(await s.call_tool("get_setpoint_manager_properties", {"setpoint_name": "New SPM"}))
                 assert props["ok"] is True, props
                 assert props["type"] == spm_type
@@ -148,6 +149,32 @@ def test_add_on_mixed_air_node():
                 assert res["control_variable"] == "HumidityRatio" and res["replaced"] is None
                 assert "Mixed Air Hum SPM" in res["setpoint_managers_on_node"]
                 assert len(res["setpoint_managers_on_node"]) == 2, res["setpoint_managers_on_node"]
+    asyncio.run(_run())
+
+
+def test_single_zone_reheat_keeps_requested_non_first_control_zone():
+    # Regression: SetpointManagerSingleZoneReheat.addToNode overwrites the control zone with the
+    # loop's FIRST demand zone (probe_szr_control_zone.py), so a zone set before attaching was
+    # silently replaced on any multi-zone loop. The tool must set it after attaching and the
+    # property reader must show the zone that was asked for
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                zones, _hw, _chw = await _sys7(s, _unique())
+                assert len(zones) == 10, zones
+                wanted = zones[7]
+                res = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerSingleZoneReheat", "name": "SZR Zone 7",
+                    "air_loop_name": "VAV7", "node": "supply_inlet", "control_zone_name": wanted,
+                }))
+                assert res["ok"] is True, res
+                assert res["control_zone"] == wanted
+                props = unwrap(await s.call_tool("get_setpoint_manager_properties", {"setpoint_name": "SZR Zone 7"}))
+                assert props["ok"] is True, props
+                assert props["properties"]["control_zone"]["value"] == wanted, (
+                    f"control zone reset to first zone {zones[0]!r}? got {props['properties']['control_zone']}"
+                )
     asyncio.run(_run())
 
 
@@ -296,80 +323,6 @@ def test_remove_only_temperature_spm_on_outlet_warns():
                 missing = unwrap(await s.call_tool("remove_setpoint_manager", {"name": only}))
                 assert missing["ok"] is False and "not found" in missing["error"]
     asyncio.run(_run())
-
-
-# ── in-process: node placement ───────────────────────────────────────────
-
-@pytest.fixture
-def inproc_loop(tmp_path: Path):
-    """Empty model in model_manager + air loop  Clg → Htg → Fan  with a coil to anchor on."""
-    if not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"):
-        pytest.skip("requires OpenStudio")
-    import openstudio
-
-    from mcp_server.model_manager import clear_model, load_model
-
-    osm = tmp_path / "spm.osm"
-    openstudio.model.Model().save(openstudio.toPath(str(osm)), True)
-    model = load_model(osm)
-    loop = openstudio.model.AirLoopHVAC(model)
-    loop.setName("Loop")
-    always_on = model.alwaysOnDiscreteSchedule()
-    clg = openstudio.model.CoilCoolingDXSingleSpeed(model)
-    clg.setName("Clg")
-    htg = openstudio.model.CoilHeatingElectric(model, always_on)
-    htg.setName("Htg")
-    fan = openstudio.model.FanVariableVolume(model, always_on)
-    fan.setName("Fan")
-    for comp in (clg, htg, fan):
-        assert comp.addToNode(loop.supplyOutletNode())
-    yield model, loop
-    clear_model()
-
-
-def test_after_component_places_spm_on_that_outlet_node(inproc_loop):
-    # Validates: after_component=<coil> resolves the coil's OUTLET node (the node between it
-    # and the next component), not the loop outlet
-    from mcp_server.skills.loop_operations.setpoint_managers import add_setpoint_manager
-    model, loop = inproc_loop
-    clg = model.getCoilCoolingDXSingleSpeedByName("Clg").get()
-    clg_outlet = clg.outletModelObject().get().to_Node().get()
-
-    res = add_setpoint_manager("SetpointManagerOutdoorAirReset", "Coil Leaving SPM",
-                               air_loop_name="Loop", after_component="Clg")
-
-    assert res["ok"] is True, res
-    assert res["node_name"] == clg_outlet.nameString()
-    spm = model.getSetpointManagerOutdoorAirResetByName("Coil Leaving SPM").get()
-    assert spm.setpointNode().get().handle() == clg_outlet.handle()
-    assert loop.supplyOutletNode().setpointManagers().__len__() == 0, "loop outlet untouched"
-
-
-def test_replace_existing_deletes_exactly_the_colliding_spm(inproc_loop):
-    # Regression: the SDK deletes the colliding SPM from the MODEL, not just the node; the
-    # tool must report it and leave a different-control-variable neighbour alone
-    import openstudio
-
-    from mcp_server.skills.loop_operations.setpoint_managers import add_setpoint_manager
-    model, loop = inproc_loop
-    outlet = loop.supplyOutletNode()
-    sch = openstudio.model.ScheduleConstant(model)
-    sch.setValue(12.8)
-    temp = openstudio.model.SetpointManagerScheduled(model, sch)
-    temp.setName("Old Temp")
-    assert temp.addToNode(outlet)
-    hum = openstudio.model.SetpointManagerScheduled(model, sch)
-    hum.setName("Hum")
-    assert hum.setControlVariable("HumidityRatio") and hum.addToNode(outlet)
-
-    res = add_setpoint_manager("SetpointManagerWarmest", "Warmest", air_loop_name="Loop",
-                               replace_existing=True)
-
-    assert res["ok"] is True, res
-    assert res["replaced"] == "Old Temp"
-    assert sorted(res["setpoint_managers_on_node"]) == ["Hum", "Warmest"]
-    assert not model.getObject(temp.handle()).is_initialized(), "old Temperature SPM is gone"
-    assert model.getObject(hum.handle()).is_initialized(), "HumidityRatio neighbour survives"
 
 
 # ── refusals must not leave orphans (review finding) ─────────────────────

--- a/tests/test_add_setpoint_manager_placement.py
+++ b/tests/test_add_setpoint_manager_placement.py
@@ -1,0 +1,92 @@
+"""In-process node-placement tests for add_setpoint_manager (follow-up to #148).
+
+Split from test_add_setpoint_manager.py (stdio contract tests) to stay under the
+file-size limit. These call the operation directly because they assert on the
+SPM's setpointNode() handle and on object handles the SDK deletes.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from conftest import integration_enabled
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not integration_enabled(), reason="integration disabled"),
+]
+
+
+# ── in-process: node placement ───────────────────────────────────────────
+
+@pytest.fixture
+def inproc_loop(tmp_path: Path):
+    """Empty model in model_manager + air loop  Clg → Htg → Fan  with a coil to anchor on."""
+    if not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"):
+        pytest.skip("requires OpenStudio")
+    import openstudio
+
+    from mcp_server.model_manager import clear_model, load_model
+
+    osm = tmp_path / "spm.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(osm)), True)
+    model = load_model(osm)
+    loop = openstudio.model.AirLoopHVAC(model)
+    loop.setName("Loop")
+    always_on = model.alwaysOnDiscreteSchedule()
+    clg = openstudio.model.CoilCoolingDXSingleSpeed(model)
+    clg.setName("Clg")
+    htg = openstudio.model.CoilHeatingElectric(model, always_on)
+    htg.setName("Htg")
+    fan = openstudio.model.FanVariableVolume(model, always_on)
+    fan.setName("Fan")
+    for comp in (clg, htg, fan):
+        assert comp.addToNode(loop.supplyOutletNode())
+    yield model, loop
+    clear_model()
+
+
+def test_after_component_places_spm_on_that_outlet_node(inproc_loop):
+    # Validates: after_component=<coil> resolves the coil's OUTLET node (the node between it
+    # and the next component), not the loop outlet
+    from mcp_server.skills.loop_operations.setpoint_managers import add_setpoint_manager
+    model, loop = inproc_loop
+    clg = model.getCoilCoolingDXSingleSpeedByName("Clg").get()
+    clg_outlet = clg.outletModelObject().get().to_Node().get()
+
+    res = add_setpoint_manager("SetpointManagerOutdoorAirReset", "Coil Leaving SPM",
+                               air_loop_name="Loop", after_component="Clg")
+
+    assert res["ok"] is True, res
+    assert res["node_name"] == clg_outlet.nameString()
+    spm = model.getSetpointManagerOutdoorAirResetByName("Coil Leaving SPM").get()
+    assert spm.setpointNode().get().handle() == clg_outlet.handle()
+    assert loop.supplyOutletNode().setpointManagers().__len__() == 0, "loop outlet untouched"
+
+
+def test_replace_existing_deletes_exactly_the_colliding_spm(inproc_loop):
+    # Regression: the SDK deletes the colliding SPM from the MODEL, not just the node; the
+    # tool must report it and leave a different-control-variable neighbour alone
+    import openstudio
+
+    from mcp_server.skills.loop_operations.setpoint_managers import add_setpoint_manager
+    model, loop = inproc_loop
+    outlet = loop.supplyOutletNode()
+    sch = openstudio.model.ScheduleConstant(model)
+    sch.setValue(12.8)
+    temp = openstudio.model.SetpointManagerScheduled(model, sch)
+    temp.setName("Old Temp")
+    assert temp.addToNode(outlet)
+    hum = openstudio.model.SetpointManagerScheduled(model, sch)
+    hum.setName("Hum")
+    assert hum.setControlVariable("HumidityRatio") and hum.addToNode(outlet)
+
+    res = add_setpoint_manager("SetpointManagerWarmest", "Warmest", air_loop_name="Loop",
+                               replace_existing=True)
+
+    assert res["ok"] is True, res
+    assert res["replaced"] == "Old Temp"
+    assert sorted(res["setpoint_managers_on_node"]) == ["Hum", "Warmest"]
+    assert not model.getObject(temp.handle()).is_initialized(), "old Temperature SPM is gone"
+    assert model.getObject(hum.handle()).is_initialized(), "HumidityRatio neighbour survives"

--- a/tests/test_hvac_supply_sim.py
+++ b/tests/test_hvac_supply_sim.py
@@ -15,6 +15,7 @@ Configurations tested:
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 
 import pytest
@@ -340,6 +341,54 @@ def test_replaced_supply_branch_components_simulate():
                                      "OS_Fan_VariableVolume", "OS_AirLoopHVAC_OutdoorAirSystem"], types
                     swapped += 1
                 assert swapped == 10
+
+                await _save_run_and_check(s, name)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# 7. Outlet setpoint manager swapped for outdoor-air reset — loop still simulates
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_replaced_outlet_setpoint_manager_simulates():
+    """System 7 with its outlet SPM replaced by OutdoorAirReset + tuned → EnergyPlus completes."""
+    # Validates: add_setpoint_manager(replace_existing=True) + set_setpoint_manager_properties
+    # leave a loop EnergyPlus accepts (one Temperature SPM on the outlet), no fatal/severe
+    name = f"sim_spm_{uuid.uuid4().hex[:8]}"
+
+    async def _run():
+        async with stdio_client(server_params()) as (r, w):
+            async with ClientSession(r, w) as s:
+                await s.initialize()
+                zone_names = await _setup_baseline(s, name)
+                sys7 = unwrap(await s.call_tool("add_baseline_system", {
+                    "system_type": 7, "thermal_zone_names": zone_names, "system_name": "VAV7 Sim",
+                }))
+                assert sys7["ok"] is True, sys7
+                before = unwrap(await s.call_tool("get_air_loop_details", {"air_loop_name": "VAV7 Sim"}))
+                old = before["air_loop"]["setpoint_managers"]
+                assert len(old) == 1, old
+
+                added = unwrap(await s.call_tool("add_setpoint_manager", {
+                    "spm_type": "SetpointManagerOutdoorAirReset", "name": "VAV7 SAT Reset",
+                    "air_loop_name": "VAV7 Sim", "replace_existing": True,
+                }))
+                assert added["ok"] is True, added
+                assert added["replaced"] == old[0]["name"]
+                tuned = unwrap(await s.call_tool("set_setpoint_manager_properties", {
+                    "setpoint_name": "VAV7 SAT Reset",
+                    "properties": json.dumps({
+                        "setpoint_at_outdoor_low_temperature": 15.6, "outdoor_low_temperature": 10.0,
+                        "setpoint_at_outdoor_high_temperature": 12.8, "outdoor_high_temperature": 21.0,
+                    }),
+                }))
+                assert tuned["ok"] is True, tuned
+                after = unwrap(await s.call_tool("get_air_loop_details", {"air_loop_name": "VAV7 Sim"}))
+                assert after["air_loop"]["setpoint_managers"] == [
+                    {"type": "OS_SetpointManager_OutdoorAirReset", "name": "VAV7 SAT Reset"},
+                ]
 
                 await _save_run_and_check(s, name)
 

--- a/tests/test_skill_registration.py
+++ b/tests/test_skill_registration.py
@@ -94,6 +94,8 @@ EXPECTED_TOOLS = {
     "add_air_loop_supply_component",
     "remove_air_loop_supply_component",
     "replace_air_loop_supply_component",
+    "add_setpoint_manager",
+    "remove_setpoint_manager",
     # Phase 6A: Loads
     "get_load_details",
     "create_people_definition",

--- a/tests/test_tool_routing.py
+++ b/tests/test_tool_routing.py
@@ -93,6 +93,7 @@ ROUTING_CASES = [
     ("add a boiler to the hot water loop", "hvac", "add_supply_equipment"),
     ("replace the cooling coil on the air loop", "hvac", "replace_air_loop_supply_component"),
     ("swap the constant volume fan for a variable speed fan", "hvac", "replace_air_loop_supply_component"),
+    ("add a scheduled setpoint manager to the hot water loop", "hvac", "add_setpoint_manager"),
     ("set chiller COP to 5.5", "hvac", "set_component_properties"),
     ("create a 2-story office building", "core", "create_new_building"),
     ("run an annual simulation", "simulation", "run_simulation"),


### PR DESCRIPTION
Follow-up to #148 (plan: `docs/plans/plan-followup-add-setpoint-manager.md`). Stacked on #155 because it reuses that PR's node-resolution helpers; retarget to develop once #155 merges.

## Why
Removing or replacing a supply-branch component (#148) moves setpoint managers, but nothing could create one on a chosen node. They were only ever built inside whole-system builders, so "add a supply air temperature reset" meant a hand-written measure.

## What changed
New `mcp_server/skills/loop_operations/setpoint_managers.py` (~290 lines), two tools registered from the new `tools_air_loop.py`:

- **`add_setpoint_manager`**: any of the 7 types `get_/set_setpoint_manager_properties` already handle, on an air or plant loop's `supply_outlet` / `supply_inlet` / `mixed_air` node, or `after_component=<coil or fan>`. Explicit constructor branch per type with its required arg (schedule, dual schedules, control zone; optional `control_variable` for Scheduled). Air-loop-only types are refused on plant loops before anything is built.
- **Collision guard**: `SetpointManager.addToNode` silently deletes an SPM already on the node with the same control variable, with no return-value signal. The tool refuses by default (nothing created, nothing deleted), replaces only with `replace_existing=True`, and reports `replaced`. Different control variables coexist without the flag.
- **`remove_setpoint_manager`**: deletes one SPM, returns `remaining_on_node`, and warns when a loop supply outlet is left with no Temperature control (EnergyPlus will not run that loop).

## SDK facts (probed, OpenStudio 3.11.0, `dev/issue149-probes/`)
- `SetpointManagerScheduled(model, schedule)` and the 3-arg form throw on incompatible schedule type limits or an unknown control variable, and leave the half-built SPM in the model. The tool snapshots and rolls back, so a refusal leaves the SPM count unchanged (tested).
- `ScheduledDualSetpoint.setHigh/LowSetpointSchedule` return False on a non-temperature schedule; both are checked.
- In the baseline builders the OA system is last on the branch, so `mixed_air` resolves to the supply outlet node on System 3/7.

## Also in this PR
- `loop_operations/tools.py` split: the #148 and setpoint-manager registrations live in `tools_air_loop.py`, called from `tools.py::register`, keeping both under the size limit. `tests/doc_contract_lib.py` globs `tools*.py` so the AST roster check still sees them.
- `tests/eval_tool_selection.py` loader fixed: it globbed `tools.py` only and its regex required `name=` first, so it loaded no docstrings at all. With docstrings loaded, 73 of 76 cases pass; the 3 failures are stale pre-existing cases (`list building stories` / `list lighting loads` → `list_model_objects`, and the accuracy gate) left for a follow-up. This script is not collected by CI.
- `component_properties`: `_get_spm_scheduled_dual_setpoint_props` called `nameString()` on an `OptionalSchedule` and crashed `get_setpoint_manager_properties` on every dual SPM. Fixed; covered by the per-type test.

## Tests
- `tests/test_add_setpoint_manager.py` (26 + 4 tests; amd64 and arm64 shard 1, `ci.yml` updated): every type, plant and mixed-air placement, collision refuse then replace, coexisting control variables, 11 refusal cases, 4 orphan-free refusals, remove with and without the outlet warning, in-process node placement and replace-exactly-the-collider.
- `tests/test_hvac_supply_sim.py::test_replaced_outlet_setpoint_manager_simulates` (shard 5): System 7 outlet SPM swapped for OutdoorAirReset and tuned, EnergyPlus runs clean.
- Docker: SPM file + component controls 40 passed; loop_operations / air-loop supply / unit suites re-run on the commit.
- Codex review: 3 findings (constructor orphan, unchecked dual setters, eval loader), all verified by probe and fixed.

## Docs
README table (14 tools), `add-hvac` SKILL + eval rows, `tool-workflows` "Supply Air Temperature Reset" recipe. The `.claude/rules/component-types.md` step for new SPM types is local-only (that directory is gitignored).
