### PR TITLE
Add ground temperature and Kiva foundation heat transfer

### DIFF
--- a/.claude/skills/foundation-modeling/SKILL.md
+++ b/.claude/skills/foundation-modeling/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: foundation-modeling
+description: Choose and apply a ground heat transfer method — EPW ground temperatures for a fast approximate answer, or EnergyPlus Kiva for real slab-edge heat transfer. Use when a model has no ground temperatures, when slab or basement heat loss matters, or when the user asks about foundations, slabs, basements or crawlspaces.
+---
+
+# Foundation and ground heat transfer
+
+Two methods, and they are not interchangeable. Pick deliberately.
+
+| | `set_ground_temperatures` | `set_kiva_foundation` |
+|---|---|---|
+| What it does | Writes the four `Site:GroundTemperature:*` objects from the EPW header | Solves a 2D finite-difference soil domain per floor |
+| Needs from the user | Nothing | The foundation type, and ideally real insulation detail |
+| Simulation cost | None | Substantial — one domain per floor |
+| Good for | Screening runs, compliance work, models with no foundation information | Slab-edge loss, basement-dominated buildings, studying the foundation itself |
+
+**Default to the simple method.** Reach for Kiva when the foundation is what the question is about,
+or when the user asks for it. A Kiva surface ignores `Site:GroundTemperature:BuildingSurface`
+entirely, so the two do not stack.
+
+## The simple method
+
+```
+1. set_ground_temperatures()
+```
+
+Resolves the EPW itself — the one `import_gbxml` used, or the model's own weather file. Writes
+`Shallow`, `Deep` and `FCfactorMethod` from the EPW's measured values, and derives
+`BuildingSurface` from the model's heating setpoints.
+
+**Why `BuildingSurface` is not written from the EPW:** those are *undisturbed* soil temperatures, an
+open field with no building on it. The EPW's own `.stat` file says they "should NOT BE USED in the
+GroundTemperatures object to compute building floor losses". Boston's January figure is −0.29 °C;
+writing that under a heated slab overstates the loss badly.
+
+If the model has no thermostats yet, `BuildingSurface` is skipped with a reason — run it again after
+HVAC, or state the value:
+
+```
+2. set_ground_temperatures(building_surface_method="constant", building_surface_constant_c=18.0)
+```
+
+## The detailed method: Kiva
+
+**Always call `get_foundation_options()` first, then ask the user.** Do not pick an archetype for
+them.
+
+```
+1. get_foundation_options()
+```
+
+It reports which floors and below-grade walls EnergyPlus would accept, why each rejected surface was
+rejected, the exposed perimeter computed from the building footprint, how many Kiva domains would be
+created, and the five archetypes **with their full parameter sets**.
+
+### Put the choice to the user
+
+Show them the archetype list with its actual numbers — not just the names. Ask which describes the
+building's foundation:
+
+- **Slab on grade, uninsulated**
+- **Slab on grade with perimeter insulation**
+- **Heated basement, insulated walls**
+- **Unheated basement**
+- **Vented crawlspace**
+
+**Say plainly that the R-values are conventional starting points, not code-derived.** There is no
+vendored source for Kiva insulation geometry, so the archetype numbers are a way to skip a
+ten-question interrogation, not a substitute for knowing the building. Each archetype carries a
+`basis` string saying so, and the response reports the ASHRAE 90.1 F-factor / C-factor target for
+the model's climate zone as a cross-check. If the user knows their real insulation, take it.
+
+### Apply it
+
+```
+2. set_kiva_foundation(archetype="heated_basement_insulated")
+```
+
+Overriding anything the user does know:
+
+```
+3. set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+     exterior_vertical_insulation_r_si=3.52,
+     exterior_vertical_insulation_depth_m=1.2)
+```
+
+Use `dry_run=True` to show the user exactly what would be written before committing:
+
+```
+4. set_kiva_foundation(archetype="unheated_basement", dry_run=True)
+```
+
+## What to check in the result
+
+- **`provenance` on every value** — `user`, `archetype:<name>`, `epw_header`,
+  `openstudio_default`, or `computed_geometry`. Anything marked `archetype:*` is a number nobody
+  sourced; report that to the user rather than presenting the result as measured.
+- **`ground_temperature_interaction`** — if `set_ground_temperatures` ran earlier, this says which
+  surfaces Kiva now governs and whether `BuildingSurface` still applies to anything.
+- **`warnings`** — unpaired below-grade walls, clamped interior bays, missing soil properties.
+
+## Expect refusals, and do not treat them as failures
+
+EnergyPlus is strict about Kiva surfaces, and the tool refuses rather than writing a model that
+fails at run time:
+
+- **Massless construction layers are the most common blocker on a real Revit model.** gbXML slabs
+  routinely carry no-mass layers and EnergyPlus refuses them outright. Fix with
+  `create_standard_opaque_material`, `create_construction` and `assign_construction_to_surface`,
+  then retry. This is normal, not an edge case.
+- Windows or doors on the surface — not allowed with a Foundation boundary condition.
+- Walls with more than four vertices.
+- Surfaces with no parent space.
+- More than 20 eligible floors requires `confirm_many_domains=True`, because that is 20 separate 2D
+  domains and a much slower simulation.
+
+Never set `Foundation` with `set_surface_boundary_conditions` — EnergyPlus also needs a
+`Foundation:Kiva` object and an exposed-perimeter object, and fails fatally without them.
+`set_kiva_foundation` writes all three together, and the other tool refuses the condition for that
+reason.
+
+## After either method
+
+Kiva needs a weather file at simulation time — EnergyPlus will not run it design-day-only. Neither
+tool saves; call `save_osm_model` to persist.

--- a/.claude/skills/foundation-modeling/eval.md
+++ b/.claude/skills/foundation-modeling/eval.md
@@ -1,0 +1,16 @@
+## Should trigger
+| Query | Expected tools | Critical params |
+|---|---|---|
+| "Model the foundation heat transfer properly with Kiva" | get_foundation_options | — |
+| "What foundation modelling options does this model have?" | get_foundation_options | — |
+| "This is a heated basement — set up Kiva for it" | set_kiva_foundation | archetype |
+| "Add R-20 perimeter insulation to the slab and model it with Kiva" | set_kiva_foundation | exterior_vertical_insulation_r_si |
+| "Show me what Kiva would change before applying it" | set_kiva_foundation | dry_run |
+
+## Should NOT trigger
+| Query | Forbidden tools | Expected alternatives |
+|---|---|---|
+| "Set the ground temperatures from the project weather file" | set_kiva_foundation | set_ground_temperatures |
+| "Which surfaces are missing ground contact?" | set_kiva_foundation, get_foundation_options | repair_and_validate_gbxml_geometry |
+| "Make the below-grade walls adiabatic" | set_kiva_foundation | set_surface_boundary_conditions |
+| "What is the EUI of this model?" | get_foundation_options, set_kiva_foundation | extract_summary_metrics |

--- a/.claude/skills/gbxml-import/SKILL.md
+++ b/.claude/skills/gbxml-import/SKILL.md
@@ -87,6 +87,21 @@ left once merge and weld have closed what they can.
   partly below grade gets its above-grade portion buried too. `partially_below_grade` holds walls
   crossing grade with less than half buried — reported, not proposed for a batch fix. `ok` is
   unaffected by any of this, so it will not stop you; check the count yourself.
+- **Check `ground_temperatures_missing`.** A translated model sets none of the four
+  `Site:GroundTemperature:*` objects, so EnergyPlus falls back to its own defaults — 18 °C
+  every month on every `Ground` surface, in Boston and in Austin alike. Report only, `ok` is
+  unaffected, so check the count yourself. Two remedies, and they are not equivalent:
+  `set_ground_temperatures()` reads the project EPW's own header and is instant, but it is
+  approximate — EPW ground temperatures are *undisturbed* soil (the EPW's own `.stat` says they
+  "should NOT BE USED ... to compute building floor losses"), so `Site:GroundTemperature:Shallow`,
+  `:Deep` and `:FCfactorMethod` get the raw values while `BuildingSurface` gets a value derived
+  from the model's heating setpoints. Note what each object actually does: `BuildingSurface`
+  drives the floor heat balance, `Shallow`/`Deep` are inert without a ground heat exchanger, and
+  `FCfactorMethod` only matters for F/C-factor constructions. If the model has no thermostats yet,
+  `BuildingSurface` is skipped with a reason — run the tool again after HVAC, or pass
+  `set_ground_temperatures(building_surface_method="constant", building_surface_constant_c=18.0)`.
+  For real slab-edge heat transfer, use Kiva (the `Foundation` boundary condition) instead of
+  monthly temperatures at all.
 - **The repair tools above can desynchronize interior surface pairs**, since each rewrites one
   side of a pair in isolation. Two sides with different vertex counts make EnergyPlus abort at
   `GetSurfaceData` before simulating — nothing else in this server catches it, `validate_model`

--- a/.claude/skills/gbxml-import/eval.md
+++ b/.claude/skills/gbxml-import/eval.md
@@ -5,6 +5,8 @@
 | "Convert the available gbXML file to OSM using the project weather file" | import_gbxml | gbxml_path present, epw_path present |
 | "Repair and validate the loaded gbXML geometry" | repair_and_validate_gbxml_geometry | — |
 | "Check this imported gbXML model for overlaps and non-enclosed spaces" | repair_and_validate_gbxml_geometry | — |
+| "Set the ground temperatures on this model from the project weather file" | set_ground_temperatures | — |
+| "This imported model has no ground temperatures — apply the EPW's" | set_ground_temperatures | — |
 
 ## Should NOT trigger
 | Query | Forbidden tools | Expected alternatives |

--- a/.claude/skills/qaqc/SKILL.md
+++ b/.claude/skills/qaqc/SKILL.md
@@ -26,6 +26,9 @@ Inspect the current model for common issues before running a simulation.
    - **Spaces without zones:** `list_spaces()` — look for spaces not assigned to a thermal zone
    - **Missing constructions:** `list_surfaces()` — look for surfaces without constructions
    - **No weather file:** `get_weather_info()` — check if EPW is attached
+   - **No ground temperatures:** `get_weather_info()` — `ground_temperatures` reports the four
+     `Site:GroundTemperature:*` objects. A gbXML-derived model has none, and EnergyPlus then
+     assumes 18 °C every month under the slab. Fix with `set_ground_temperatures()`.
    - **No design days:** needed for HVAC sizing
    - **No run period:** `get_run_period()` — check if simulation dates are set
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
               # + python_ems (plugin templates, actuator discovery, plugin sims)
               # + outcome grader (LLM benchmark gate-2 ground truth, ~7s)
               # + gbXML .stat-file climate-zone resolution test (moved from shard 4 to balance runtime)
-              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py tests/test_file_transfer.py tests/test_measure_discovery.py tests/test_python_ems.py tests/test_knowledge_ablation.py tests/test_outcome_grader_integration.py tests/test_apply_measure_run_id.py tests/test_gbxml_import.py::test_import_gbxml_resolves_climate_zone_from_stat_file_on_austin_fixture"
+              FILES="tests/test_common_measures.py tests/test_hvac_systems.py tests/test_replace_zone_terminal.py tests/test_geometry.py tests/test_skill_energy_report.py tests/test_http_transport.py tests/test_session_isolation.py tests/test_auth.py tests/test_session_eviction.py tests/test_file_transfer.py tests/test_measure_discovery.py tests/test_python_ems.py tests/test_knowledge_ablation.py tests/test_outcome_grader_integration.py tests/test_apply_measure_run_id.py tests/test_ground_temperatures.py tests/test_gbxml_import.py::test_import_gbxml_resolves_climate_zone_from_stat_file_on_austin_fixture"
               EXTRA_ENV=""
               ;;
             3)
@@ -329,7 +329,7 @@ jobs:
               # + weather fail-fast + failed-run extraction guard
               # + hvac_only standards swap parity benchmark (issue #97, moved from shard 4 to balance runtime)
               # + gbxml_deltas (pure-Python unit-style, no MCP round trip — cheap)
-              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py tests/test_generic_hvac_comfort.py tests/test_hvac_only_swap.py tests/test_run_simulation_weather_guard.py tests/test_save_name_delivery.py tests/test_gbxml_deltas.py"
+              FILES="tests/test_hvac_supply_sim.py tests/test_hvac_validation.py tests/test_bar_building.py tests/test_concurrent_tools.py tests/test_stdout_logger_silence.py tests/test_sim_queue.py tests/test_per_user_run_dirs.py tests/test_audit_log.py tests/test_retention.py tests/test_python_ems_phase2.py tests/test_generic_hvac_comfort.py tests/test_hvac_only_swap.py tests/test_run_simulation_weather_guard.py tests/test_save_name_delivery.py tests/test_kiva_foundation.py tests/test_gbxml_deltas.py"
               EXTRA_ENV=""
               ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **`set_ground_temperatures`** (weather skill): applies an EPW header's `GROUND TEMPERATURES`
+  record to the model's four `Site:GroundTemperature:*` objects. A gbXML translation sets none of
+  them, so EnergyPlus silently assumes 18 °C every month on every `Ground` surface. Shallow, Deep
+  and FCfactorMethod take the raw EPW values at the nearest available depths to 0.5 m and 4.0 m;
+  BuildingSurface takes a value derived from the model's heating setpoints instead, because EPW
+  ground temperatures are undisturbed soil and the EPW's own `.stat` warns they "should NOT BE
+  USED ... to compute building floor losses". `building_surface_method` selects
+  `setpoint_offset` (default), `epw_raw`, `constant` or `none`.
+- **`repair_and_validate_gbxml_geometry`** now reports `ground_temperatures_missing` (report-only;
+  `ok` is unaffected, matching `ground_contact_missing_count`), with a four-state
+  absent/defaulted/partial/set breakdown per object.
+- **`get_weather_info`** now returns a `ground_temperatures` read-back, including on models with
+  no weather file attached.
+- `import_gbxml` stashes the staged EPW alongside the staged gbXML, so `set_ground_temperatures`
+  needs no argument after an import.
+- **`set_kiva_foundation` and `get_foundation_options`** (geometry skill): EnergyPlus Kiva, a 2D
+  finite-difference foundation model, as the detailed alternative to monthly ground temperatures.
+  A `Foundation` surface ignores `Site:GroundTemperature:BuildingSurface` and gets a solved soil
+  domain including slab-edge losses and insulation geometry. Driven by an archetype menu
+  (slab on grade uninsulated / perimeter-insulated, heated or unheated basement, vented crawlspace)
+  so the workflow can ask the user one question instead of ten; every applied value reports its
+  provenance. **The insulation R-values are conventional starting points, not code-derived** — there
+  is no vendored source for Kiva insulation geometry, so the ASHRAE 90.1 F-factor/C-factor target for
+  the model's climate zone is reported alongside as a cross-check rather than used as a derivation.
+  Exposed perimeter is computed from the joined building footprint.
+- `set_surface_boundary_conditions` now refuses `"Foundation"`, which produced a model that failed
+  fatally in EnergyPlus for want of the two companion objects; it points at `set_kiva_foundation`,
+  which writes all three together.
+- `find_missing_ground_temperatures()` reports `kiva_foundation_surface_count` and stops flagging
+  `Site:GroundTemperature:BuildingSurface` once every ground-coupled surface uses Kiva and the object
+  would be inert.
+- New `foundation-modeling` skill and worked example
+  `docs/examples/25_ground_and_foundation_heat_transfer.md` covering both methods.
+
 ## [1.0.0-beta] - 2026-06-05
 
 First major release (beta): openstudio-mcp can now run as a shared, multi-user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,9 @@
 - `set_surface_boundary_conditions` now refuses `"Foundation"`, which produced a model that failed
   fatally in EnergyPlus for want of the two companion objects; it points at `set_kiva_foundation`,
   which writes all three together.
-- `find_missing_ground_temperatures()` reports `kiva_foundation_surface_count` and stops flagging
-  `Site:GroundTemperature:BuildingSurface` once every ground-coupled surface uses Kiva and the object
-  would be inert.
+- `find_missing_ground_temperatures()` reports `kiva_foundation_surface_count`; once every
+  ground-coupled surface uses Kiva, `Site:GroundTemperature:BuildingSurface` moves from
+  `ground_temperatures_missing_objects` to `ground_temperatures_superseded_by_kiva`
 - New `foundation-modeling` skill and worked example
   `docs/examples/25_ground_and_foundation_heat_transfer.md` covering both methods.
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Read/write any OpenStudio object by introspection — covers types without a ded
 </details>
 
 <details>
-<summary><b>Geometry</b> — 10 tools</summary>
+<summary><b>Geometry</b> — 12 tools</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -477,12 +477,13 @@ List components via `list_model_objects("BoilerHotWater")`, loop detail tools, e
 </details>
 
 <details>
-<summary><b>Weather & simulation config</b> — 7 tools</summary>
+<summary><b>Weather & simulation config</b> — 8 tools</summary>
 
 | Tool | Description |
 |------|-------------|
 | `list_weather_files` | Available EPW files (with .stat/.ddy) |
-| `get_weather_info` | City, lat, lon, timezone from a weather file |
+| `get_weather_info` | City, lat, lon, timezone, and ground-temperature state |
+| `set_ground_temperatures` | Apply an EPW header's ground temperatures to the model |
 | `add_design_day` | Add a heating/cooling design day |
 | `get_simulation_control` | Read sizing flags and timesteps/hour |
 | `set_simulation_control` | Modify sizing flags and/or timestep |
@@ -688,7 +689,7 @@ The component-properties tools query/modify these 15 types:
 
 ## Examples
 
-23 worked examples with full tool-call sequences:
+25 worked examples with full tool-call sequences:
 
 | # | Example | # | Example |
 |---|---------|---|---------|
@@ -704,6 +705,7 @@ The component-properties tools query/modify these 15 types:
 | 10 | [Typical Building (ComStock)](docs/examples/10_comstock_typical_building.md) | 21 | [gbXML Import from Revit](docs/examples/21_gbxml_import.md) |
 | 11 | [Results Deep Dive](docs/examples/11_results_extraction.md) | 22 | [Repairing & Validating gbXML Geometry](docs/examples/22_repair_and_validate_gbxml_geometry.md) |
 | 23 | [Attributing Space Types (post-gbXML)](docs/examples/23_attribute_space_types.md) | 24 | [Guaranteed Climate Zone & Zone Volume Checks](docs/examples/24_gbxml_climate_zone_and_zone_volume_checks.md) |
+| 25 | [Ground &amp; Foundation Heat Transfer](docs/examples/25_ground_and_foundation_heat_transfer.md) | | |
 
 ---
 

--- a/docs/examples/25_ground_and_foundation_heat_transfer.md
+++ b/docs/examples/25_ground_and_foundation_heat_transfer.md
@@ -1,0 +1,266 @@
+# Example 25: Ground and Foundation Heat Transfer (`/foundation-modeling`)
+
+Two ways to model what happens under a building — a fast approximate one and a real 2D soil solver —
+and how to tell which a model needs.
+
+## Scenario
+
+A gbXML translation arrives with no ground temperatures at all. EnergyPlus falls back to its own
+defaults: 18 °C every month on every `Ground` surface, in Boston and in Austin alike. The project
+EPW has carried measured ground temperatures the whole time and nothing read them.
+
+The fix is not one tool but a choice. Ground-coupled heat transfer can be represented by a monthly
+temperature under the slab, or by solving the soil as a two-dimensional domain. Those give different
+answers and cost very different amounts of simulation time, and picking without knowing the
+difference is how a model ends up confidently wrong.
+
+## Concepts
+
+### What EnergyPlus does with a ground-coupled surface
+
+A surface whose outside boundary condition is `Ground` exchanges heat with a temperature you supply,
+month by month. There are four objects, and they drive different things:
+
+| Object | Drives | Default |
+|--------|--------|---------|
+| `Site:GroundTemperature:BuildingSurface` | **Every `Ground` surface's heat balance** — this is the slab | 18.0 °C |
+| `Site:GroundTemperature:FCfactorMethod` | F/C-factor constructions only | 13.0 °C |
+| `Site:GroundTemperature:Shallow` | Surface ground heat exchangers, `Site:GroundDomain` | 13.0 °C |
+| `Site:GroundTemperature:Deep` | Deep ground heat exchangers | 16.0 °C |
+
+On a typical gbXML model with no ground heat exchanger and no F/C-factor constructions, **only
+`BuildingSurface` changes the answer.** The other three are inert. Four written objects are not four
+improvements.
+
+### Why the EPW's numbers cannot go straight into BuildingSurface
+
+The EPW header carries a `GROUND TEMPERATURES` record — three depths, twelve monthly values each:
+
+```
+GROUND TEMPERATURES,3,.5,,,,-0.29,-1.36,0.53,3.49,11.23,17.20,21.23,22.45,20.36,15.73,9.53,3.79,
+                      2,,,,3.63,...,  4,,,,6.88,...
+```
+
+Those are **undisturbed** soil temperatures — an open field with no building on it. The EPW's own
+`.stat` file says so, at `tests/assets/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.stat:498-500`:
+
+> `**These ground temperatures should NOT BE USED in the GroundTemperatures object to compute building floor losses.`
+> `The temperatures for 0.5 m depth can be used for GroundTemperatures:Surface.`
+> `The temperatures for 4.0 m depth can be used for GroundTemperatures:Deep.`
+
+Boston's January value at 0.5 m is −0.29 °C. Writing that under a heated slab overstates the floor
+loss badly — the soil under a building is warmed by the building.
+
+### What Kiva does instead
+
+Kiva solves a two-dimensional finite-difference slice through the slab edge and sweeps it around the
+exposed perimeter, so slab-edge loss and insulation geometry fall out of the physics rather than
+being averaged away:
+
+```
+                    │ ← interior
+   grade            │
+  ─────┬────────────┤  ← wall_height_above_grade (0.2 m default)
+       │▓▓          │
+       │▓▓ exterior │
+       │▓▓ vertical │═══════════════  ← the slab (your Floor surface)
+       │▓▓ insul.   │▒▒▒▒▒ interior horizontal insulation (↔ width)
+       │  ↕ depth   │
+       └────┬───────┘  ← wall_depth_below_slab (0.0 m default)
+         ┌──┴──┐
+         │footing│     ← footing_depth (0.3 m default)
+         └──────┘
+              ↓ soil solved to far-field 40 m, deep ground "Autoselect"
+```
+
+**Basement depth is not a Kiva input.** Kiva reads the below-grade wall surfaces attached to the same
+Foundation object; their height *is* the depth. `wall_height_above_grade` only says how much of that
+wall shows above grade, and `wall_depth_below_slab` is the footing stem below the slab underside.
+
+A `Foundation` surface **ignores `Site:GroundTemperature:BuildingSurface` entirely.** The two methods
+do not stack.
+
+## Choosing a method
+
+| | `set_ground_temperatures` | `set_kiva_foundation` |
+|---|---|---|
+| Cost | None | One 2D domain **per floor** |
+| User input | None | Foundation type, ideally real insulation detail |
+| Use when | Screening, compliance runs, no foundation information available | Slab-edge loss matters, basement-dominated building, the foundation is the subject |
+
+Default to the simple method. Reach for Kiva when the foundation is what the question is about.
+
+## Prompt
+
+> The gbXML import has no ground temperatures. Set them from the project weather file — and if the
+> basement matters, model it properly.
+
+---
+
+## Walkthrough A — the simple method
+
+```
+1. import_gbxml(gbxml_path="/inputs/project.xml", epw_path="/inputs/boston.epw")
+2. repair_and_validate_gbxml_geometry()
+   → ground_temperatures_missing: true
+     ground_temperatures_missing_count: 4
+     ground_temperatures_state: {building_surface: "absent", fcfactor_method: "absent",
+                                 shallow: "absent", deep: "absent"}
+     ground_temperatures_hint: "...apply the EPW's values with set_ground_temperatures(), or model
+                                the foundation directly with set_kiva_foundation()..."
+3. set_ground_temperatures()                    # resolves the EPW the import used
+   → applied:
+       Site:GroundTemperature:Shallow:        depth_m 0.5, monthly_c [-0.29, -1.36, ... 3.79]
+       Site:GroundTemperature:Deep:           depth_m 4.0, monthly_c [6.88, 4.93, ... 9.84]
+       Site:GroundTemperature:FCfactorMethod: depth_m 0.5, source "epw_raw"
+       Site:GroundTemperature:BuildingSurface: monthly_c [19.1] x12,
+                                               source "setpoint_offset",
+                                               mean_heating_setpoint_c 21.1, offset_c 2.0
+4. repair_and_validate_gbxml_geometry()
+   → ground_temperatures_missing: false
+```
+
+`ground_temperatures_missing` is **report-only** — it never moves `ok`, exactly like
+`ground_contact_missing_count`. Check the count yourself.
+
+Note what step 3 did *not* do: it did not put −0.29 °C under the slab. `BuildingSurface` was derived
+from the model's own heating setpoints — the occupied 21.1 °C, minus 2 °C. That offset is a
+documented rule of thumb, not a calculation, which is the whole reason Kiva exists.
+
+**If the model has no thermostats yet**, `BuildingSurface` is skipped with a reason and the other
+three are still written. Run it again after HVAC, or state the value:
+
+```
+5. set_ground_temperatures(building_surface_method="constant", building_surface_constant_c=18.0)
+```
+
+To accept the undisturbed values anyway — against the `.stat`'s advice, and it will say so:
+
+```
+6. set_ground_temperatures(building_surface_method="epw_raw")
+   → warnings: ["...writes UNDISTURBED soil temperatures... expect overstated slab heat loss."]
+```
+
+## Walkthrough B — Kiva, with the interview
+
+**Always look before choosing.**
+
+```
+1. get_foundation_options()
+   → eligible_floors: [{surface: "Surface 1", exposed_perimeter_m: 30.0}, ...]
+     eligible_walls:  [...]
+     blocked: [{surface: "Surface 12",
+                reasons: ["construction layer 'CP02 CARPET PAD' is not a standard opaque
+                           material — EnergyPlus refuses massless layers on a Foundation surface"]}]
+     kiva_domains_if_applied: 2
+     climate_zone: "5A"
+     code_targets: {slab_max_f_factor: {Heated: 0.9, Unheated: 0.73}, ...}
+     archetypes: [...five, each with its full parameter set and a `basis` string...]
+```
+
+### Put the choice to the user
+
+Show the five archetypes **with their numbers**, and ask which describes the building:
+
+| Archetype | Insulation |
+|---|---|
+| `slab_on_grade_uninsulated` | none |
+| `slab_on_grade_perimeter_insulated` | exterior vertical R-SI 1.76, 0.6 m deep |
+| `heated_basement_insulated` | exterior vertical R-SI 1.76, full below-grade wall depth |
+| `unheated_basement` | none |
+| `crawlspace_vented` | interior horizontal R-SI 1.76, 0.6 m wide |
+
+**Say that the R-values are conventional starting points.** There is no vendored source for Kiva
+insulation geometry — openstudio-standards carries ASHRAE 90.1 ground data, but as F-factor and
+C-factor, which are code *performance* per unit perimeter and cannot be converted to insulation
+geometry without Appendix A tables that are not available here. So the tool reports the 90.1 target
+for the model's climate zone as a **cross-check**, never as the source. If the user knows their real
+insulation, take it over the archetype.
+
+### Apply
+
+```
+2. set_kiva_foundation(archetype="heated_basement_insulated")
+   → applied: {floors: ["Surface 1"], walls: ["Surface 2", "Surface 3", ...],
+               foundations: [{name: "Kiva heated_basement_insulated Surface 1",
+                              exposed_perimeter: {method: "TotalExposedPerimeter",
+                                                  value: 30.0,
+                                                  provenance: "computed_geometry"}}]}
+     plan.geometry: {wall_height_above_grade_m: {value: 0.2,
+                                                 provenance: "openstudio_default (archetype agrees)",
+                                                 written: false}, ...}
+     ground_temperature_interaction: {surfaces_now_kiva: 5, ground_surfaces_remaining: 0,
+                                      warning: "...the 5 surface(s) just converted to Kiva ignore
+                                                it. It now applies to no surfaces at all."}
+```
+
+Overriding what the user actually knows:
+
+```
+3. set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+     exterior_vertical_insulation_r_si=3.52,
+     exterior_vertical_insulation_depth_m=1.2)
+```
+
+Showing the user the plan first:
+
+```
+4. set_kiva_foundation(archetype="unheated_basement", dry_run=True)
+   → dry_run: true, plan: {...}, note: "Nothing was changed."
+```
+
+### Reading the provenance
+
+Every value says where it came from, because several were never sourced:
+
+| provenance | means |
+|---|---|
+| `user` | the caller supplied it |
+| `archetype:<name>` | a conventional starting point — report this to the user |
+| `openstudio_default (archetype agrees)` | left defaulted; the archetype did not override it |
+| `epw_header` | the EPW's soil properties (blank in every bundled TMY file) |
+| `computed_geometry` | exposed perimeter from the joined building footprint |
+| `computed_geometry_zero_clamped` | an interior bay with no exposed edge |
+
+## Key Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `set_ground_temperatures` | Write the four `Site:GroundTemperature:*` objects from the EPW header |
+| `get_weather_info` | Read back which ground-temperature objects are set |
+| `get_foundation_options` | Eligible surfaces, blockers, exposed perimeter, archetype menu, code targets |
+| `set_kiva_foundation` | Apply a Kiva 2D foundation model |
+| `repair_and_validate_gbxml_geometry` | Reports `ground_temperatures_missing` (report-only) |
+
+## Common Pitfalls
+
+- **Massless construction layers are the most common Kiva blocker on a real Revit model.** gbXML
+  slabs routinely carry no-mass layers and EnergyPlus refuses them outright — `exampleModel()`'s own
+  floors fail this on `CP02 CARPET PAD`. Fix with `create_standard_opaque_material`,
+  `create_construction` and `assign_construction_to_surface`, then retry. Normal, not an edge case.
+- **A Kiva surface may not carry windows or doors**, and a Kiva wall may not exceed four vertices.
+- **Never set `Foundation` with `set_surface_boundary_conditions`.** EnergyPlus also needs a
+  `Foundation:Kiva` object and a `SurfaceProperty:ExposedFoundationPerimeter`, and fails fatally
+  without them. That tool now refuses the condition and points here.
+- **Kiva needs a weather file at simulation time** — it cannot run design-day-only.
+- **One 2D domain per floor** is an EnergyPlus rule, not a choice. Forty slabs is forty domains;
+  past twenty the tool requires `confirm_many_domains=True`.
+- **`Shallow` and `Deep` are inert** without a ground heat exchanger, and `FCfactorMethod` only
+  affects F/C-factor constructions. Do not read four applied objects as four improvements.
+- Neither tool saves. Call `save_osm_model`.
+
+## Integration Test
+
+- `tests/test_epw_ground_temperatures.py` — the EPW header parser (unit tier, no Docker)
+- `tests/test_zone_heating_setpoints.py` — the setpoint derivation (unit tier)
+- `tests/test_ground_temperatures.py` — the simple method end to end
+- `tests/test_kiva_archetypes.py` — the archetype table and provenance (unit tier)
+- `tests/test_kiva_foundation.py` — Kiva model state, including
+  `test_forward_translation_emits_the_kiva_objects_without_errors`
+
+The forward-translation test is a proxy: a missing exposed-perimeter object is a *runtime* fatal, so
+it was also verified once by hand. EnergyPlus 25.2.0, Boston TMY3, one-week run, two slabs with
+`slab_on_grade_perimeter_insulated`: `EnergyPlus Completed Successfully -- 8 Warning; 0 Severe
+Errors`, with `eplusout.eio` reporting two Kiva foundations of 1053 cells each and a total exposed
+perimeter of 30.00 m — the same number the tool computed. Details in the
+`tests/test_kiva_foundation.py` module docstring.

--- a/mcp_server/skills/gbxml_import/README.md
+++ b/mcp_server/skills/gbxml_import/README.md
@@ -263,9 +263,36 @@ skipped, with the specific reason, rather than guessed at, in every one of these
 `docs/examples/22_repair_and_validate_gbxml_geometry.md` for a worked example with exact
 before/after counts on a real fixture.
 
+## Missing ground temperatures
+
+A seventh defect on the same terms as missing ground connections: report-only, `ok` unaffected,
+and it fires on essentially every import. A translation sets none of the four
+`Site:GroundTemperature:*` objects, so EnergyPlus uses its own IDD defaults — 18 °C every month
+on BuildingSurface, regardless of climate.
+
+`find_missing_ground_temperatures()` (weather skill) is merged into
+`repair_and_validate_gbxml_geometry`'s result exactly like `find_missing_ground_contact()`. It
+reports four states per object rather than a boolean, because presence is not evidence of intent:
+an all-defaulted object is written to the OSM and survives a reload, and a typical OpenStudio
+model ships BuildingSurface and Deep already present at their defaults (see
+`measures/local/custom/*/tests/example_model.osm:77,92`). So `absent`, `defaulted` and `partial`
+all count as missing; only `set` does not.
+
+The fix is `set_ground_temperatures()`, which reads the EPW header's GROUND TEMPERATURES record.
+Note the physics limit, which is why the tool does not simply copy the EPW values across: those
+are *undisturbed* soil temperatures, and the EPW's own `.stat` says so
+(`tests/assets/USA_MA_Boston-Logan...stat:498-500` — "should NOT BE USED in the GroundTemperatures
+object to compute building floor losses"). Shallow, Deep and FCfactorMethod take the raw values at
+the nearest available depths to 0.5 m and 4.0 m; BuildingSurface — the only one that drives the
+floor heat balance — takes a value derived from the model's own heating setpoints instead.
+
+`import_gbxml_op` stashes the staged EPW alongside the staged gbXML in `gbxml_source_state`, on
+the same generation contract, so the fix needs no argument after an import.
+
 ## Tools
 
-`import_gbxml`, `repair_and_validate_gbxml_geometry`. See also `repair_missing_roof_ceiling`,
+`import_gbxml`, `repair_and_validate_gbxml_geometry`. See also `set_ground_temperatures`
+(weather skill, for the ground-temperature gap above), `repair_missing_roof_ceiling`,
 `merge_coplanar_sliver_surfaces`, `weld_coincident_vertices`, `patch_missing_surfaces`, and
 `trim_overlapping_surfaces` (geometry skill) for the five automatable non-enclosed-space causes,
 and `change_building_location` (common_measures skill, to set climate zone explicitly if

--- a/mcp_server/skills/gbxml_import/gbxml_source_state.py
+++ b/mcp_server/skills/gbxml_import/gbxml_source_state.py
@@ -1,4 +1,4 @@
-"""Session-scoped memory of the gbXML file a model was imported from.
+"""Session-scoped memory of the gbXML file (and EPW) a model was imported from.
 
 Stored in model_manager's generic per-session `extra` dict (see
 mcp_server.model_manager.get_session_extra), the same mechanism the space-type
@@ -43,21 +43,30 @@ _write_lock = threading.Lock()
 class GbxmlSourceState:
     gbxml_path: str
     model_generation: int
+    epw_path: str | None = None
 
 
-def set_source(gbxml_path: str, model_generation: int) -> None:
-    """Record the gbXML file that produced the model with generation `model_generation`.
+def set_source(gbxml_path: str, model_generation: int, epw_path: str | None = None) -> None:
+    """Record the gbXML file (and its EPW) that produced the model with `model_generation`.
 
     `model_generation` must be the value returned by the load_model_with_generation()
     call that loaded that model. A concurrent later import on this session may already
     have stashed a newer generation — never overwrite it with an older one.
+
+    `epw_path` is stashed in the same write rather than through a separate setter: a second
+    setter would have to re-read the entry outside this lock, reintroducing exactly the
+    compare-and-set race the lock and the generation guard exist to prevent.
     """
     extra = model_manager.get_session_extra()
     with _write_lock:
         existing = extra.get(_KEY)
         if existing is not None and existing.model_generation > model_generation:
             return
-        extra[_KEY] = GbxmlSourceState(gbxml_path=gbxml_path, model_generation=model_generation)
+        extra[_KEY] = GbxmlSourceState(
+            gbxml_path=gbxml_path,
+            model_generation=model_generation,
+            epw_path=epw_path,
+        )
 
 
 def get_source_for_model(model_generation: int) -> str | None:
@@ -75,3 +84,20 @@ def get_source_for_model(model_generation: int) -> str | None:
     if state is None or state.model_generation != model_generation:
         return None
     return state.gbxml_path
+
+
+def get_epw_for_model(model_generation: int) -> str | None:
+    """Return the EPW the model with generation `model_generation` was imported against.
+
+    Same generation contract as get_source_for_model: a stash bound to a different model is
+    no answer at all. None when the model did not come from import_gbxml_op, or when the
+    import predates EPW stashing.
+
+    The path is the staged copy under the import's run_dir/weather/ — the bytes
+    ChangeBuildingLocation actually consumed. Run retention may have deleted it since, so
+    callers must treat a missing file as "not found" and fall back, never as an error.
+    """
+    state = model_manager.get_session_extra().get(_KEY)
+    if state is None or state.model_generation != model_generation:
+        return None
+    return state.epw_path

--- a/mcp_server/skills/gbxml_import/operations.py
+++ b/mcp_server/skills/gbxml_import/operations.py
@@ -41,6 +41,7 @@ from mcp_server.skills.geometry.operations import match_surfaces
 from mcp_server.skills.geometry.paired_vertex_sync import sync_paired_surface_vertices
 from mcp_server.skills.geometry.winding import normalize_local_frame_winding
 from mcp_server.skills.measures.runner_messages import OSW_MAX_BYTES, parse_all_step_messages
+from mcp_server.skills.weather.ground_temperatures import find_missing_ground_temperatures
 from mcp_server.util import create_run_dir, read_file_bounded, read_tail_bounded, reject_escaping_symlinks
 
 # Failure-path log tail: 50 lines fit comfortably in 200KB; read_tail_bounded
@@ -319,7 +320,14 @@ def import_gbxml_op(
         # itself returned — sync tools on one session run concurrently, so reading
         # model_generation() afterwards could observe a later load and bind this
         # file to the wrong model.
-        set_gbxml_source(str(gbxmls_dir / gbxml_name), generation)
+        # The EPW is stashed on the same terms and for the same reason: set_ground_temperatures
+        # needs the file this model's location came from, and the OSM keeps only a weather-file
+        # url that may be a bare basename.
+        set_gbxml_source(
+            str(gbxmls_dir / gbxml_name),
+            generation,
+            epw_path=str(weather_dir / epw_src.name),
+        )
 
         result = {
             "ok": True,
@@ -532,6 +540,12 @@ def repair_and_validate_gbxml_geometry_op() -> dict[str, Any]:
         # deliberately NOT affected: a model with no ground connection still simulates, it is
         # just wrong thermally, and this fires on essentially every gbXML import.
         result.update({k: v for k, v in ground_result.items() if k != "ok"})
+
+        # Same contract for ground TEMPERATURES: report only, `ok` untouched. A gbXML
+        # translation sets none of the Site:GroundTemperature:* objects, so E+ silently uses
+        # its own defaults (18 C on every Ground surface). Needs no EPW to detect.
+        temperature_result = find_missing_ground_temperatures()
+        result.update({k: v for k, v in temperature_result.items() if k != "ok"})
 
         # Optional: only runs when this session's model came from import_gbxml_op and hasn't
         # been reloaded/replaced since (see gbxml_source_state). Silently skipped otherwise —

--- a/mcp_server/skills/geometry/README.md
+++ b/mcp_server/skills/geometry/README.md
@@ -1,0 +1,114 @@
+# geometry skill — internal notes
+
+Most of this package is gbXML repair (see `mcp_server/skills/gbxml_import/README.md` for the defect
+catalogue those tools address). This note covers only the Kiva foundation work, because its
+constraints were expensive to establish and are not discoverable from the OpenStudio API.
+
+## Kiva: what EnergyPlus actually enforces
+
+Read out of the EnergyPlus 25.2.0 binary's own error strings, not from documentation:
+
+| Rule | Consequence |
+|---|---|
+| only one floor per `Foundation:Kiva` | one Kiva object **per floor surface**, always |
+| floor and wall surfaces only | anything else is refused |
+| a `Foundation` surface with no `SurfaceProperty:ExposedFoundationPerimeter` | **fatal** |
+| Kiva walls must have ≤ 4 vertices | refused |
+| `"Foundation" ... must use only regular material objects` | no massless / no-mass / air-gap layers |
+| `Exterior boundary condition = Foundation is not allowed with windows` | no subsurfaces |
+| requires a weather file | Kiva cannot run design-day-only |
+| paired wall lengths ≤ the floor's exposed perimeter | validated before writing |
+
+`kiva_surface_blockers()` in `kiva_eligibility.py` checks every one that is cheap, and refuses the
+surface with a reason rather than writing a model that dies at run time. On a real Revit model the
+massless-layer rule is the most common outcome — `openstudio.model.exampleModel()`'s own floors fail
+it on `CP02 CARPET PAD`.
+
+## Three SDK traps, all verified by probe
+
+**1. `Surface.exposedPerimeter()` segfaults on a surface with no parent Space.** No Python
+exception, no error dict — the interpreter dies and takes the MCP session with it. gbXML imports
+produce parentless surfaces routinely (that is why `patch_missing_surfaces` exists). `_has_space()`
+guards every call and `test_space_less_floor_is_reported_not_crashed` is the regression.
+
+**2. `createSurfacePropertyExposedFoundationPerimeter(method, value)` reports success when it
+silently discarded the input.** It returns an initialized Optional either way:
+
+| call | initialized | method reads back |
+|---|---|---|
+| `("TotalExposedPerimeter", 12.0)` | True | `'TotalExposedPerimeter'` |
+| `("ExposedPerimeterFraction", 1.0)` | True | `'ExposedPerimeterFraction'` |
+| `("Calculate", 12.0)` | **True** | `''` |
+| `("Bogus", 12.0)` | **True** | `''` |
+
+An out-of-range fraction (a fraction must be 0..1) gets the same treatment — method set, value
+unset. So the method is whitelisted here, the value is range-checked against it, and
+`_write_exposed_perimeter()` reads both back and compares. `is_initialized()` is never treated as
+success. `BySegment` is legal in the IDD but not offered: EnergyPlus cannot auto-correct a clockwise
+floor polygon under it, OpenStudio exposes no segment API, and gbXML winding is exactly what
+`weld_coincident_vertices` exists to clean up.
+
+**3. `Surface.setAdjacentFoundation()` leaves `SunExposed`/`WindExposed` intact.** It sets the
+boundary condition but not the exposure, so a buried slab would keep taking solar gain — the same
+defect `ground_contact.py`'s docstring is about. `setOutsideBoundaryCondition("Foundation")` is
+called **first** because that one derives NoSun/NoWind.
+
+Also: `model.getFoundationKivaSettings()` creates the unique object;
+`getOptionalFoundationKivaSettings()` does not. Same hazard as the `Site:GroundTemperature:*`
+objects in `weather/ground_temperatures.py`, and the read paths use the Optional form throughout.
+
+## Exposed perimeter
+
+The only recipe that works:
+
+```python
+polys = openstudio.Point3dVectorVector()
+for f in every_at_or_below_grade_floor:      # ALL of them, not just the selected ones
+    polys.append(f.space().get().transformation() * f.vertices())
+joined = openstudio.joinAllPolygons(polys, 0.01)
+exposed = sum(f.exposedPerimeter(j) for j in joined)
+```
+
+A hand-built `Polygon3d` returns 0.0 — the winding does not match. Neighbouring floors must be in the
+join or an interior bay will not correctly score zero. Disjoint wings produce several polygons and
+each floor scores against exactly one, so summing across them is required. A computed zero is clamped
+to `MIN_EXPOSED_PERIMETER_M` (Kiva rejects a zero perimeter), matching the vendored `tbd` gem.
+
+## The archetype numbers, and what they are not
+
+`kiva_archetypes.py` carries five foundation types. **There is no vendored basis for Kiva insulation
+geometry in this image, and the module says so rather than implying one:**
+
+- openstudio-standards has 90 `GroundContact*` rows, but as F-factor and C-factor — code performance
+  per unit perimeter, with no insulation depth, width or position. Inverting them needs ASHRAE 90.1
+  Appendix A tables that are not vendored.
+- NECB's `apply_kiva_foundation` applies no insulation at all; ComStock has none.
+- The `tbd-3.5.0` gem supplies the XPS properties and the 0.6 m interior-horizontal width. Those are
+  cited; everything else is a conventional starting point carrying a `basis` string that says so.
+
+The 90.1 F/C-factor target for the model's climate zone is reported alongside as a cross-check, which
+is what that data legitimately is.
+
+Provenance is not decoration. `wall_height_above_grade = 0.2` is both the archetype value and the IDD
+default, so where they agree the field is left defaulted and reported as
+`openstudio_default (archetype agrees)` — claiming `archetype:*` for a field never written would make
+the whole mechanism theatre.
+
+## File layout
+
+| File | Role |
+|---|---|
+| `kiva_archetypes.py` | The table, R→thickness, provenance merge. **No `openstudio` import** — unit-testable. |
+| `kiva_eligibility.py` | Blockers, candidate classification, wall pairing, exposed perimeter. |
+| `kiva_foundation.py` | Read side: `get_foundation_options`, code targets, object helpers. |
+| `kiva_apply.py` | Write side: `set_kiva_foundation`. |
+| `tools_kiva.py` | MCP registration, split out because `tools.py` was already at ~389/400 lines. |
+
+## Interaction with `Site:GroundTemperature:*`
+
+A `Foundation` surface ignores `Site:GroundTemperature:BuildingSurface` entirely, and Kiva is
+incompatible with the F/C-factor constructions that `FCfactorMethod` affects. `set_kiva_foundation`
+reports this in `ground_temperature_interaction`, and
+`weather/ground_temperatures.find_missing_ground_temperatures()` goes quiet about BuildingSurface once
+every ground-coupled surface is Kiva — otherwise `repair_and_validate_gbxml_geometry` nags forever at
+the user who did the higher-fidelity thing.

--- a/mcp_server/skills/geometry/README.md
+++ b/mcp_server/skills/geometry/README.md
@@ -62,20 +62,18 @@ objects in `weather/ground_temperatures.py`, and the read paths use the Optional
 
 ## Exposed perimeter
 
-The only recipe that works:
+Each candidate floor's edges are projected to z = 0, and its exposed perimeter is the length of
+those edges minus every interval that lies under a collinear edge of another at-or-below-grade
+floor (`kiva_eligibility.compute_exposed_perimeters`). Interval subtraction handles partial
+overlaps and T-junctions; a courtyard's edges stay exposed because no floor lies on their other
+side; duplicated footprints are reported and do not cover each other. All candidate floors take
+part as neighbours, not only the selected ones, or an interior bay will not correctly score zero.
 
-```python
-polys = openstudio.Point3dVectorVector()
-for f in every_at_or_below_grade_floor:      # ALL of them, not just the selected ones
-    polys.append(f.space().get().transformation() * f.vertices())
-joined = openstudio.joinAllPolygons(polys, 0.01)
-exposed = sum(f.exposedPerimeter(j) for j in joined)
-```
-
-A hand-built `Polygon3d` returns 0.0 — the winding does not match. Neighbouring floors must be in the
-join or an interior bay will not correctly score zero. Disjoint wings produce several polygons and
-each floor scores against exactly one, so summing across them is required. A computed zero is clamped
-to `MIN_EXPOSED_PERIMETER_M` (Kiva rejects a zero perimeter), matching the vendored `tbd` gem.
+The SDK route is deliberately not used. `Surface.exposedPerimeter()` and `joinAllPolygons()` both
+assert |z| <= tolerance, so a basement floor scores 0.0 through them, and the join fills holes, so a
+3x3 ring of 10 m slabs around an open courtyard reported 120 m instead of 160 m. A computed zero
+(a fully enclosed interior bay) is clamped to `MIN_EXPOSED_PERIMETER_M` (Kiva rejects a zero
+perimeter), matching the vendored `tbd` gem.
 
 ## Two Foundation:Kiva fields are measured from the wall top, not from grade
 

--- a/mcp_server/skills/geometry/README.md
+++ b/mcp_server/skills/geometry/README.md
@@ -17,10 +17,13 @@ Read out of the EnergyPlus 25.2.0 binary's own error strings, not from documenta
 | `"Foundation" ... must use only regular material objects` | no massless / no-mass / air-gap layers |
 | `Exterior boundary condition = Foundation is not allowed with windows` | no subsurfaces |
 | requires a weather file | Kiva cannot run design-day-only |
-| paired wall lengths ≤ the floor's exposed perimeter | validated before writing |
+| paired wall lengths ≤ the floor's exposed perimeter | severe at run time; `kiva_apply._walls_exceeding_perimeter()` refuses it before writing |
 
 `kiva_surface_blockers()` in `kiva_eligibility.py` checks every one that is cheap, and refuses the
-surface with a reason rather than writing a model that dies at run time. On a real Revit model the
+surface with a reason rather than writing a model that dies at run time. Matched interior surfaces
+(`Surface` boundary) are never candidates however deep they sit: a two-storey basement's middle
+floor or a partition between two basement zones has a partner, not soil, and converting it would
+reset the pairing and drop the partner to Outdoors. On a real Revit model the
 massless-layer rule is the most common outcome — `openstudio.model.exampleModel()`'s own floors fail
 it on `CP02 CARPET PAD`.
 

--- a/mcp_server/skills/geometry/README.md
+++ b/mcp_server/skills/geometry/README.md
@@ -77,6 +77,18 @@ join or an interior bay will not correctly score zero. Disjoint wings produce se
 each floor scores against exactly one, so summing across them is required. A computed zero is clamped
 to `MIN_EXPOSED_PERIMETER_M` (Kiva rejects a zero perimeter), matching the vendored `tbd` gem.
 
+## Two Foundation:Kiva fields are measured from the wall top, not from grade
+
+From `Energy+.idd`: *Exterior Vertical Insulation Depth* is "the extent of insulation as measured
+from the wall top to the bottom edge", and *Wall Height Above Grade* is "the distance from the
+exterior grade to the wall top". So a full-depth basement run (`MATCH_WALL_DEPTH`) is the paired
+walls' top-to-bottom span, and the wall height is their `z_max` — both derived per foundation in
+`kiva_apply._wall_geometry_by_floor()` from world coordinates, reported under
+`wall_geometry_by_floor` in the plan and on each `applied.foundations[i]`. A user-supplied
+`exterior_vertical_insulation_depth_m` or `wall_height_above_grade_m` is written verbatim. Walls of
+differing height on one floor share one Foundation object; the largest span is used and
+`mixed_heights` says so.
+
 ## The archetype numbers, and what they are not
 
 `kiva_archetypes.py` carries five foundation types. **There is no vendored basis for Kiva insulation

--- a/mcp_server/skills/geometry/boundary_conditions.py
+++ b/mcp_server/skills/geometry/boundary_conditions.py
@@ -32,6 +32,13 @@ from mcp_server.osm_helpers import fetch_object, parse_str_list
 # would leave a dangling reference.
 _REQUIRES_PAIRING = "Surface"
 
+# "Foundation" is in the SDK's valid list, but a surface set to it with no FoundationKiva object
+# attached is a guaranteed EnergyPlus fatal ("references a Foundation Outside Boundary Condition
+# but there is no corresponding SURFACEPROPERTY:EXPOSEDFOUNDATIONPERIMETER object defined").
+# set_kiva_foundation writes the boundary condition, the Foundation object and the perimeter
+# object together, which is the only combination that simulates.
+_REQUIRES_KIVA = "Foundation"
+
 
 def _valid(values_fn) -> list[str]:
     """Allowed values straight from the SDK, so this can't drift from the bindings."""
@@ -78,6 +85,14 @@ def set_surface_boundary_conditions(
                 "error": "'Surface' cannot be set directly — it means 'adjacent to a "
                          "specific other surface' and needs that partner. Use "
                          "match_surfaces() to pair surfaces between adjacent spaces.",
+            }
+        if outside_boundary_condition == _REQUIRES_KIVA:
+            return {
+                "ok": False,
+                "error": "'Foundation' cannot be set directly — EnergyPlus also needs a "
+                         "Foundation:Kiva object and a SurfaceProperty:ExposedFoundationPerimeter "
+                         "on the surface, and fails fatally without them. Use "
+                         "set_kiva_foundation(), which writes all three together.",
             }
         if outside_boundary_condition not in valid_bcs:
             return {

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -139,24 +139,43 @@ def _walls_exceeding_perimeter(model, walls_by_floor, perimeters) -> dict[str, A
     return exceeding
 
 
-def _retire_foundation(kiva, warnings: list[str]) -> None:
-    """Remove a Foundation object the overwrite has just replaced, unless walls still use it.
+def _stranded_walls(model, floor_names, walls_by_floor) -> dict[str, list[str]]:
+    """Walls that would be left on a floorless Foundation object if these floors were overwritten.
 
-    Called after the floor's new walls are attached, so anything still on the old object is a
-    wall this run did not re-pair (include_below_grade_walls=False, or a wall that no longer
-    shares an edge). Removing it then would leave those walls with a dangling Foundation
-    reference; leaving it silently would ship a Foundation:Kiva with walls and no floor.
+    EnergyPlus: a wall referencing a Foundation:Kiva "must also reference [it] in a floor surface
+    within the same Zone" — severe at run time. So an overwrite that re-pairs fewer walls than the
+    previous run is refused up front, never written and warned about.
     """
-    stranded = sorted(s.nameString() for s in kiva.surfaces())
-    if stranded:
-        warnings.append(
-            f"Previous foundation '{kiva.nameString()}' was kept because {len(stranded)} wall(s) "
-            f"still reference it and were not re-paired this run: {stranded}. EnergyPlus needs a "
-            f"floor on every Foundation:Kiva — re-run with include_below_grade_walls=True or set "
-            f"those walls' boundary condition explicitly.",
+    stranded: dict[str, list[str]] = {}
+    for floor_name in floor_names:
+        floor = model.getSurfaceByName(floor_name).get()
+        previous = floor.adjacentFoundation()
+        if not previous.is_initialized():
+            continue
+        re_paired = set(walls_by_floor.get(floor_name, []))
+        left = sorted(
+            s.nameString() for s in previous.get().surfaces()
+            if s.nameString() != floor_name and s.nameString() not in re_paired
         )
-        return
+        if left:
+            stranded[floor_name] = left
+    return stranded
+
+
+def _retire_foundation(kiva) -> str | None:
+    """Remove the Foundation object an overwrite has just replaced. Returns an error, or None.
+
+    _stranded_walls() has already refused any run that would leave a wall on it, so by the time
+    this runs the object must be empty; anything else is a bug worth failing loudly on.
+    """
+    remaining = sorted(s.nameString() for s in kiva.surfaces())
+    if remaining:
+        return (
+            f"Previous foundation '{kiva.nameString()}' still carries {remaining} after its floor "
+            f"was moved; refusing to leave a Foundation:Kiva with no floor."
+        )
     kiva.remove()
+    return None
 
 
 def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perimeters,
@@ -223,7 +242,9 @@ def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perim
             "exposed_perimeter": {"method": method, "value": value, "provenance": provenance},
         })
         if previous.is_initialized():
-            _retire_foundation(previous.get(), warnings)
+            error = _retire_foundation(previous.get())
+            if error is not None:
+                return applied, error
 
     applied["settings_written"] = sorted(settings_written)
     return applied, None
@@ -366,6 +387,16 @@ def set_kiva_foundation(
                 "error": f"{len(already)} floor(s) already carry a Kiva foundation; pass "
                          f"overwrite=True to replace them.",
                 "already_kiva": sorted(already),
+            }
+        stranded = _stranded_walls(model, already, wall_pairing["pairs"])
+        if stranded:
+            return {
+                "ok": False,
+                "error": f"Overwriting would leave {sum(len(v) for v in stranded.values())} wall(s) "
+                         f"on a Foundation object with no floor, which EnergyPlus refuses at run "
+                         f"time. No changes were made. Re-run with include_below_grade_walls=True, "
+                         f"or move those walls off the Foundation boundary condition first.",
+                "stranded_walls": stranded,
             }
 
         plan = {

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -26,7 +26,11 @@ from mcp_server.model_manager import ensure_generation_unchanged, get_model_with
 from mcp_server.osm_helpers import parse_str_list
 from mcp_server.skills.geometry.kiva_archetypes import (
     ARCHETYPES,
+    MATCH_WALL_DEPTH,
+    PROVENANCE_COMPUTED,
+    PROVENANCE_USER,
     IncompleteInsulationError,
+    ResolvedValue,
     UnknownArchetypeError,
     get_archetype,
     resolve_insulation,
@@ -45,10 +49,10 @@ from mcp_server.skills.geometry.kiva_foundation import (
     _apply_insulation,
     _model_climate_zone,
     _resolve_perimeter,
-    _wall_depth_for,
     _write_exposed_perimeter,
     code_ground_targets,
     existing_soil_properties,
+    paired_wall_geometry,
 )
 
 # Slack for the wall-length check, in metres. The EnergyPlus comparison is exact; this only
@@ -180,9 +184,51 @@ def _retire_foundation(kiva) -> str | None:
     return None
 
 
+def _wall_geometry_by_floor(model, walls_by_floor, geometry, insulation, warnings) -> dict[str, Any]:
+    """Per-floor values that depend on the paired walls, resolved once for plan and apply alike.
+
+    Wall Height Above Grade is derived from the walls' top unless the caller set it: the
+    EnergyPlus field is the distance from grade to the wall top, and the archetype default of
+    0.2 m is only right for a stem wall that happens to show 0.2 m. The full-depth insulation
+    run (MATCH_WALL_DEPTH) is the walls' top-to-bottom span, since that field is measured from
+    the wall top.
+    """
+    height = geometry["wall_height_above_grade_m"]
+    wants_full_depth = any(spec.depth_m == MATCH_WALL_DEPTH for spec in insulation)
+    result: dict[str, Any] = {}
+    for floor_name, wall_names in walls_by_floor.items():
+        walls = paired_wall_geometry(model, wall_names) if wall_names else None
+        if walls is None:
+            result[floor_name] = {
+                "walls": None,
+                "wall_height_above_grade_m": {"value": height.value, "provenance": height.provenance},
+                "full_depth_insulation_m": None,
+            }
+            continue
+        if height.provenance == PROVENANCE_USER:
+            wall_height = ResolvedValue(height.value, PROVENANCE_USER)
+        else:
+            wall_height = ResolvedValue(max(walls["top_m"], 0.0), PROVENANCE_COMPUTED)
+        if walls["mixed_heights"]:
+            warnings.append(
+                f"Walls paired to '{floor_name}' span {walls['span_range_m'][0]} to "
+                f"{walls['span_range_m'][1]} m top-to-bottom; one Foundation:Kiva carries one "
+                f"insulation depth, so the largest span ({walls['span_m']} m) is used.",
+            )
+        result[floor_name] = {
+            "walls": walls,
+            "wall_height_above_grade_m": {"value": wall_height.value,
+                                          "provenance": wall_height.provenance},
+            "full_depth_insulation_m": walls["span_m"] if wants_full_depth else None,
+        }
+    return result
+
+
 def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perimeters,
-           archetype, warnings) -> tuple[dict[str, Any], str | None]:
+           archetype, warnings, wall_geometry) -> tuple[dict[str, Any], str | None]:
     """Write the Kiva objects. Returns (applied, error)."""
+    # "insulation" holds the LAST foundation's layers, kept for callers that read it; the
+    # per-foundation record is applied["foundations"][i]["insulation"].
     applied: dict[str, Any] = {"floors": [], "walls": [], "insulation": {}, "foundations": []}
 
     settings_written = {k: v for k, v in soil.items() if v.write}
@@ -210,19 +256,25 @@ def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perim
         kiva = openstudio.model.FoundationKiva(model)
         kiva.setName(f"Kiva {archetype} {floor_name}")
 
-        for field, setter in (
-            ("wall_height_above_grade_m", kiva.setWallHeightAboveGrade),
-            ("wall_depth_below_slab_m", kiva.setWallDepthBelowSlab),
-            ("footing_depth_m", kiva.setFootingDepth),
+        per_floor = wall_geometry[floor_name]
+        wall_height = per_floor["wall_height_above_grade_m"]
+        for field, setter, resolved in (
+            ("wall_height_above_grade_m", kiva.setWallHeightAboveGrade,
+             geometry["wall_height_above_grade_m"]
+             if wall_height["provenance"] != PROVENANCE_COMPUTED
+             else ResolvedValue(wall_height["value"], PROVENANCE_COMPUTED)),
+            ("wall_depth_below_slab_m", kiva.setWallDepthBelowSlab, geometry["wall_depth_below_slab_m"]),
+            ("footing_depth_m", kiva.setFootingDepth, geometry["footing_depth_m"]),
         ):
-            resolved = geometry[field]
             if resolved.write and not setter(resolved.value):
                 return applied, f"OpenStudio refused {field}={resolved.value} on '{floor_name}'"
 
-        error = _apply_insulation(model, kiva, insulation, _wall_depth_for(model, wall_names),
-                                  applied["insulation"], warnings)
+        span = per_floor["walls"]["span_m"] if per_floor["walls"] else None
+        floor_insulation: dict[str, Any] = {}
+        error = _apply_insulation(model, kiva, insulation, span, floor_insulation, warnings)
         if error is not None:
             return applied, error
+        applied["insulation"] = floor_insulation
 
         # Boundary condition FIRST: setAdjacentFoundation leaves sun/wind exposure alone, and a
         # buried slab left SunExposed takes fictitious solar gain.
@@ -247,6 +299,9 @@ def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perim
             "name": kiva.nameString(),
             "floor": floor_name,
             "walls": wall_names,
+            "wall_geometry": per_floor["walls"],
+            "wall_height_above_grade_m": wall_height,
+            "insulation": floor_insulation,
             "exposed_perimeter": {"method": method, "value": value, "provenance": provenance},
         })
         if previous.is_initialized():
@@ -436,11 +491,15 @@ def set_kiva_foundation(
                 "stranded_walls": stranded,
             }
 
+        wall_geometry = _wall_geometry_by_floor(
+            model, wall_pairing["pairs"], geometry, insulation, warnings,
+        )
         plan = {
             "archetype": archetype,
             "basis": get_archetype(archetype).basis,
             "floors": floor_names,
             "walls_by_floor": wall_pairing["pairs"],
+            "wall_geometry_by_floor": wall_geometry,
             "geometry": {k: {"value": v.value, "provenance": v.provenance, "written": v.write}
                          for k, v in geometry.items()},
             "soil": {k: {"value": v.value, "provenance": v.provenance, "written": v.write}
@@ -455,7 +514,7 @@ def set_kiva_foundation(
                     "note": "Nothing was changed. Re-run without dry_run to apply."}
 
         applied, error = _apply(model, floor_names, wall_pairing["pairs"], geometry,
-                                insulation, soil, perimeters, archetype, warnings)
+                                insulation, soil, perimeters, archetype, warnings, wall_geometry)
         if error is not None:
             return {"ok": False, "error": error, "partial_state": applied}
 

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -47,6 +47,7 @@ from mcp_server.skills.geometry.kiva_foundation import (
     _wall_depth_for,
     _write_exposed_perimeter,
     code_ground_targets,
+    existing_soil_properties,
 )
 
 # Slack for the wall-length check, in metres. The EnergyPlus comparison is exact; this only
@@ -387,6 +388,7 @@ def set_kiva_foundation(
                 "soil_density_kg_m3": soil_density_kg_m3,
                 "soil_specific_heat_j_kgk": soil_specific_heat_j_kgk,
             },
+            existing=existing_soil_properties(model),
         )
         warnings.extend(soil_warnings)
 
@@ -439,6 +441,7 @@ def set_kiva_foundation(
                          for k, v in geometry.items()},
             "soil": {k: {"value": v.value, "provenance": v.provenance, "written": v.write}
                      for k, v in soil.items()},
+            "insulation": {spec.position: spec.as_plan() for spec in insulation},
             "exposed_perimeter": {n: {"method": m, "value": val, "provenance": p}
                                   for n, (m, val, p) in perimeters.items()},
         }

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -1,0 +1,345 @@
+"""The write half of the Kiva feature: set_kiva_foundation.
+
+Split from kiva_foundation.py (which holds the read side, the perimeter resolution and the object
+helpers) to keep both inside the ~400 line budget, CLAUDE.md rule 1.
+
+Order of operations matters here and is not arbitrary:
+
+  1. Validate the archetype and every argument before touching the SDK.
+  2. Resolve every surface name; a single bad name aborts with nothing written — the pattern
+     boundary_conditions.py::set_surface_boundary_conditions established.
+  3. `setOutsideBoundaryCondition("Foundation")` BEFORE `setAdjacentFoundation`, because the latter
+     leaves SunExposed/WindExposed intact and would put solar gain on a buried slab.
+  4. Create the exposed-perimeter object and read it back — its constructor reports success even
+     when it silently discarded the input.
+
+`dry_run=True` returns the identical plan payload without mutating, so the agent can show the user
+exactly what would happen before committing.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import openstudio
+
+from mcp_server.model_manager import ensure_generation_unchanged, get_model_with_generation
+from mcp_server.osm_helpers import parse_str_list
+from mcp_server.skills.geometry.kiva_archetypes import (
+    ARCHETYPES,
+    UnknownArchetypeError,
+    get_archetype,
+    resolve_insulation,
+    resolve_kiva_parameters,
+    resolve_soil_properties,
+)
+from mcp_server.skills.geometry.kiva_eligibility import (
+    KIVA_DOMAIN_WARN_THRESHOLD,
+    classify_foundation_candidates,
+    pair_walls_to_floors,
+)
+from mcp_server.skills.geometry.kiva_foundation import (
+    _apply_insulation,
+    _model_climate_zone,
+    _resolve_perimeter,
+    _wall_depth_for,
+    _write_exposed_perimeter,
+    code_ground_targets,
+)
+
+# A basement archetype landing on a slab-on-grade model is the most likely misuse, and it writes a
+# foundation wall that is not there. Above this depth we require corroborating geometry.
+SUSPICIOUS_WALL_DEPTH_M = 0.5
+
+
+def _epw_soil_set(model, generation: int, epw_path: str | None, warnings: list[str]):
+    """The EPW's GROUND TEMPERATURES soil properties, or None.
+
+    Reuses Phase 1's resolution chain verbatim rather than copying it — and Kiva needs a weather
+    file at simulation time anyway, so a miss here is worth reporting.
+    """
+    from mcp_server.skills.weather.epw_ground_temperatures import (
+        EpwGroundTemperatureError,
+        nearest_depth_set,
+        read_ground_temperature_sets,
+    )
+    from mcp_server.skills.weather.ground_temperatures import SHALLOW_TARGET_DEPTH_M, _resolve_epw
+
+    epw, source = _resolve_epw(model, generation, epw_path)
+    if epw is None:
+        warnings.append(
+            "No EPW found, so soil properties fall back to OpenStudio defaults. Note that "
+            "EnergyPlus refuses to run Kiva without a weather file — set one before simulating.",
+        )
+        return None
+    try:
+        sets, _ = read_ground_temperature_sets(epw)
+    except EpwGroundTemperatureError as e:
+        warnings.append(f"Could not read soil properties from {source}: {e}")
+        return None
+    chosen, _ = nearest_depth_set(sets, SHALLOW_TARGET_DEPTH_M)
+    return chosen
+
+
+def _ground_temperature_interaction(model, applied: dict[str, Any]) -> dict[str, Any]:
+    """What Kiva just did to the Phase 1 ground temperatures, stated rather than left implicit."""
+    from mcp_server.skills.weather.ground_temperatures import read_ground_temperature_state
+
+    state = read_ground_temperature_state(model)
+    remaining = [
+        s.nameString() for s in model.getSurfaces()
+        if s.outsideBoundaryCondition().startswith("Ground")
+    ]
+    result: dict[str, Any] = {
+        "surfaces_now_kiva": len(applied.get("floors", [])) + len(applied.get("walls", [])),
+        "ground_surfaces_remaining": len(remaining),
+        "building_surface_state": state["building_surface"]["state"],
+    }
+    if state["building_surface"]["state"] in ("set", "partial"):
+        result["warning"] = (
+            f"Site:GroundTemperature:BuildingSurface is {state['building_surface']['state']}, but "
+            f"the {result['surfaces_now_kiva']} surface(s) just converted to Kiva ignore it. It "
+            + (
+                f"still applies to {len(remaining)} remaining Ground surface(s)."
+                if remaining else "now applies to no surfaces at all."
+            )
+        )
+    return result
+
+
+def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perimeters,
+           archetype, warnings) -> tuple[dict[str, Any], str | None]:
+    """Write the Kiva objects. Returns (applied, error)."""
+    settings_written = {k: v for k, v in soil.items() if v.write}
+    if settings_written:
+        settings = model.getFoundationKivaSettings()   # creating here is the intent
+        if "soil_conductivity_w_mk" in settings_written:
+            settings.setSoilConductivity(settings_written["soil_conductivity_w_mk"].value)
+        if "soil_density_kg_m3" in settings_written:
+            settings.setSoilDensity(settings_written["soil_density_kg_m3"].value)
+        if "soil_specific_heat_j_kgk" in settings_written:
+            settings.setSoilSpecificHeat(settings_written["soil_specific_heat_j_kgk"].value)
+
+    applied: dict[str, Any] = {"floors": [], "walls": [], "insulation": {}, "foundations": []}
+
+    for floor_name in floor_names:
+        floor = model.getSurfaceByName(floor_name).get()
+        wall_names = walls_by_floor.get(floor_name, [])
+
+        if floor.adjacentFoundation().is_initialized():
+            floor.resetAdjacentFoundation()
+
+        kiva = openstudio.model.FoundationKiva(model)
+        kiva.setName(f"Kiva {archetype} {floor_name}")
+
+        for field, setter in (
+            ("wall_height_above_grade_m", kiva.setWallHeightAboveGrade),
+            ("wall_depth_below_slab_m", kiva.setWallDepthBelowSlab),
+            ("footing_depth_m", kiva.setFootingDepth),
+        ):
+            resolved = geometry[field]
+            if resolved.write and not setter(resolved.value):
+                return applied, f"OpenStudio refused {field}={resolved.value} on '{floor_name}'"
+
+        _apply_insulation(model, kiva, insulation, _wall_depth_for(model, wall_names),
+                          applied["insulation"], warnings)
+
+        # Boundary condition FIRST: setAdjacentFoundation leaves sun/wind exposure alone, and a
+        # buried slab left SunExposed takes fictitious solar gain.
+        for surface, kind in [(floor, "floor")] + [
+            (model.getSurfaceByName(n).get(), "wall") for n in wall_names
+        ]:
+            if not surface.setOutsideBoundaryCondition("Foundation"):
+                return applied, (
+                    f"OpenStudio refused the Foundation boundary condition on "
+                    f"'{surface.nameString()}'"
+                )
+            if not surface.setAdjacentFoundation(kiva):
+                return applied, f"OpenStudio refused to attach '{surface.nameString()}' to {kiva.nameString()}"
+            applied["floors" if kind == "floor" else "walls"].append(surface.nameString())
+
+        method, value, provenance = perimeters[floor_name]
+        error = _write_exposed_perimeter(floor, method, value)
+        if error is not None:
+            return applied, error
+
+        applied["foundations"].append({
+            "name": kiva.nameString(),
+            "floor": floor_name,
+            "walls": wall_names,
+            "exposed_perimeter": {"method": method, "value": value, "provenance": provenance},
+        })
+
+    applied["settings_written"] = sorted(settings_written)
+    return applied, None
+
+
+def set_kiva_foundation(
+    archetype: str,
+    floor_surface_names: list[str] | str | None = None,
+    include_below_grade_walls: bool = True,
+    include_adiabatic: bool = False,
+    exposed_perimeter_method: str = "auto",
+    exposed_perimeter_m: float | None = None,
+    exposed_perimeter_fraction: float | None = None,
+    wall_height_above_grade_m: float | None = None,
+    wall_depth_below_slab_m: float | None = None,
+    footing_depth_m: float | None = None,
+    interior_horizontal_insulation_r_si: float | None = None,
+    interior_horizontal_insulation_width_m: float | None = None,
+    exterior_vertical_insulation_r_si: float | None = None,
+    exterior_vertical_insulation_depth_m: float | None = None,
+    soil_conductivity_w_mk: float | None = None,
+    soil_density_kg_m3: float | None = None,
+    soil_specific_heat_j_kgk: float | None = None,
+    epw_path: str | None = None,
+    confirm_many_domains: bool = False,
+    overwrite: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Apply a Kiva foundation model. See the module docstrings for the SDK hazards this navigates."""
+    try:
+        get_archetype(archetype)
+    except UnknownArchetypeError as e:
+        return {"ok": False, "error": str(e), "valid_values": sorted(ARCHETYPES)}
+
+    try:
+        model, generation = get_model_with_generation()
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+
+    try:
+        warnings: list[str] = []
+        candidates = classify_foundation_candidates(model, include_adiabatic=include_adiabatic)
+        available = {f["surface"] for f in candidates["eligible_floors"]}
+
+        requested = (parse_str_list(floor_surface_names)
+                     if isinstance(floor_surface_names, str) else floor_surface_names)
+        if requested:
+            requested = list(dict.fromkeys(requested))
+            blocked = {b["surface"]: b["reasons"] for b in candidates["blocked"]}
+            refused = {n: blocked.get(n, ["not an eligible foundation floor at or below grade"])
+                       for n in requested if n not in available}
+            if refused:
+                return {
+                    "ok": False,
+                    "error": f"{len(refused)} requested surface(s) cannot be Kiva floors; "
+                             f"no changes were made.",
+                    "refused_surfaces": refused,
+                }
+            floor_names = requested
+        else:
+            floor_names = sorted(available)
+
+        if not floor_names:
+            return {
+                "ok": False,
+                "error": "No eligible foundation floors in this model. Call get_foundation_options() "
+                         "to see why each candidate was blocked.",
+                "blocked": candidates["blocked"],
+            }
+        if len(floor_names) > KIVA_DOMAIN_WARN_THRESHOLD and not confirm_many_domains:
+            return {
+                "ok": False,
+                "error": f"{len(floor_names)} floors would create {len(floor_names)} separate Kiva "
+                         f"2D domains (EnergyPlus allows one floor per Foundation object), which "
+                         f"slows simulation substantially. Pass confirm_many_domains=True to "
+                         f"proceed, or narrow floor_surface_names.",
+                "eligible_floor_count": len(floor_names),
+            }
+
+        wall_pairing: dict[str, Any] = {"pairs": {n: [] for n in floor_names}, "unpaired": []}
+        if include_below_grade_walls:
+            wall_pairing = pair_walls_to_floors(
+                model, floor_names, [w["surface"] for w in candidates["eligible_walls"]],
+            )
+            for entry in wall_pairing["unpaired"]:
+                warnings.append(
+                    f"Below-grade wall '{entry['surface']}' was not applied: {entry['reason']}.",
+                )
+
+        geometry, geometry_warnings = resolve_kiva_parameters(archetype, {
+            "wall_height_above_grade_m": wall_height_above_grade_m,
+            "wall_depth_below_slab_m": wall_depth_below_slab_m,
+            "footing_depth_m": footing_depth_m,
+        })
+        warnings.extend(geometry_warnings)
+
+        depth = geometry["wall_depth_below_slab_m"]
+        if depth.value and depth.value > SUSPICIOUS_WALL_DEPTH_M and not candidates["eligible_walls"]:
+            return {
+                "ok": False,
+                "error": f"wall_depth_below_slab_m resolved to {depth.value} m but this model has "
+                         f"no below-grade walls — that looks like a basement archetype applied to a "
+                         f"slab-on-grade model. Pass the value explicitly if it is intended.",
+            }
+
+        insulation, insulation_warnings = resolve_insulation(archetype, {
+            "interior_horizontal_r_si": interior_horizontal_insulation_r_si,
+            "interior_horizontal_width_m": interior_horizontal_insulation_width_m,
+            "exterior_vertical_r_si": exterior_vertical_insulation_r_si,
+            "exterior_vertical_depth_m": exterior_vertical_insulation_depth_m,
+        })
+        warnings.extend(insulation_warnings)
+
+        soil, soil_warnings = resolve_soil_properties(
+            _epw_soil_set(model, generation, epw_path, warnings),
+            {
+                "soil_conductivity_w_mk": soil_conductivity_w_mk,
+                "soil_density_kg_m3": soil_density_kg_m3,
+                "soil_specific_heat_j_kgk": soil_specific_heat_j_kgk,
+            },
+        )
+        warnings.extend(soil_warnings)
+
+        perimeters, perimeter_error = _resolve_perimeter(
+            model, floor_names, exposed_perimeter_method,
+            exposed_perimeter_m, exposed_perimeter_fraction, warnings,
+        )
+        if perimeter_error is not None:
+            return {"ok": False, "error": perimeter_error}
+
+        already = [n for n in floor_names
+                   if model.getSurfaceByName(n).get().adjacentFoundation().is_initialized()]
+        if already and not overwrite:
+            return {
+                "ok": False,
+                "error": f"{len(already)} floor(s) already carry a Kiva foundation; pass "
+                         f"overwrite=True to replace them.",
+                "already_kiva": sorted(already),
+            }
+
+        plan = {
+            "archetype": archetype,
+            "basis": get_archetype(archetype).basis,
+            "floors": floor_names,
+            "walls_by_floor": wall_pairing["pairs"],
+            "geometry": {k: {"value": v.value, "provenance": v.provenance, "written": v.write}
+                         for k, v in geometry.items()},
+            "soil": {k: {"value": v.value, "provenance": v.provenance, "written": v.write}
+                     for k, v in soil.items()},
+            "exposed_perimeter": {n: {"method": m, "value": val, "provenance": p}
+                                  for n, (m, val, p) in perimeters.items()},
+        }
+        if dry_run:
+            ensure_generation_unchanged(generation)
+            return {"ok": True, "dry_run": True, "plan": plan, "warnings": warnings,
+                    "note": "Nothing was changed. Re-run without dry_run to apply."}
+
+        applied, error = _apply(model, floor_names, wall_pairing["pairs"], geometry,
+                                insulation, soil, perimeters, archetype, warnings)
+        if error is not None:
+            return {"ok": False, "error": error, "partial_state": applied}
+
+        ensure_generation_unchanged(generation)
+        return {
+            "ok": True,
+            "plan": plan,
+            "applied": applied,
+            "warnings": warnings,
+            "code_targets": code_ground_targets(_model_climate_zone(model)),
+            "ground_temperature_interaction": _ground_temperature_interaction(model, applied),
+            "note": "Changes the in-memory model; call save_osm_model to persist. EnergyPlus "
+                    "requires a weather file to run Kiva.",
+        }
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to apply Kiva foundation: {e}"}

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -35,9 +35,12 @@ from mcp_server.skills.geometry.kiva_archetypes import (
 from mcp_server.skills.geometry.kiva_eligibility import (
     KIVA_DOMAIN_WARN_THRESHOLD,
     classify_foundation_candidates,
+    floor_perimeter,
     pair_walls_to_floors,
+    paired_wall_length,
 )
 from mcp_server.skills.geometry.kiva_foundation import (
+    PERIMETER_METHOD_FRACTION,
     _apply_insulation,
     _model_climate_zone,
     _resolve_perimeter,
@@ -45,6 +48,10 @@ from mcp_server.skills.geometry.kiva_foundation import (
     _write_exposed_perimeter,
     code_ground_targets,
 )
+
+# Slack for the wall-length check, in metres. The EnergyPlus comparison is exact; this only
+# absorbs floating-point noise between a wall width and the matching floor edge.
+WALL_LENGTH_TOLERANCE_M = 0.001
 
 # A basement archetype landing on a slab-on-grade model is the most likely misuse, and it writes a
 # foundation wall that is not there. Above this depth we require corroborating geometry.
@@ -104,6 +111,36 @@ def _ground_temperature_interaction(model, applied: dict[str, Any]) -> dict[str,
             )
         )
     return result
+
+
+def _walls_exceeding_perimeter(model, walls_by_floor, perimeters) -> dict[str, Any]:
+    """Floors whose paired walls are longer than the exposed perimeter EnergyPlus will see.
+
+    EnergyPlus: "the Wall surfaces referencing the same Foundation:Kiva have a combined length
+    greater than the exposed perimeter of the foundation" — a severe error at run time, so it is
+    refused here before anything is written. Under ExposedPerimeterFraction the perimeter
+    EnergyPlus uses is the fraction of the floor polygon's full perimeter.
+    """
+    exceeding: dict[str, Any] = {}
+    for floor_name, wall_names in walls_by_floor.items():
+        if not wall_names:
+            continue
+        method, value, _ = perimeters[floor_name]
+        if method == PERIMETER_METHOD_FRACTION:
+            full = floor_perimeter(model, floor_name)
+            if full is None:
+                continue
+            exposed = value * full
+        else:
+            exposed = value
+        wall_length = paired_wall_length(model, wall_names)
+        if wall_length > exposed + WALL_LENGTH_TOLERANCE_M:
+            exceeding[floor_name] = {
+                "paired_wall_length_m": round(wall_length, 3),
+                "exposed_perimeter_m": round(exposed, 3),
+                "walls": list(wall_names),
+            }
+    return exceeding
 
 
 def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perimeters,
@@ -297,6 +334,19 @@ def set_kiva_foundation(
         )
         if perimeter_error is not None:
             return {"ok": False, "error": perimeter_error}
+
+        exceeding = _walls_exceeding_perimeter(model, wall_pairing["pairs"], perimeters)
+        if exceeding:
+            return {
+                "ok": False,
+                "error": f"On {len(exceeding)} floor(s) the paired below-grade walls are longer "
+                         f"than the exposed perimeter, which EnergyPlus refuses at run time "
+                         f"('combined length greater than the exposed perimeter of the "
+                         f"foundation'). No changes were made. Pass "
+                         f"include_below_grade_walls=False, narrow floor_surface_names, or give "
+                         f"the real exposed_perimeter_m.",
+                "wall_length_exceeds_perimeter": exceeding,
+            }
 
         already = [n for n in floor_names
                    if model.getSurfaceByName(n).get().adjacentFoundation().is_initialized()]

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -26,6 +26,7 @@ from mcp_server.model_manager import ensure_generation_unchanged, get_model_with
 from mcp_server.osm_helpers import parse_str_list
 from mcp_server.skills.geometry.kiva_archetypes import (
     ARCHETYPES,
+    IncompleteInsulationError,
     UnknownArchetypeError,
     get_archetype,
     resolve_insulation,
@@ -373,12 +374,15 @@ def set_kiva_foundation(
         })
         warnings.extend(geometry_warnings)
 
-        insulation, insulation_warnings = resolve_insulation(archetype, {
-            "interior_horizontal_r_si": interior_horizontal_insulation_r_si,
-            "interior_horizontal_width_m": interior_horizontal_insulation_width_m,
-            "exterior_vertical_r_si": exterior_vertical_insulation_r_si,
-            "exterior_vertical_depth_m": exterior_vertical_insulation_depth_m,
-        })
+        try:
+            insulation, insulation_warnings = resolve_insulation(archetype, {
+                "interior_horizontal_r_si": interior_horizontal_insulation_r_si,
+                "interior_horizontal_width_m": interior_horizontal_insulation_width_m,
+                "exterior_vertical_r_si": exterior_vertical_insulation_r_si,
+                "exterior_vertical_depth_m": exterior_vertical_insulation_depth_m,
+            })
+        except IncompleteInsulationError as e:
+            return {"ok": False, "error": str(e), "missing_argument": e.argument}
         warnings.extend(insulation_warnings)
 
         soil, soil_warnings = resolve_soil_properties(

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -181,17 +181,21 @@ def _retire_foundation(kiva) -> str | None:
 def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perimeters,
            archetype, warnings) -> tuple[dict[str, Any], str | None]:
     """Write the Kiva objects. Returns (applied, error)."""
+    applied: dict[str, Any] = {"floors": [], "walls": [], "insulation": {}, "foundations": []}
+
     settings_written = {k: v for k, v in soil.items() if v.write}
     if settings_written:
         settings = model.getFoundationKivaSettings()   # creating here is the intent
-        if "soil_conductivity_w_mk" in settings_written:
-            settings.setSoilConductivity(settings_written["soil_conductivity_w_mk"].value)
-        if "soil_density_kg_m3" in settings_written:
-            settings.setSoilDensity(settings_written["soil_density_kg_m3"].value)
-        if "soil_specific_heat_j_kgk" in settings_written:
-            settings.setSoilSpecificHeat(settings_written["soil_specific_heat_j_kgk"].value)
-
-    applied: dict[str, Any] = {"floors": [], "walls": [], "insulation": {}, "foundations": []}
+        for field, setter in (
+            ("soil_conductivity_w_mk", settings.setSoilConductivity),
+            ("soil_density_kg_m3", settings.setSoilDensity),
+            ("soil_specific_heat_j_kgk", settings.setSoilSpecificHeat),
+        ):
+            if field in settings_written and not setter(settings_written[field].value):
+                return applied, (
+                    f"OpenStudio refused {field}={settings_written[field].value} on "
+                    f"FoundationKivaSettings"
+                )
 
     for floor_name in floor_names:
         floor = model.getSurfaceByName(floor_name).get()
@@ -213,8 +217,10 @@ def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perim
             if resolved.write and not setter(resolved.value):
                 return applied, f"OpenStudio refused {field}={resolved.value} on '{floor_name}'"
 
-        _apply_insulation(model, kiva, insulation, _wall_depth_for(model, wall_names),
-                          applied["insulation"], warnings)
+        error = _apply_insulation(model, kiva, insulation, _wall_depth_for(model, wall_names),
+                                  applied["insulation"], warnings)
+        if error is not None:
+            return applied, error
 
         # Boundary condition FIRST: setAdjacentFoundation leaves sun/wind exposure alone, and a
         # buried slab left SunExposed takes fictitious solar gain.
@@ -278,6 +284,31 @@ def set_kiva_foundation(
         get_archetype(archetype)
     except UnknownArchetypeError as e:
         return {"ok": False, "error": str(e), "valid_values": sorted(ARCHETYPES)}
+
+    # Every dimensional input must be positive. OpenStudio's setters refuse a bad value, but they
+    # do so one object at a time, after earlier objects are written; check before touching anything.
+    not_positive = {
+        name: value for name, value in {
+            "wall_height_above_grade_m": wall_height_above_grade_m,
+            "footing_depth_m": footing_depth_m,
+            "interior_horizontal_insulation_r_si": interior_horizontal_insulation_r_si,
+            "interior_horizontal_insulation_width_m": interior_horizontal_insulation_width_m,
+            "exterior_vertical_insulation_r_si": exterior_vertical_insulation_r_si,
+            "exterior_vertical_insulation_depth_m": exterior_vertical_insulation_depth_m,
+            "soil_conductivity_w_mk": soil_conductivity_w_mk,
+            "soil_density_kg_m3": soil_density_kg_m3,
+            "soil_specific_heat_j_kgk": soil_specific_heat_j_kgk,
+        }.items() if value is not None and value <= 0
+    }
+    if wall_depth_below_slab_m is not None and wall_depth_below_slab_m < 0:
+        not_positive["wall_depth_below_slab_m"] = wall_depth_below_slab_m
+    if not_positive:
+        return {
+            "ok": False,
+            "error": f"{len(not_positive)} argument(s) must be positive (wall_depth_below_slab_m "
+                     f"may be 0); no changes were made.",
+            "invalid_arguments": not_positive,
+        }
 
     try:
         model, generation = get_model_with_generation()

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -53,10 +53,6 @@ from mcp_server.skills.geometry.kiva_foundation import (
 # absorbs floating-point noise between a wall width and the matching floor edge.
 WALL_LENGTH_TOLERANCE_M = 0.001
 
-# A basement archetype landing on a slab-on-grade model is the most likely misuse, and it writes a
-# foundation wall that is not there. Above this depth we require corroborating geometry.
-SUSPICIOUS_WALL_DEPTH_M = 0.5
-
 
 def _epw_soil_set(model, generation: int, epw_path: str | None, warnings: list[str]):
     """The EPW's GROUND TEMPERATURES soil properties, or None.
@@ -300,15 +296,6 @@ def set_kiva_foundation(
             "footing_depth_m": footing_depth_m,
         })
         warnings.extend(geometry_warnings)
-
-        depth = geometry["wall_depth_below_slab_m"]
-        if depth.value and depth.value > SUSPICIOUS_WALL_DEPTH_M and not candidates["eligible_walls"]:
-            return {
-                "ok": False,
-                "error": f"wall_depth_below_slab_m resolved to {depth.value} m but this model has "
-                         f"no below-grade walls — that looks like a basement archetype applied to a "
-                         f"slab-on-grade model. Pass the value explicitly if it is intended.",
-            }
 
         insulation, insulation_warnings = resolve_insulation(archetype, {
             "interior_horizontal_r_si": interior_horizontal_insulation_r_si,

--- a/mcp_server/skills/geometry/kiva_apply.py
+++ b/mcp_server/skills/geometry/kiva_apply.py
@@ -139,6 +139,26 @@ def _walls_exceeding_perimeter(model, walls_by_floor, perimeters) -> dict[str, A
     return exceeding
 
 
+def _retire_foundation(kiva, warnings: list[str]) -> None:
+    """Remove a Foundation object the overwrite has just replaced, unless walls still use it.
+
+    Called after the floor's new walls are attached, so anything still on the old object is a
+    wall this run did not re-pair (include_below_grade_walls=False, or a wall that no longer
+    shares an edge). Removing it then would leave those walls with a dangling Foundation
+    reference; leaving it silently would ship a Foundation:Kiva with walls and no floor.
+    """
+    stranded = sorted(s.nameString() for s in kiva.surfaces())
+    if stranded:
+        warnings.append(
+            f"Previous foundation '{kiva.nameString()}' was kept because {len(stranded)} wall(s) "
+            f"still reference it and were not re-paired this run: {stranded}. EnergyPlus needs a "
+            f"floor on every Foundation:Kiva — re-run with include_below_grade_walls=True or set "
+            f"those walls' boundary condition explicitly.",
+        )
+        return
+    kiva.remove()
+
+
 def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perimeters,
            archetype, warnings) -> tuple[dict[str, Any], str | None]:
     """Write the Kiva objects. Returns (applied, error)."""
@@ -158,7 +178,8 @@ def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perim
         floor = model.getSurfaceByName(floor_name).get()
         wall_names = walls_by_floor.get(floor_name, [])
 
-        if floor.adjacentFoundation().is_initialized():
+        previous = floor.adjacentFoundation()
+        if previous.is_initialized():
             floor.resetAdjacentFoundation()
 
         kiva = openstudio.model.FoundationKiva(model)
@@ -201,6 +222,8 @@ def _apply(model, floor_names, walls_by_floor, geometry, insulation, soil, perim
             "walls": wall_names,
             "exposed_perimeter": {"method": method, "value": value, "provenance": provenance},
         })
+        if previous.is_initialized():
+            _retire_foundation(previous.get(), warnings)
 
     applied["settings_written"] = sorted(settings_written)
     return applied, None

--- a/mcp_server/skills/geometry/kiva_archetypes.py
+++ b/mcp_server/skills/geometry/kiva_archetypes.py
@@ -46,7 +46,7 @@ never written would make provenance theatre, so `resolve_kiva_parameters` report
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 # XPS, from tbd-3.5.0/lib/tbd/geo.rb ("XPS 25mm"). The one vendored material basis available.
 XPS_CONDUCTIVITY_W_MK = 0.029
@@ -78,6 +78,7 @@ TBD_BASIS = "material properties and interior-horizontal width from the vendored
 # Provenance vocabulary. Every reported value carries exactly one of these.
 PROVENANCE_USER = "user"
 PROVENANCE_EPW = "epw_header"
+PROVENANCE_EXISTING = "existing_model"
 PROVENANCE_DEFAULT = "openstudio_default"
 PROVENANCE_DEFAULT_AGREES = "openstudio_default (archetype agrees)"
 PROVENANCE_COMPUTED = "computed_geometry"
@@ -105,6 +106,18 @@ class InsulationSpec:
     r_si_m2k_w: float
     depth_m: float | str | None = None
     width_m: float | None = None
+    # Per-field origin, filled by resolve_insulation: "user" or "archetype:<name>". Empty on the
+    # table entries themselves, which are the archetype by definition.
+    provenance: dict[str, str] = field(default_factory=dict, compare=False)
+
+    def as_plan(self) -> dict[str, object]:
+        """The layer as the plan reports it: every value next to where it came from."""
+        return {
+            "r_si_m2k_w": {"value": self.r_si_m2k_w,
+                           "provenance": self.provenance.get("r_si_m2k_w")},
+            "depth_m": {"value": self.depth_m, "provenance": self.provenance.get("depth_m")},
+            "width_m": {"value": self.width_m, "provenance": self.provenance.get("width_m")},
+        }
 
 
 @dataclass(frozen=True)
@@ -268,17 +281,17 @@ def resolve_kiva_parameters(
         "wall_depth_below_slab_m": archetype.wall_depth_below_slab_m,
         "footing_depth_m": archetype.footing_depth_m,
     }
-    for field, idd_default in _GEOMETRY_DEFAULTS.items():
-        if field in supplied:
-            resolved[field] = ResolvedValue(supplied[field], PROVENANCE_USER)
+    for name, idd_default in _GEOMETRY_DEFAULTS.items():
+        if name in supplied:
+            resolved[name] = ResolvedValue(supplied[name], PROVENANCE_USER)
             continue
-        archetype_value = archetype_values[field]
+        archetype_value = archetype_values[name]
         if archetype_value == idd_default:
-            resolved[field] = ResolvedValue(
+            resolved[name] = ResolvedValue(
                 archetype_value, PROVENANCE_DEFAULT_AGREES, write=False,
             )
         else:
-            resolved[field] = ResolvedValue(archetype_value, f"archetype:{archetype_name}")
+            resolved[name] = ResolvedValue(archetype_value, f"archetype:{archetype_name}")
 
     unknown = sorted(set(supplied) - set(_GEOMETRY_DEFAULTS))
     if unknown:
@@ -302,7 +315,16 @@ def resolve_insulation(
     supplied = {k: v for k, v in (overrides or {}).items() if v is not None}
     warnings: list[str] = []
 
-    by_position = {spec.position: spec for spec in archetype.insulation}
+    from_archetype = f"archetype:{archetype_name}"
+    by_position = {
+        spec.position: InsulationSpec(
+            position=spec.position, r_si_m2k_w=spec.r_si_m2k_w, depth_m=spec.depth_m,
+            width_m=spec.width_m,
+            provenance={"r_si_m2k_w": from_archetype, "depth_m": from_archetype,
+                        "width_m": from_archetype},
+        )
+        for spec in archetype.insulation
+    }
     for position in (POSITION_INTERIOR_HORIZONTAL, POSITION_EXTERIOR_VERTICAL):
         r_si = supplied.get(f"{position}_r_si")
         depth = supplied.get(f"{position}_depth_m")
@@ -316,11 +338,17 @@ def resolve_insulation(
                 f"applies no {position} insulation.",
             )
             continue
+        base = existing.provenance if existing else {}
         by_position[position] = InsulationSpec(
             position=position,
             r_si_m2k_w=r_si if r_si is not None else existing.r_si_m2k_w,
             depth_m=depth if depth is not None else (existing.depth_m if existing else None),
             width_m=width if width is not None else (existing.width_m if existing else None),
+            provenance={
+                "r_si_m2k_w": PROVENANCE_USER if r_si is not None else base.get("r_si_m2k_w"),
+                "depth_m": PROVENANCE_USER if depth is not None else base.get("depth_m"),
+                "width_m": PROVENANCE_USER if width is not None else base.get("width_m"),
+            },
         )
 
     ordered = [by_position[p] for p in
@@ -331,18 +359,25 @@ def resolve_insulation(
 def resolve_soil_properties(
     ground_temperature_set=None,
     overrides: dict[str, float | None] | None = None,
+    existing: dict[str, float | None] | None = None,
 ) -> tuple[dict[str, ResolvedValue], list[str]]:
     """Soil conductivity, density and specific heat for FoundationKivaSettings.
 
-    Precedence: caller override, then the EPW header's GROUND TEMPERATURES soil fields, then the
-    OpenStudio defaults. Those three EPW fields are blank in every EPW bundled with this repo, so
-    the defaulted path is the normal one — and when nothing is chosen the writer should not create
-    the settings object at all, which is why every value carries `write`.
+    Precedence: caller override, then a value already chosen on the model's FoundationKivaSettings
+    (reported as `existing_model`, never overwritten), then the EPW header's GROUND TEMPERATURES
+    soil fields, then the OpenStudio defaults. Those three EPW fields are blank in every EPW bundled
+    with this repo, so the defaulted path is the normal one — and when nothing is chosen the writer
+    should not create the settings object at all, which is why every value carries `write`.
+
+    `existing` maps the three field names to the model's non-defaulted values (None when the
+    field is still at its IDD default, or when the settings object does not exist). Without it the
+    plan would report `openstudio_default` for a value the simulation will not actually use.
 
     `ground_temperature_set` is an epw_ground_temperatures.GroundTemperatureSet or None; it is
     duck-typed so this module stays free of that import at runtime.
     """
     supplied = {k: v for k, v in (overrides or {}).items() if v is not None}
+    chosen = {k: v for k, v in (existing or {}).items() if v is not None}
     warnings: list[str] = []
     resolved: dict[str, ResolvedValue] = {}
 
@@ -357,15 +392,18 @@ def resolve_soil_properties(
             "soil_density_kg_m3": ground_temperature_set.density_kg_m3,
             "soil_specific_heat_j_kgk": ground_temperature_set.specific_heat_j_kgk,
         }
-    for field, default in _SOIL_DEFAULTS.items():
-        if field in supplied:
-            resolved[field] = ResolvedValue(supplied[field], PROVENANCE_USER)
+    for name, default in _SOIL_DEFAULTS.items():
+        if name in supplied:
+            resolved[name] = ResolvedValue(supplied[name], PROVENANCE_USER)
             continue
-        epw_value = epw_values[field]
+        if name in chosen:
+            resolved[name] = ResolvedValue(chosen[name], PROVENANCE_EXISTING, write=False)
+            continue
+        epw_value = epw_values[name]
         if epw_value is not None:
-            resolved[field] = ResolvedValue(epw_value, PROVENANCE_EPW)
+            resolved[name] = ResolvedValue(epw_value, PROVENANCE_EPW)
         else:
-            resolved[field] = ResolvedValue(default, PROVENANCE_DEFAULT, write=False)
+            resolved[name] = ResolvedValue(default, PROVENANCE_DEFAULT, write=False)
 
     if ground_temperature_set is not None and all(
         r.provenance == PROVENANCE_DEFAULT for r in resolved.values()

--- a/mcp_server/skills/geometry/kiva_archetypes.py
+++ b/mcp_server/skills/geometry/kiva_archetypes.py
@@ -1,0 +1,399 @@
+"""Foundation archetypes for EnergyPlus Kiva, and the provenance of every value they supply.
+
+Kiva needs foundation detail a gbXML export does not contain — insulation position, R-value and
+extent. Asking a modeller ten dimensional questions gets nobody a model, so this module offers a
+short menu of named foundation types, each expanding into a complete parameter set that the caller
+can then override field by field.
+
+**An archetype is an insulation strategy, not a geometry description.** Basement depth is not a
+Kiva input: EnergyPlus reads the below-grade wall surfaces attached to the same Foundation object
+and their height *is* the depth. `wallHeightAboveGrade` only says how much of that wall shows above
+grade, and `wallDepthBelowSlab` is the footing stem below the slab underside. So an archetype can
+never contradict the geometry the model already carries.
+
+Kept free of `import openstudio` (CLAUDE.md rule 4) so the table and the provenance merge — the
+part most likely to be wrong — are unit-testable with no container. Same trade as
+weather/epw_ground_temperatures.py and gbxml_import/zone_checks.py.
+
+## Where the numbers come from, honestly
+
+There is **no vendored Kiva insulation geometry** in this image, and this module does not pretend
+otherwise:
+
+- `openstudio-standards-0.8.5` carries 90 `GroundContact*` rows in
+  `ashrae_90_1_2019.construction_properties.json`, but they are **F-factor and C-factor only** —
+  code performance per unit perimeter, with no insulation depth, width or position. Inverting an
+  F-factor into Kiva geometry needs ASHRAE 90.1 Appendix A tables that are not vendored here.
+- NECB's `apply_kiva_foundation` (openstudio-standards) applies no insulation at all.
+- ComStock has no foundation insulation parameters.
+
+**Sourced:** the XPS material properties and the 0.6 m interior-horizontal width come from the
+`tbd-3.5.0` gem (`lib/tbd/geo.rb`), which is vendored and does exactly this job.
+
+**Not sourced:** every R-value and insulation extent below is a *conventional starting point*. Each
+archetype carries a `basis` string saying so, and it travels into the tool response. The caller is
+separately shown the 90.1 F-factor/C-factor target for the model's climate zone, so the vendored
+data is used for what it actually is — a cross-check — rather than as a fake derivation.
+
+## IDD defaults and the provenance rule
+
+Probed on OpenStudio 3.11.0: `wallHeightAboveGrade` 0.2, `wallDepthBelowSlab` 0.0, `footingDepth`
+0.3, both horizontal insulation extents 0.0, soil 1.73 / 1842.0 / 419.0.
+
+Several archetype values equal the IDD default. Claiming `archetype:<name>` for a field that was
+never written would make provenance theatre, so `resolve_kiva_parameters` reports
+`openstudio_default (archetype agrees)` in that case and the writer leaves the field defaulted.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# XPS, from tbd-3.5.0/lib/tbd/geo.rb ("XPS 25mm"). The one vendored material basis available.
+XPS_CONDUCTIVITY_W_MK = 0.029
+XPS_DENSITY_KG_M3 = 28.0
+XPS_SPECIFIC_HEAT_J_KGK = 1450.0
+XPS_ROUGHNESS = "Rough"
+
+# OpenStudio/EnergyPlus IDD defaults, probed on 3.11.0.
+IDD_WALL_HEIGHT_ABOVE_GRADE_M = 0.2
+IDD_WALL_DEPTH_BELOW_SLAB_M = 0.0
+IDD_FOOTING_DEPTH_M = 0.3
+IDD_SOIL_CONDUCTIVITY_W_MK = 1.73
+IDD_SOIL_DENSITY_KG_M3 = 1842.0
+IDD_SOIL_SPECIFIC_HEAT_J_KGK = 419.0
+
+# TBD's clamp for a floor with no exposed edge — Kiva rejects a zero perimeter.
+MIN_EXPOSED_PERIMETER_M = 0.001
+
+# R-SI 1.76 m2K/W is R-10 IP, the conventional starting point for slab-edge and basement-wall
+# insulation in this table. Not a code-derived value — see the module docstring.
+CONVENTIONAL_R_SI = 1.76
+
+CONVENTIONAL_BASIS = (
+    "conventional starting point — not derived from a code table or a vendored dataset; "
+    "check it against the reported 90.1 F-factor/C-factor target for this climate zone"
+)
+TBD_BASIS = "material properties and interior-horizontal width from the vendored tbd gem (geo.rb)"
+
+# Provenance vocabulary. Every reported value carries exactly one of these.
+PROVENANCE_USER = "user"
+PROVENANCE_EPW = "epw_header"
+PROVENANCE_DEFAULT = "openstudio_default"
+PROVENANCE_DEFAULT_AGREES = "openstudio_default (archetype agrees)"
+PROVENANCE_COMPUTED = "computed_geometry"
+PROVENANCE_COMPUTED_CLAMPED = "computed_geometry_zero_clamped"
+PROVENANCE_FALLBACK_FRACTION = "fallback_fraction"
+
+# Insulation positions, matching the FoundationKiva setter families.
+POSITION_INTERIOR_HORIZONTAL = "interior_horizontal"
+POSITION_EXTERIOR_VERTICAL = "exterior_vertical"
+
+# Sentinel for "run this insulation the full depth of the below-grade wall", which is only
+# knowable from the model geometry at write time.
+MATCH_WALL_DEPTH = "match_wall_depth"
+
+
+@dataclass(frozen=True)
+class InsulationSpec:
+    """One insulation layer on the Kiva cross-section.
+
+    `depth_m` may be the string MATCH_WALL_DEPTH, meaning "run to the bottom of the below-grade
+    wall" — resolved from geometry by the writer, since the archetype cannot know it.
+    """
+
+    position: str
+    r_si_m2k_w: float
+    depth_m: float | str | None = None
+    width_m: float | None = None
+
+
+@dataclass(frozen=True)
+class Archetype:
+    name: str
+    label: str
+    description: str
+    basis: str
+    wall_height_above_grade_m: float
+    wall_depth_below_slab_m: float
+    footing_depth_m: float
+    insulation: tuple[InsulationSpec, ...]
+
+
+ARCHETYPES: dict[str, Archetype] = {
+    "slab_on_grade_uninsulated": Archetype(
+        name="slab_on_grade_uninsulated",
+        label="Slab on grade, uninsulated",
+        description=(
+            "A slab poured at grade with no perimeter insulation. Common in older commercial "
+            "construction and in mild climates."
+        ),
+        basis="no insulation to source — the absence is the modelling choice",
+        wall_height_above_grade_m=IDD_WALL_HEIGHT_ABOVE_GRADE_M,
+        wall_depth_below_slab_m=IDD_WALL_DEPTH_BELOW_SLAB_M,
+        footing_depth_m=IDD_FOOTING_DEPTH_M,
+        insulation=(),
+    ),
+    "slab_on_grade_perimeter_insulated": Archetype(
+        name="slab_on_grade_perimeter_insulated",
+        label="Slab on grade with perimeter insulation",
+        description=(
+            "A slab at grade with rigid insulation on the outside face of the perimeter foundation "
+            "wall, running down from grade. The common code-compliant slab detail."
+        ),
+        basis=CONVENTIONAL_BASIS,
+        wall_height_above_grade_m=IDD_WALL_HEIGHT_ABOVE_GRADE_M,
+        wall_depth_below_slab_m=IDD_WALL_DEPTH_BELOW_SLAB_M,
+        footing_depth_m=IDD_FOOTING_DEPTH_M,
+        insulation=(
+            InsulationSpec(POSITION_EXTERIOR_VERTICAL, CONVENTIONAL_R_SI, depth_m=0.6),
+        ),
+    ),
+    "heated_basement_insulated": Archetype(
+        name="heated_basement_insulated",
+        label="Heated basement, insulated walls",
+        description=(
+            "A conditioned basement with rigid insulation on the outside face of the basement "
+            "wall, running its full below-grade depth. Depth comes from your model's wall "
+            "geometry, not from this archetype."
+        ),
+        basis=CONVENTIONAL_BASIS,
+        wall_height_above_grade_m=IDD_WALL_HEIGHT_ABOVE_GRADE_M,
+        wall_depth_below_slab_m=IDD_WALL_DEPTH_BELOW_SLAB_M,
+        footing_depth_m=IDD_FOOTING_DEPTH_M,
+        insulation=(
+            InsulationSpec(POSITION_EXTERIOR_VERTICAL, CONVENTIONAL_R_SI, depth_m=MATCH_WALL_DEPTH),
+        ),
+    ),
+    "unheated_basement": Archetype(
+        name="unheated_basement",
+        label="Unheated basement",
+        description=(
+            "An unconditioned basement with no added foundation insulation — whatever resistance "
+            "exists is in the wall construction itself."
+        ),
+        basis="no insulation to source — the absence is the modelling choice",
+        wall_height_above_grade_m=IDD_WALL_HEIGHT_ABOVE_GRADE_M,
+        wall_depth_below_slab_m=IDD_WALL_DEPTH_BELOW_SLAB_M,
+        footing_depth_m=IDD_FOOTING_DEPTH_M,
+        insulation=(),
+    ),
+    "crawlspace_vented": Archetype(
+        name="crawlspace_vented",
+        label="Vented crawlspace",
+        description=(
+            "A shallow vented crawlspace with insulation laid horizontally inward from the "
+            "foundation wall. More of the stem wall shows above grade than on a slab."
+        ),
+        basis=f"{CONVENTIONAL_BASIS}; width {TBD_BASIS}",
+        wall_height_above_grade_m=0.6,
+        wall_depth_below_slab_m=IDD_WALL_DEPTH_BELOW_SLAB_M,
+        footing_depth_m=IDD_FOOTING_DEPTH_M,
+        insulation=(
+            InsulationSpec(POSITION_INTERIOR_HORIZONTAL, CONVENTIONAL_R_SI, width_m=0.6),
+        ),
+    ),
+}
+
+# Geometry fields an archetype supplies, paired with the IDD default they may coincide with.
+_GEOMETRY_DEFAULTS = {
+    "wall_height_above_grade_m": IDD_WALL_HEIGHT_ABOVE_GRADE_M,
+    "wall_depth_below_slab_m": IDD_WALL_DEPTH_BELOW_SLAB_M,
+    "footing_depth_m": IDD_FOOTING_DEPTH_M,
+}
+
+_SOIL_DEFAULTS = {
+    "soil_conductivity_w_mk": IDD_SOIL_CONDUCTIVITY_W_MK,
+    "soil_density_kg_m3": IDD_SOIL_DENSITY_KG_M3,
+    "soil_specific_heat_j_kgk": IDD_SOIL_SPECIFIC_HEAT_J_KGK,
+}
+
+_EPW_SOIL_FIELDS = {
+    "soil_conductivity_w_mk": "conductivity_w_mk",
+    "soil_density_kg_m3": "density_kg_m3",
+    "soil_specific_heat_j_kgk": "specific_heat_j_kgk",
+}
+
+
+class UnknownArchetypeError(ValueError):
+    """The caller named a foundation archetype that does not exist."""
+
+
+@dataclass(frozen=True)
+class ResolvedValue:
+    """One parameter, its origin, and whether the writer should actually write it.
+
+    `write` is False when the resolved value equals the IDD default and no caller asked for it —
+    leaving the field defaulted keeps the OSM honest about what was actually chosen.
+    """
+
+    value: float | str | None
+    provenance: str
+    write: bool = True
+    note: str | None = None
+
+
+def xps_thickness_m(r_si_m2k_w: float) -> float:
+    """Thickness of XPS giving the requested thermal resistance.
+
+    Modellers think in R, and FoundationKiva wants a Material with a thickness — this is the
+    conversion between them, at the vendored XPS conductivity.
+    """
+    if r_si_m2k_w <= 0:
+        raise ValueError(f"R-value must be positive, got {r_si_m2k_w}")
+    return r_si_m2k_w * XPS_CONDUCTIVITY_W_MK
+
+
+def get_archetype(name: str) -> Archetype:
+    """The named archetype, or UnknownArchetypeError listing the valid names."""
+    try:
+        return ARCHETYPES[name]
+    except KeyError:
+        raise UnknownArchetypeError(
+            f"Unknown foundation archetype '{name}'. Valid: {sorted(ARCHETYPES)}",
+        ) from None
+
+
+def resolve_kiva_parameters(
+    archetype_name: str,
+    overrides: dict[str, float | None] | None = None,
+) -> tuple[dict[str, ResolvedValue], list[str]]:
+    """Merge an archetype's geometry values with caller overrides.
+
+    Returns (resolved, warnings). A caller value always wins and reports `user`. An archetype value
+    that equals the IDD default reports `openstudio_default (archetype agrees)` with `write=False`,
+    so the writer leaves the field alone rather than claiming credit for a default.
+    """
+    archetype = get_archetype(archetype_name)
+    supplied = {k: v for k, v in (overrides or {}).items() if v is not None}
+    warnings: list[str] = []
+    resolved: dict[str, ResolvedValue] = {}
+
+    for field, idd_default in _GEOMETRY_DEFAULTS.items():
+        if field in supplied:
+            resolved[field] = ResolvedValue(supplied[field], PROVENANCE_USER)
+            continue
+        archetype_value = getattr(archetype, field)
+        if archetype_value == idd_default:
+            resolved[field] = ResolvedValue(
+                archetype_value, PROVENANCE_DEFAULT_AGREES, write=False,
+            )
+        else:
+            resolved[field] = ResolvedValue(archetype_value, f"archetype:{archetype_name}")
+
+    unknown = sorted(set(supplied) - set(_GEOMETRY_DEFAULTS))
+    if unknown:
+        warnings.append(
+            f"Ignoring unrecognised geometry override(s): {', '.join(unknown)}",
+        )
+    return resolved, warnings
+
+
+def resolve_insulation(
+    archetype_name: str,
+    overrides: dict[str, float | None] | None = None,
+) -> tuple[list[InsulationSpec], list[str]]:
+    """The insulation layers to apply, after caller overrides.
+
+    Overrides are per position: `<position>_r_si`, `<position>_depth_m`, `<position>_width_m`.
+    Supplying an R-value for a position the archetype does not use adds that layer; supplying one
+    the archetype does use replaces its value.
+    """
+    archetype = get_archetype(archetype_name)
+    supplied = {k: v for k, v in (overrides or {}).items() if v is not None}
+    warnings: list[str] = []
+
+    by_position = {spec.position: spec for spec in archetype.insulation}
+    for position in (POSITION_INTERIOR_HORIZONTAL, POSITION_EXTERIOR_VERTICAL):
+        r_si = supplied.get(f"{position}_r_si")
+        depth = supplied.get(f"{position}_depth_m")
+        width = supplied.get(f"{position}_width_m")
+        if r_si is None and depth is None and width is None:
+            continue
+        existing = by_position.get(position)
+        if existing is None and r_si is None:
+            warnings.append(
+                f"Ignoring {position} extent override: no R-value given and this archetype "
+                f"applies no {position} insulation.",
+            )
+            continue
+        by_position[position] = InsulationSpec(
+            position=position,
+            r_si_m2k_w=r_si if r_si is not None else existing.r_si_m2k_w,
+            depth_m=depth if depth is not None else (existing.depth_m if existing else None),
+            width_m=width if width is not None else (existing.width_m if existing else None),
+        )
+
+    ordered = [by_position[p] for p in
+               (POSITION_INTERIOR_HORIZONTAL, POSITION_EXTERIOR_VERTICAL) if p in by_position]
+    return ordered, warnings
+
+
+def resolve_soil_properties(
+    ground_temperature_set=None,
+    overrides: dict[str, float | None] | None = None,
+) -> tuple[dict[str, ResolvedValue], list[str]]:
+    """Soil conductivity, density and specific heat for FoundationKivaSettings.
+
+    Precedence: caller override, then the EPW header's GROUND TEMPERATURES soil fields, then the
+    OpenStudio defaults. Those three EPW fields are blank in every EPW bundled with this repo, so
+    the defaulted path is the normal one — and when nothing is chosen the writer should not create
+    the settings object at all, which is why every value carries `write`.
+
+    `ground_temperature_set` is an epw_ground_temperatures.GroundTemperatureSet or None; it is
+    duck-typed so this module stays free of that import at runtime.
+    """
+    supplied = {k: v for k, v in (overrides or {}).items() if v is not None}
+    warnings: list[str] = []
+    resolved: dict[str, ResolvedValue] = {}
+
+    for field, default in _SOIL_DEFAULTS.items():
+        if field in supplied:
+            resolved[field] = ResolvedValue(supplied[field], PROVENANCE_USER)
+            continue
+        epw_value = None
+        if ground_temperature_set is not None:
+            epw_value = getattr(ground_temperature_set, _EPW_SOIL_FIELDS[field], None)
+        if epw_value is not None:
+            resolved[field] = ResolvedValue(epw_value, PROVENANCE_EPW)
+        else:
+            resolved[field] = ResolvedValue(default, PROVENANCE_DEFAULT, write=False)
+
+    if ground_temperature_set is not None and all(
+        r.provenance == PROVENANCE_DEFAULT for r in resolved.values()
+    ):
+        warnings.append(
+            "The EPW header carries no soil properties (blank in every TMY file shipped with "
+            "this repo), so OpenStudio's defaults stand: 1.73 W/m-K, 1842 kg/m3, 419 J/kg-K.",
+        )
+    return resolved, warnings
+
+
+def archetype_menu() -> list[dict[str, object]]:
+    """The archetype list an agent shows the user, with each one's full parameter set.
+
+    The point is that the user sees the numbers before committing to them, rather than picking an
+    opaque name — which is the only honest way to offer defaults nobody sourced.
+    """
+    menu: list[dict[str, object]] = []
+    for name, archetype in ARCHETYPES.items():
+        menu.append({
+            "name": name,
+            "label": archetype.label,
+            "description": archetype.description,
+            "basis": archetype.basis,
+            "wall_height_above_grade_m": archetype.wall_height_above_grade_m,
+            "wall_depth_below_slab_m": archetype.wall_depth_below_slab_m,
+            "footing_depth_m": archetype.footing_depth_m,
+            "insulation": [
+                {
+                    "position": spec.position,
+                    "r_si_m2k_w": spec.r_si_m2k_w,
+                    "material": "XPS",
+                    "thickness_m": round(xps_thickness_m(spec.r_si_m2k_w), 4),
+                    "depth_m": spec.depth_m,
+                    "width_m": spec.width_m,
+                }
+                for spec in archetype.insulation
+            ],
+        })
+    return menu

--- a/mcp_server/skills/geometry/kiva_archetypes.py
+++ b/mcp_server/skills/geometry/kiva_archetypes.py
@@ -207,11 +207,6 @@ _SOIL_DEFAULTS = {
     "soil_specific_heat_j_kgk": IDD_SOIL_SPECIFIC_HEAT_J_KGK,
 }
 
-_EPW_SOIL_FIELDS = {
-    "soil_conductivity_w_mk": "conductivity_w_mk",
-    "soil_density_kg_m3": "density_kg_m3",
-    "soil_specific_heat_j_kgk": "specific_heat_j_kgk",
-}
 
 
 class UnknownArchetypeError(ValueError):
@@ -268,11 +263,16 @@ def resolve_kiva_parameters(
     warnings: list[str] = []
     resolved: dict[str, ResolvedValue] = {}
 
+    archetype_values = {
+        "wall_height_above_grade_m": archetype.wall_height_above_grade_m,
+        "wall_depth_below_slab_m": archetype.wall_depth_below_slab_m,
+        "footing_depth_m": archetype.footing_depth_m,
+    }
     for field, idd_default in _GEOMETRY_DEFAULTS.items():
         if field in supplied:
             resolved[field] = ResolvedValue(supplied[field], PROVENANCE_USER)
             continue
-        archetype_value = getattr(archetype, field)
+        archetype_value = archetype_values[field]
         if archetype_value == idd_default:
             resolved[field] = ResolvedValue(
                 archetype_value, PROVENANCE_DEFAULT_AGREES, write=False,
@@ -346,13 +346,22 @@ def resolve_soil_properties(
     warnings: list[str] = []
     resolved: dict[str, ResolvedValue] = {}
 
+    epw_values = {
+        "soil_conductivity_w_mk": None,
+        "soil_density_kg_m3": None,
+        "soil_specific_heat_j_kgk": None,
+    }
+    if ground_temperature_set is not None:
+        epw_values = {
+            "soil_conductivity_w_mk": ground_temperature_set.conductivity_w_mk,
+            "soil_density_kg_m3": ground_temperature_set.density_kg_m3,
+            "soil_specific_heat_j_kgk": ground_temperature_set.specific_heat_j_kgk,
+        }
     for field, default in _SOIL_DEFAULTS.items():
         if field in supplied:
             resolved[field] = ResolvedValue(supplied[field], PROVENANCE_USER)
             continue
-        epw_value = None
-        if ground_temperature_set is not None:
-            epw_value = getattr(ground_temperature_set, _EPW_SOIL_FIELDS[field], None)
+        epw_value = epw_values[field]
         if epw_value is not None:
             resolved[field] = ResolvedValue(epw_value, PROVENANCE_EPW)
         else:

--- a/mcp_server/skills/geometry/kiva_archetypes.py
+++ b/mcp_server/skills/geometry/kiva_archetypes.py
@@ -226,6 +226,34 @@ class UnknownArchetypeError(ValueError):
     """The caller named a foundation archetype that does not exist."""
 
 
+class IncompleteInsulationError(ValueError):
+    """An insulation layer has a material but not the extent EnergyPlus needs to place it.
+
+    Foundation:Kiva: an interior-horizontal material needs a width ("extent of insulation as
+    measured from the wall interior"); an exterior-vertical material needs a depth ("measured
+    from the wall top to the bottom edge"). OpenStudio accepts the half-specified object and the
+    ForwardTranslator passes it through; EnergyPlus then terminates fatally. `argument` names the
+    set_kiva_foundation parameter that supplies the missing extent.
+    """
+
+    def __init__(self, position: str, argument: str):
+        self.position = position
+        self.argument = argument
+        super().__init__(
+            f"{position} insulation has an R-value but no extent; EnergyPlus refuses a "
+            f"Foundation:Kiva whose {position.replace('_', ' ')} material has no "
+            f"{'width' if position == POSITION_INTERIOR_HORIZONTAL else 'depth'}. "
+            f"Pass {argument} (this archetype supplies none for that position).",
+        )
+
+
+# The tool argument that supplies each position's required extent.
+_EXTENT_ARGUMENT = {
+    POSITION_INTERIOR_HORIZONTAL: "interior_horizontal_insulation_width_m",
+    POSITION_EXTERIOR_VERTICAL: "exterior_vertical_insulation_depth_m",
+}
+
+
 @dataclass(frozen=True)
 class ResolvedValue:
     """One parameter, its origin, and whether the writer should actually write it.
@@ -309,7 +337,10 @@ def resolve_insulation(
 
     Overrides are per position: `<position>_r_si`, `<position>_depth_m`, `<position>_width_m`.
     Supplying an R-value for a position the archetype does not use adds that layer; supplying one
-    the archetype does use replaces its value.
+    the archetype does use replaces its value. A layer whose required extent (width for interior
+    horizontal, depth for exterior vertical) is still None after the merge raises
+    IncompleteInsulationError rather than being returned: the SDK would write it and EnergyPlus
+    would refuse it.
     """
     archetype = get_archetype(archetype_name)
     supplied = {k: v for k, v in (overrides or {}).items() if v is not None}
@@ -353,6 +384,10 @@ def resolve_insulation(
 
     ordered = [by_position[p] for p in
                (POSITION_INTERIOR_HORIZONTAL, POSITION_EXTERIOR_VERTICAL) if p in by_position]
+    for spec in ordered:
+        extent = spec.width_m if spec.position == POSITION_INTERIOR_HORIZONTAL else spec.depth_m
+        if extent is None:
+            raise IncompleteInsulationError(spec.position, _EXTENT_ARGUMENT[spec.position])
     return ordered, warnings
 
 

--- a/mcp_server/skills/geometry/kiva_eligibility.py
+++ b/mcp_server/skills/geometry/kiva_eligibility.py
@@ -58,6 +58,10 @@ from mcp_server.skills.geometry.ground_contact import (
 
 MAX_KIVA_WALL_VERTICES = 4
 
+# A matched interior boundary condition: the surface has a partner, not soil. Never a Kiva
+# candidate regardless of depth, and never part of the ground-contact footprint.
+_MATCHED_INTERIOR = "Surface"
+
 # joinAllPolygons tolerance. Matches the value both vendored implementations use and the scale of
 # the sibling geometry guards (PLANE_TOLERANCE, GRADE_TOLERANCE_M).
 POLYGON_JOIN_TOLERANCE_M = 0.01
@@ -187,7 +191,8 @@ def classify_foundation_candidates(model, include_adiabatic: bool = False) -> di
 
     Adiabatic surfaces are excluded by default: `patch_missing_surfaces` sets that condition
     deliberately on facets it could not identify, and silently burying them would undo a decision
-    another tool made on purpose.
+    another tool made on purpose. Matched interior surfaces (`Surface`) are always excluded: depth
+    says nothing about whether a floor or wall touches soil when it has a partner on the other side.
     """
     eligible_floors: list[dict[str, Any]] = []
     eligible_walls: list[dict[str, Any]] = []
@@ -201,6 +206,12 @@ def classify_foundation_candidates(model, include_adiabatic: bool = False) -> di
 
         condition = surface.outsideBoundaryCondition()
         if condition == "Adiabatic" and not include_adiabatic:
+            continue
+        if condition == _MATCHED_INTERIOR:
+            # A matched interior boundary has a partner surface, not soil, however deep it sits —
+            # a two-storey basement's middle floor, a crawlspace modelled as a zone, a partition
+            # between two basement zones. ground_contact.py makes the same cut. Converting one
+            # would also reset the pairing and drop its partner to Outdoors/SunExposed.
             continue
 
         if not _has_space(surface):
@@ -292,6 +303,7 @@ def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str,
     candidates = [
         s for s in model.getSurfaces()
         if s.surfaceType() == "Floor" and _has_space(s) and _floor_is_at_or_below_grade(s)
+        and s.outsideBoundaryCondition() != _MATCHED_INTERIOR
     ]
     if not candidates:
         return {}, ["No at-or-below-grade floors found to build a footprint from."]

--- a/mcp_server/skills/geometry/kiva_eligibility.py
+++ b/mcp_server/skills/geometry/kiva_eligibility.py
@@ -1,0 +1,323 @@
+"""Which surfaces EnergyPlus Kiva will accept, and the exposed perimeter of each foundation floor.
+
+Split from kiva_foundation.py to keep both files inside the ~250/400 line budget (CLAUDE.md rule 1).
+This half answers "may this surface be a Kiva surface, and how much slab edge is exposed"; the other
+half writes the objects.
+
+## The segfault
+
+`Surface.exposedPerimeter()` takes an `openstudio::Polygon3d`, and **it segfaults the interpreter
+when the surface has no parent Space** — no Python exception, no error dict, the MCP session dies.
+Reproduced twice on OpenStudio 3.11.0. gbXML imports genuinely produce parentless surfaces (that is
+why `patch_missing_surfaces` exists), so every path here checks `space().is_initialized()` before
+touching that method. `_has_space()` is the guard and it is not optional.
+
+## Computing exposed perimeter
+
+Verified recipe, and the only one that works:
+
+    polys = openstudio.Point3dVectorVector()
+    for f in every_candidate_floor:                  # ALL of them, not just the selected ones
+        polys.append(f.space().get().transformation() * f.vertices())
+    joined = openstudio.joinAllPolygons(polys, 0.01)
+    exposed = sum(f.exposedPerimeter(j) for j in joined)
+
+On `exampleModel()` this gives each of the four quadrant floors 20.0 and a total of 80.0 — exactly
+the footprint. A hand-built `Polygon3d` returns 0.0 because the winding does not match, so the join
+is mandatory. Neighbouring floors must be in the join or an interior slab bay will not correctly
+score zero. A disjoint-wing model produces several polygons and each floor scores against exactly
+one, so summing across them is both required and safe.
+
+## The EnergyPlus rules, from the 25.2 binary's own error strings
+
+  - only one floor per Foundation:Kiva object
+  - only floor and wall surfaces may reference a Foundation boundary condition
+  - a Foundation surface with no SurfaceProperty:ExposedFoundationPerimeter is fatal
+  - Kiva walls must have no more than four vertices
+  - "Foundation" boundary condition must use only regular material objects (no massless/no-mass)
+  - "Foundation" is not allowed with windows
+  - Kiva requires a weather file; it cannot run design-day-only
+  - paired wall lengths must not exceed the floor's exposed perimeter
+
+Everything cheap to check is checked here and the surface is refused with a reason. Nothing is
+half-written and nothing is guessed — the same posture as ground_contact.py, which refuses to decide
+whether a slab is on grade or over a crawlspace.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import openstudio
+
+from mcp_server.skills.geometry.edge_graph import point_key
+from mcp_server.skills.geometry.ground_contact import (
+    GRADE_TOLERANCE_M,
+    MIN_BURIED_WALL_FRACTION,
+    world_z_range,
+)
+
+MAX_KIVA_WALL_VERTICES = 4
+
+# joinAllPolygons tolerance. Matches the value both vendored implementations use and the scale of
+# the sibling geometry guards (PLANE_TOLERANCE, GRADE_TOLERANCE_M).
+POLYGON_JOIN_TOLERANCE_M = 0.01
+
+# Above this many eligible floors, EnergyPlus builds that many separate 2D finite-difference
+# domains (one Kiva object per floor is its rule, not a choice) and the run time stops being
+# incidental. The caller must opt in past this.
+KIVA_DOMAIN_WARN_THRESHOLD = 20
+
+
+def _has_space(surface) -> bool:
+    """Guard for the exposedPerimeter segfault. Never call that method without this."""
+    return surface.space().is_initialized()
+
+
+def _world_vertices(surface):
+    """Surface vertices in world coordinates, or None when it has no parent space."""
+    if not _has_space(surface):
+        return None
+    return surface.space().get().transformation() * surface.vertices()
+
+
+def _layers_are_standard_opaque(surface) -> tuple[bool, str | None]:
+    """(ok, reason). EnergyPlus refuses a Foundation surface whose construction has no-mass layers."""
+    construction = surface.construction()
+    if not construction.is_initialized():
+        return False, "no construction assigned"
+    layered = construction.get().to_LayeredConstruction()
+    if not layered.is_initialized():
+        return False, "construction is not a layered construction"
+    layers = layered.get().layers()
+    if not layers:
+        return False, "construction has no layers"
+    for layer in layers:
+        if not layer.to_StandardOpaqueMaterial().is_initialized():
+            return False, (
+                f"construction layer '{layer.nameString()}' is not a standard opaque material — "
+                f"EnergyPlus refuses massless layers on a Foundation surface"
+            )
+    return True, None
+
+
+def kiva_surface_blockers(surface) -> list[str]:
+    """Every reason EnergyPlus would refuse this surface as a Kiva surface. Empty means eligible."""
+    blockers: list[str] = []
+
+    surface_type = surface.surfaceType()
+    if surface_type not in ("Floor", "Wall"):
+        blockers.append(f"surface type is {surface_type}; Kiva accepts only Floor and Wall")
+
+    if not _has_space(surface):
+        blockers.append("surface has no parent space")
+
+    if len(surface.subSurfaces()) > 0:
+        blockers.append(
+            "surface carries windows or doors; the Foundation boundary condition is not allowed "
+            "with subsurfaces",
+        )
+
+    if surface_type == "Wall" and len(surface.vertices()) > MAX_KIVA_WALL_VERTICES:
+        blockers.append(
+            f"wall has {len(surface.vertices())} vertices; Kiva walls are limited to "
+            f"{MAX_KIVA_WALL_VERTICES}",
+        )
+
+    ok, reason = _layers_are_standard_opaque(surface)
+    if not ok:
+        blockers.append(reason)
+
+    return blockers
+
+
+def _floor_is_at_or_below_grade(surface) -> bool:
+    z_range = world_z_range(surface)
+    if z_range is None:
+        return False
+    return z_range[1] <= GRADE_TOLERANCE_M
+
+
+def _wall_buried_fraction(surface) -> float | None:
+    """Fraction of a wall's height that sits below grade, or None when it has no parent space."""
+    z_range = world_z_range(surface)
+    if z_range is None:
+        return None
+    z_min, z_max = z_range
+    height = z_max - z_min
+    if height <= 0:
+        return None
+    below = max(0.0, min(z_max, 0.0) - z_min)
+    return below / height
+
+
+def _edge_keys(surface) -> set[frozenset]:
+    """The surface's edges as unordered, rounded endpoint pairs.
+
+    Uses edge_graph.point_key for rounding so this agrees with the repo's other edge work rather
+    than inventing a third tolerance.
+    """
+    vertices = _world_vertices(surface)
+    if vertices is None:
+        return set()
+    keys = [point_key(v) for v in vertices]
+    return {
+        frozenset((keys[i], keys[(i + 1) % len(keys)]))
+        for i in range(len(keys))
+        if keys[i] != keys[(i + 1) % len(keys)]
+    }
+
+
+def _shared_edge_length(surface_a, surface_b) -> float:
+    """Total length of edges the two surfaces share, in metres."""
+    vertices = _world_vertices(surface_a)
+    if vertices is None:
+        return 0.0
+    other = _edge_keys(surface_b)
+    total = 0.0
+    count = len(vertices)
+    for i in range(count):
+        p, q = vertices[i], vertices[(i + 1) % count]
+        if frozenset((point_key(p), point_key(q))) in other:
+            total += (p - q).length()
+    return total
+
+
+def classify_foundation_candidates(model, include_adiabatic: bool = False) -> dict[str, Any]:
+    """Split the model's surfaces into Kiva-eligible floors, pairable walls, and blocked.
+
+    Adiabatic surfaces are excluded by default: `patch_missing_surfaces` sets that condition
+    deliberately on facets it could not identify, and silently burying them would undo a decision
+    another tool made on purpose.
+    """
+    eligible_floors: list[dict[str, Any]] = []
+    eligible_walls: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+
+    for surface in sorted(model.getSurfaces(), key=lambda s: s.nameString()):
+        name = surface.nameString()
+        surface_type = surface.surfaceType()
+        if surface_type not in ("Floor", "Wall"):
+            continue
+
+        condition = surface.outsideBoundaryCondition()
+        if condition == "Adiabatic" and not include_adiabatic:
+            continue
+
+        if not _has_space(surface):
+            # Reported rather than skipped: a parentless surface is a real gbXML defect, and it is
+            # also the input that segfaults exposedPerimeter, so it must be visible.
+            blocked.append({
+                "surface": name,
+                "surface_type": surface_type,
+                "reasons": ["surface has no parent space"],
+            })
+            continue
+
+        if surface_type == "Floor":
+            if not _floor_is_at_or_below_grade(surface):
+                continue
+        else:
+            buried = _wall_buried_fraction(surface)
+            if buried is None or buried < MIN_BURIED_WALL_FRACTION:
+                continue
+
+        blockers = kiva_surface_blockers(surface)
+        if blockers:
+            blocked.append({
+                "surface": name,
+                "surface_type": surface_type,
+                "reasons": blockers,
+            })
+            continue
+
+        entry = {
+            "surface": name,
+            "outside_boundary_condition": condition,
+            "already_kiva": surface.adjacentFoundation().is_initialized(),
+        }
+        if surface_type == "Floor":
+            eligible_floors.append(entry)
+        else:
+            entry["buried_fraction"] = round(_wall_buried_fraction(surface), 3)
+            eligible_walls.append(entry)
+
+    return {
+        "eligible_floors": eligible_floors,
+        "eligible_walls": eligible_walls,
+        "blocked": blocked,
+    }
+
+
+def pair_walls_to_floors(model, floor_names: list[str], wall_names: list[str]) -> dict[str, Any]:
+    """Attach each below-grade wall to the floor it shares an edge with.
+
+    EnergyPlus requires a Kiva wall to reference the *same* Foundation object as its floor, so this
+    is adjacency rather than selection. A wall touching no eligible floor is reported and dropped —
+    never attached to an arbitrary foundation.
+    """
+    floors = {n: model.getSurfaceByName(n).get() for n in floor_names
+              if model.getSurfaceByName(n).is_initialized()}
+    pairs: dict[str, list[str]] = {n: [] for n in floors}
+    unpaired: list[dict[str, str]] = []
+
+    for wall_name in wall_names:
+        optional = model.getSurfaceByName(wall_name)
+        if not optional.is_initialized():
+            unpaired.append({"surface": wall_name, "reason": "surface not found"})
+            continue
+        wall = optional.get()
+        best_floor, best_length = None, 0.0
+        for floor_name, floor in floors.items():
+            length = _shared_edge_length(wall, floor)
+            if length > best_length:
+                best_floor, best_length = floor_name, length
+        if best_floor is None:
+            unpaired.append({
+                "surface": wall_name,
+                "reason": "shares no edge with an eligible foundation floor",
+            })
+            continue
+        pairs[best_floor].append(wall_name)
+
+    return {"pairs": pairs, "unpaired": unpaired}
+
+
+def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str, float], list[str]]:
+    """Exposed perimeter per floor, from the joined footprint of every candidate floor.
+
+    The join deliberately spans every at-or-below-grade floor in the model, not just the requested
+    ones: an interior slab bay only scores zero if its neighbours are present in the footprint.
+    """
+    warnings: list[str] = []
+    candidates = [
+        s for s in model.getSurfaces()
+        if s.surfaceType() == "Floor" and _has_space(s) and _floor_is_at_or_below_grade(s)
+    ]
+    if not candidates:
+        return {}, ["No at-or-below-grade floors found to build a footprint from."]
+
+    polys = openstudio.Point3dVectorVector()
+    for surface in candidates:
+        polys.append(_world_vertices(surface))
+
+    try:
+        joined = openstudio.joinAllPolygons(polys, POLYGON_JOIN_TOLERANCE_M)
+    except Exception as e:
+        return {}, [f"Could not join floor polygons into a footprint: {e}"]
+
+    if not joined:
+        return {}, ["Joining the floor polygons produced no footprint."]
+
+    perimeters: dict[str, float] = {}
+    for name in floor_names:
+        optional = model.getSurfaceByName(name)
+        if not optional.is_initialized():
+            continue
+        surface = optional.get()
+        if not _has_space(surface):
+            # The segfault guard. Reported, never called.
+            warnings.append(f"Floor '{name}' has no parent space; its perimeter cannot be computed.")
+            continue
+        perimeters[name] = round(sum(surface.exposedPerimeter(p) for p in joined), 4)
+
+    return perimeters, warnings

--- a/mcp_server/skills/geometry/kiva_eligibility.py
+++ b/mcp_server/skills/geometry/kiva_eligibility.py
@@ -14,21 +14,16 @@ touching that method. `_has_space()` is the guard and it is not optional.
 
 ## Computing exposed perimeter
 
-    polys = openstudio.Point3dVectorVector()
-    for f in every_candidate_floor:                  # ALL of them, not just the selected ones
-        polys.append(project_to_z0(f.space().get().transformation() * f.vertices()))
-    joined = openstudio.joinAllPolygons(polys, 0.01)
-    exposed = sum(overlap length of each floor edge (at z=0) against each joined polygon)
+For every candidate floor (ALL at-or-below-grade floors, not just the selected ones), project its
+edges to z = 0; a floor's exposed perimeter is the length of its edges minus the intervals that lie
+under a collinear edge of another floor. Partial overlaps and T-junctions are handled by interval
+subtraction, and a courtyard keeps its edges because no floor lies on their other side.
 
-On `exampleModel()` this gives each of the four quadrant floors 20.0 and a total of 80.0 — exactly
-the footprint, and identical to `Surface.exposedPerimeter(joined)`. That SDK method is NOT used:
-both it and `joinAllPolygons` assert |z| <= tolerance on every point, so a floor below grade — a
-basement, the whole point of Kiva walls — scores 0.0 through it. The z = 0 projection plus
-`Polygon3d.overlap` per edge is what the SDK does internally, minus the assertion. A hand-built
-`Polygon3d` returns 0.0 because the winding does not match, so the join is mandatory.
-Neighbouring floors must be in the join or an interior slab bay will not correctly score zero. A
-disjoint-wing model produces several polygons and each floor scores against exactly one, so summing
-across them is both required and safe.
+Neither `Surface.exposedPerimeter()` nor `joinAllPolygons()` is used, for two separate reasons:
+both assert |z| <= tolerance on every point, so a basement floor scores 0.0 through them; and the
+join fills holes, so a building around an open courtyard lost the courtyard's 40 m entirely
+(3x3 ring of 10 m slabs: 120 m instead of 160 m). On `exampleModel()` the interval method gives
+each quadrant floor 20.0 and 80.0 in total, matching the SDK where the SDK is right.
 
 ## The EnergyPlus rules, from the 25.2 binary's own error strings
 
@@ -49,8 +44,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import openstudio
-
 from mcp_server.skills.geometry.edge_graph import point_key
 from mcp_server.skills.geometry.ground_contact import (
     GRADE_TOLERANCE_M,
@@ -64,8 +57,9 @@ MAX_KIVA_WALL_VERTICES = 4
 # candidate regardless of depth, and never part of the ground-contact footprint.
 _MATCHED_INTERIOR = "Surface"
 
-# joinAllPolygons tolerance. Matches the value both vendored implementations use and the scale of
-# the sibling geometry guards (PLANE_TOLERANCE, GRADE_TOLERANCE_M).
+# Collinearity and overlap tolerance for the exposed-perimeter edge scoring. Matches the value
+# both vendored implementations pass to joinAllPolygons and the scale of the sibling geometry
+# guards (PLANE_TOLERANCE, GRADE_TOLERANCE_M).
 POLYGON_JOIN_TOLERANCE_M = 0.01
 
 # Above this many eligible floors, EnergyPlus builds that many separate 2D finite-difference
@@ -362,10 +356,21 @@ def pair_walls_to_floors(model, floor_names: list[str], wall_names: list[str]) -
 
 
 def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str, float], list[str]]:
-    """Exposed perimeter per floor, from the joined footprint of every candidate floor.
+    """Exposed perimeter per floor: the length of its edges no other ground-contact floor covers.
 
-    The join deliberately spans every at-or-below-grade floor in the model, not just the requested
-    ones: an interior slab bay only scores zero if its neighbours are present in the footprint.
+    Every at-or-below-grade floor in the model takes part as a neighbour, not just the requested
+    ones: an interior slab bay only scores zero if its neighbours are present, and a courtyard
+    edge only scores exposed if the absence of a neighbour is real.
+
+    Each floor edge is projected to z = 0 and the intervals of it that lie under a collinear edge
+    of another floor are subtracted, so partial overlaps and T-junctions (a neighbour subdivided
+    differently) are handled, and a courtyard keeps its edges. The earlier recipe joined the
+    floor polygons with joinAllPolygons and scored edges against the outline; that join fills
+    holes, so a building around an open courtyard lost the courtyard's edges entirely (a 3x3
+    ring of 10 m slabs reported 120 m, not 160 m).
+
+    Two floors with the same footprint (a duplicated polygon) are reported and do not cover each
+    other: neither has a neighbour on the other side of those edges.
     """
     warnings: list[str] = []
     candidates = [
@@ -376,17 +381,14 @@ def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str,
     if not candidates:
         return {}, ["No at-or-below-grade floors found to build a footprint from."]
 
-    polys = openstudio.Point3dVectorVector()
-    for surface in candidates:
-        polys.append(_at_grade(_world_vertices(surface)))
-
-    try:
-        joined = openstudio.joinAllPolygons(polys, POLYGON_JOIN_TOLERANCE_M)
-    except Exception as e:
-        return {}, [f"Could not join floor polygons into a footprint: {e}"]
-
-    if not joined:
-        return {}, ["Joining the floor polygons produced no footprint."]
+    edges_by_floor = {s.nameString(): _flat_edges(_world_vertices(s)) for s in candidates}
+    duplicates = _duplicate_footprints(edges_by_floor)
+    for a, b in duplicates:
+        warnings.append(
+            f"Floors '{a}' and '{b}' have the same footprint; neither counts as the other's "
+            f"neighbour, so both keep their full exposed perimeter. Check for a duplicated "
+            f"floor surface.",
+        )
 
     perimeters: dict[str, float] = {}
     for name in floor_names:
@@ -395,39 +397,95 @@ def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str,
             continue
         surface = optional.get()
         if not _has_space(surface):
-            # The segfault guard. Reported, never touched.
+            # The segfault guard, kept although exposedPerimeter() is no longer called: a
+            # parentless floor has no world coordinates to score.
             warnings.append(f"Floor '{name}' has no parent space; its perimeter cannot be computed.")
             continue
-        perimeters[name] = round(_exposed_length(_world_vertices(surface), joined), 4)
+        own = edges_by_floor.get(name) or _flat_edges(_world_vertices(surface))
+        twins = {b for a, b in duplicates if a == name} | {a for a, b in duplicates if b == name}
+        neighbours = [
+            edge for other, edges in edges_by_floor.items()
+            if other != name and other not in twins for edge in edges
+        ]
+        perimeters[name] = round(_exposed_length(own, neighbours), 4)
 
     return perimeters, warnings
 
 
-def _at_grade(vertices):
-    """The same polygon projected onto z = 0.
+def _flat_edges(vertices) -> list[tuple[tuple[float, float], tuple[float, float]]]:
+    """A polygon's edges as 2D endpoint pairs (z dropped), skipping degenerate ones."""
+    points = [(v.x(), v.y()) for v in vertices]
+    edges = []
+    for i in range(len(points)):
+        p, q = points[i], points[(i + 1) % len(points)]
+        if _distance(p, q) > POLYGON_JOIN_TOLERANCE_M:
+            edges.append((p, q))
+    return edges
 
-    joinAllPolygons and Surface.exposedPerimeter both assert |z| <= tolerance on every point
-    (utilities/geometry/Intersection.cpp), so a basement floor at -2.5 m scores 0.0 through the
-    SDK method — which the clamp would then report as an interior bay. Projecting first is what
-    makes below-grade floors work at all.
+
+def _distance(p, q) -> float:
+    return ((p[0] - q[0]) ** 2 + (p[1] - q[1]) ** 2) ** 0.5
+
+
+def _duplicate_footprints(edges_by_floor) -> list[tuple[str, str]]:
+    """Pairs of floors whose edge sets coincide within tolerance, in either direction."""
+    def key(edges):
+        def rounded(point):
+            return (round(point[0], 3), round(point[1], 3))
+        return sorted(tuple(sorted((rounded(p), rounded(q)))) for p, q in edges)
+
+    keyed = {name: key(edges) for name, edges in edges_by_floor.items()}
+    names = sorted(keyed)
+    return [
+        (a, b) for i, a in enumerate(names) for b in names[i + 1:]
+        if keyed[a] == keyed[b]
+    ]
+
+
+def _covered_interval(edge, other, tolerance: float) -> tuple[float, float] | None:
+    """The [t0, t1] stretch of `edge` (metres from its start) lying under `other`, or None.
+
+    `other` covers part of `edge` when both its endpoints are within `tolerance` of the line
+    through `edge` and its projection overlaps the edge by more than `tolerance`. Direction is
+    irrelevant: a neighbour traverses a shared edge the opposite way, but a floor with flipped
+    winding is still a neighbour.
     """
-    return openstudio.Point3dVector([openstudio.Point3d(p.x(), p.y(), 0.0) for p in vertices])
+    (px, py), (qx, qy) = edge
+    length = _distance(edge[0], edge[1])
+    ux, uy = (qx - px) / length, (qy - py) / length
+    ts = []
+    for (x, y) in other:
+        dx, dy = x - px, y - py
+        # Perpendicular distance from the edge's line.
+        if abs(dx * uy - dy * ux) > tolerance:
+            return None
+        ts.append(dx * ux + dy * uy)
+    t0, t1 = max(min(ts), 0.0), min(max(ts), length)
+    if t1 - t0 <= tolerance:
+        return None
+    return t0, t1
 
 
-def _exposed_length(world_vertices, joined) -> float:
-    """Length of the floor's edges that lie on the joined footprint's outline.
-
-    This is what Surface.exposedPerimeter does internally — each edge against
-    Polygon3d.overlap — reproduced here on the z = 0 projection so it works below grade. Verified
-    to match the SDK method to 1e-3 on at-grade geometry, including unequal subdivision (a
-    neighbour whose shared edge is shorter than this floor's).
-    """
-    flat = _at_grade(world_vertices)
-    count = len(flat)
+def _exposed_length(own_edges, neighbour_edges, tolerance: float = POLYGON_JOIN_TOLERANCE_M) -> float:
+    """Total length of `own_edges` not covered by any collinear stretch of `neighbour_edges`."""
     total = 0.0
-    for i in range(count):
-        edge = openstudio.Point3dVector([flat[i], flat[(i + 1) % count]])
-        for polygon in joined:
-            for segment in polygon.overlap(edge):
-                total += (segment[0] - segment[1]).length()
+    for edge in own_edges:
+        length = _distance(edge[0], edge[1])
+        intervals = sorted(
+            interval for interval in (
+                _covered_interval(edge, other, tolerance) for other in neighbour_edges
+            ) if interval is not None
+        )
+        covered = 0.0
+        current: tuple[float, float] | None = None
+        for t0, t1 in intervals:
+            if current is None or t0 > current[1]:
+                if current is not None:
+                    covered += current[1] - current[0]
+                current = (t0, t1)
+            else:
+                current = (current[0], max(current[1], t1))
+        if current is not None:
+            covered += current[1] - current[0]
+        total += max(length - covered, 0.0)
     return total

--- a/mcp_server/skills/geometry/kiva_eligibility.py
+++ b/mcp_server/skills/geometry/kiva_eligibility.py
@@ -14,19 +14,21 @@ touching that method. `_has_space()` is the guard and it is not optional.
 
 ## Computing exposed perimeter
 
-Verified recipe, and the only one that works:
-
     polys = openstudio.Point3dVectorVector()
     for f in every_candidate_floor:                  # ALL of them, not just the selected ones
-        polys.append(f.space().get().transformation() * f.vertices())
+        polys.append(project_to_z0(f.space().get().transformation() * f.vertices()))
     joined = openstudio.joinAllPolygons(polys, 0.01)
-    exposed = sum(f.exposedPerimeter(j) for j in joined)
+    exposed = sum(overlap length of each floor edge (at z=0) against each joined polygon)
 
 On `exampleModel()` this gives each of the four quadrant floors 20.0 and a total of 80.0 — exactly
-the footprint. A hand-built `Polygon3d` returns 0.0 because the winding does not match, so the join
-is mandatory. Neighbouring floors must be in the join or an interior slab bay will not correctly
-score zero. A disjoint-wing model produces several polygons and each floor scores against exactly
-one, so summing across them is both required and safe.
+the footprint, and identical to `Surface.exposedPerimeter(joined)`. That SDK method is NOT used:
+both it and `joinAllPolygons` assert |z| <= tolerance on every point, so a floor below grade — a
+basement, the whole point of Kiva walls — scores 0.0 through it. The z = 0 projection plus
+`Polygon3d.overlap` per edge is what the SDK does internally, minus the assertion. A hand-built
+`Polygon3d` returns 0.0 because the winding does not match, so the join is mandatory.
+Neighbouring floors must be in the join or an interior slab bay will not correctly score zero. A
+disjoint-wing model produces several polygons and each floor scores against exactly one, so summing
+across them is both required and safe.
 
 ## The EnergyPlus rules, from the 25.2 binary's own error strings
 
@@ -186,6 +188,47 @@ def _shared_edge_length(surface_a, surface_b) -> float:
     return total
 
 
+def _xy_extent(vertices) -> float:
+    """Longest horizontal distance between any two vertices — a rectangular wall's width."""
+    best = 0.0
+    for i in range(len(vertices)):
+        for j in range(i + 1, len(vertices)):
+            dx = vertices[i].x() - vertices[j].x()
+            dy = vertices[i].y() - vertices[j].y()
+            best = max(best, (dx * dx + dy * dy) ** 0.5)
+    return best
+
+
+def paired_wall_length(model, wall_names: list[str]) -> float:
+    """Combined horizontal length of the named walls, in metres.
+
+    EnergyPlus compares the walls' combined length against the floor's exposed perimeter and
+    refuses the Foundation:Kiva at run time when it is larger; this is the number it compares.
+    Kiva walls are limited to four vertices, so the XY extent is the wall's width.
+    """
+    total = 0.0
+    for name in wall_names:
+        optional = model.getSurfaceByName(name)
+        if not optional.is_initialized():
+            continue
+        vertices = _world_vertices(optional.get())
+        if vertices is not None:
+            total += _xy_extent(vertices)
+    return total
+
+
+def floor_perimeter(model, floor_name: str) -> float | None:
+    """The floor polygon's full perimeter in metres, or None when it has no parent space."""
+    optional = model.getSurfaceByName(floor_name)
+    if not optional.is_initialized():
+        return None
+    vertices = _world_vertices(optional.get())
+    if vertices is None:
+        return None
+    count = len(vertices)
+    return sum((vertices[i] - vertices[(i + 1) % count]).length() for i in range(count))
+
+
 def classify_foundation_candidates(model, include_adiabatic: bool = False) -> dict[str, Any]:
     """Split the model's surfaces into Kiva-eligible floors, pairable walls, and blocked.
 
@@ -310,7 +353,7 @@ def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str,
 
     polys = openstudio.Point3dVectorVector()
     for surface in candidates:
-        polys.append(_world_vertices(surface))
+        polys.append(_at_grade(_world_vertices(surface)))
 
     try:
         joined = openstudio.joinAllPolygons(polys, POLYGON_JOIN_TOLERANCE_M)
@@ -327,9 +370,39 @@ def compute_exposed_perimeters(model, floor_names: list[str]) -> tuple[dict[str,
             continue
         surface = optional.get()
         if not _has_space(surface):
-            # The segfault guard. Reported, never called.
+            # The segfault guard. Reported, never touched.
             warnings.append(f"Floor '{name}' has no parent space; its perimeter cannot be computed.")
             continue
-        perimeters[name] = round(sum(surface.exposedPerimeter(p) for p in joined), 4)
+        perimeters[name] = round(_exposed_length(_world_vertices(surface), joined), 4)
 
     return perimeters, warnings
+
+
+def _at_grade(vertices):
+    """The same polygon projected onto z = 0.
+
+    joinAllPolygons and Surface.exposedPerimeter both assert |z| <= tolerance on every point
+    (utilities/geometry/Intersection.cpp), so a basement floor at -2.5 m scores 0.0 through the
+    SDK method — which the clamp would then report as an interior bay. Projecting first is what
+    makes below-grade floors work at all.
+    """
+    return openstudio.Point3dVector([openstudio.Point3d(p.x(), p.y(), 0.0) for p in vertices])
+
+
+def _exposed_length(world_vertices, joined) -> float:
+    """Length of the floor's edges that lie on the joined footprint's outline.
+
+    This is what Surface.exposedPerimeter does internally — each edge against
+    Polygon3d.overlap — reproduced here on the z = 0 projection so it works below grade. Verified
+    to match the SDK method to 1e-3 on at-grade geometry, including unequal subdivision (a
+    neighbour whose shared edge is shorter than this floor's).
+    """
+    flat = _at_grade(world_vertices)
+    count = len(flat)
+    total = 0.0
+    for i in range(count):
+        edge = openstudio.Point3dVector([flat[i], flat[(i + 1) % count]])
+        for polygon in joined:
+            for segment in polygon.overlap(edge):
+                total += (segment[0] - segment[1]).length()
+    return total

--- a/mcp_server/skills/geometry/kiva_eligibility.py
+++ b/mcp_server/skills/geometry/kiva_eligibility.py
@@ -302,12 +302,24 @@ def classify_foundation_candidates(model, include_adiabatic: bool = False) -> di
     }
 
 
-def pair_walls_to_floors(model, floor_names: list[str], wall_names: list[str]) -> dict[str, Any]:
-    """Attach each below-grade wall to the floor it shares an edge with.
+def _zone_key(surface) -> str | None:
+    """The thermal zone a surface belongs to, or its space when the space has no zone yet."""
+    space = surface.space()
+    if not space.is_initialized():
+        return None
+    zone = space.get().thermalZone()
+    if zone.is_initialized():
+        return f"zone:{zone.get().nameString()}"
+    return f"space:{space.get().nameString()}"
 
-    EnergyPlus requires a Kiva wall to reference the *same* Foundation object as its floor, so this
-    is adjacency rather than selection. A wall touching no eligible floor is reported and dropped —
-    never attached to an arbitrary foundation.
+
+def pair_walls_to_floors(model, floor_names: list[str], wall_names: list[str]) -> dict[str, Any]:
+    """Attach each below-grade wall to the floor it shares an edge with, in the same zone.
+
+    EnergyPlus requires a Kiva wall to reference the *same* Foundation object as its floor, and
+    that floor must be "within the same Zone" (its own error text), so this is adjacency plus
+    zone rather than selection. A wall touching no eligible floor in its zone is reported and
+    dropped — never attached to an arbitrary foundation.
     """
     floors = {n: model.getSurfaceByName(n).get() for n in floor_names
               if model.getSurfaceByName(n).is_initialized()}
@@ -320,15 +332,28 @@ def pair_walls_to_floors(model, floor_names: list[str], wall_names: list[str]) -
             unpaired.append({"surface": wall_name, "reason": "surface not found"})
             continue
         wall = optional.get()
+        wall_zone = _zone_key(wall)
         best_floor, best_length = None, 0.0
+        touches_other_zone = False
         for floor_name, floor in floors.items():
             length = _shared_edge_length(wall, floor)
+            if length <= 0.0:
+                continue
+            if _zone_key(floor) != wall_zone:
+                touches_other_zone = True
+                continue
             if length > best_length:
                 best_floor, best_length = floor_name, length
         if best_floor is None:
             unpaired.append({
                 "surface": wall_name,
-                "reason": "shares no edge with an eligible foundation floor",
+                "reason": (
+                    "shares an edge only with foundation floors in a different thermal zone; "
+                    "EnergyPlus requires the floor and wall of one Foundation:Kiva to be in the "
+                    "same zone"
+                    if touches_other_zone else
+                    "shares no edge with an eligible foundation floor"
+                ),
             })
             continue
         pairs[best_floor].append(wall_name)

--- a/mcp_server/skills/geometry/kiva_foundation.py
+++ b/mcp_server/skills/geometry/kiva_foundation.py
@@ -35,6 +35,7 @@ floor polygon under BySegment, OpenStudio exposes no segment API, and gbXML wind
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -193,7 +194,6 @@ def _wall_depth_for(model, wall_names: list[str]) -> float | None:
 
 def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) -> None:
     for spec in specs:
-        material, disposition = _insulation_material(model, spec.r_si_m2k_w)
         depth = spec.depth_m
         if depth == MATCH_WALL_DEPTH:
             depth = wall_depth_m
@@ -203,6 +203,8 @@ def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) ->
                     f"below-grade wall was paired to this floor; the insulation was not applied.",
                 )
                 continue
+        # Resolve the depth first: a layer that is skipped must not leave an unused XPS material.
+        material, disposition = _insulation_material(model, spec.r_si_m2k_w)
         if spec.position == POSITION_EXTERIOR_VERTICAL:
             if not kiva.setExteriorVerticalInsulationMaterial(material):
                 warnings.append("OpenStudio refused the exterior vertical insulation material.")
@@ -236,11 +238,21 @@ def _write_exposed_perimeter(surface, method: str, value: float) -> str | None:
 
     obj = created.get()
     # is_initialized() is NOT a success signal here — an unknown method or an out-of-range value
-    # still hands back an object with the field silently unset.
+    # still hands back an object with the field silently unset. Read both fields back.
     if obj.exposedPerimeterCalculationMethod() != method:
         return (
             f"Exposed perimeter method did not take on '{surface.nameString()}': asked for "
             f"{method!r}, model holds {obj.exposedPerimeterCalculationMethod()!r}"
+        )
+    if method == PERIMETER_METHOD_TOTAL:
+        stored = obj.totalExposedPerimeter()          # OptionalDouble
+        held = stored.get() if stored.is_initialized() else None
+    else:
+        held = obj.exposedPerimeterFraction()         # plain double, defaulted to 1.0
+    if held is None or not math.isclose(held, value, rel_tol=1e-9, abs_tol=1e-9):
+        return (
+            f"Exposed perimeter value did not take on '{surface.nameString()}': asked for "
+            f"{value}, model holds {held}"
         )
     return None
 

--- a/mcp_server/skills/geometry/kiva_foundation.py
+++ b/mcp_server/skills/geometry/kiva_foundation.py
@@ -136,6 +136,26 @@ def code_ground_targets(climate_zone: str | None) -> dict[str, Any] | None:
     return targets
 
 
+def existing_soil_properties(model) -> dict[str, float | None]:
+    """The soil values already chosen on FoundationKivaSettings, None where still defaulted.
+
+    Optional getter, so calling this never creates the settings object.
+    """
+    optional = model.getOptionalFoundationKivaSettings()
+    if not optional.is_initialized():
+        return {"soil_conductivity_w_mk": None, "soil_density_kg_m3": None,
+                "soil_specific_heat_j_kgk": None}
+    settings = optional.get()
+    return {
+        "soil_conductivity_w_mk": (
+            None if settings.isSoilConductivityDefaulted() else settings.soilConductivity()),
+        "soil_density_kg_m3": (
+            None if settings.isSoilDensityDefaulted() else settings.soilDensity()),
+        "soil_specific_heat_j_kgk": (
+            None if settings.isSoilSpecificHeatDefaulted() else settings.soilSpecificHeat()),
+    }
+
+
 def read_kiva_state(model) -> dict[str, Any]:
     """What Kiva content the model already carries. Creates nothing."""
     settings = model.getOptionalFoundationKivaSettings()
@@ -220,12 +240,20 @@ def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) ->
                 return f"OpenStudio refused the interior horizontal insulation material on {kiva.nameString()}"
             if spec.width_m is not None and not kiva.setInteriorHorizontalInsulationWidth(spec.width_m):
                 return f"OpenStudio refused an interior horizontal insulation width of {spec.width_m} m"
+        depth_provenance = spec.provenance.get("depth_m")
+        if spec.depth_m == MATCH_WALL_DEPTH:
+            depth_provenance = PROVENANCE_COMPUTED
         provenance[f"{spec.position}_insulation"] = {
             "r_si_m2k_w": spec.r_si_m2k_w,
             "material": material.nameString(),
             "material_disposition": disposition,
             "depth_m": depth,
             "width_m": spec.width_m,
+            "provenance": {
+                "r_si_m2k_w": spec.provenance.get("r_si_m2k_w"),
+                "depth_m": depth_provenance,
+                "width_m": spec.provenance.get("width_m"),
+            },
         }
     return None
 

--- a/mcp_server/skills/geometry/kiva_foundation.py
+++ b/mcp_server/skills/geometry/kiva_foundation.py
@@ -182,10 +182,21 @@ def _insulation_material(model, r_si: float):
     its own model and returns a dict with no handle to attach to a FoundationKiva.
     """
     thickness = xps_thickness_m(r_si)
-    name = f"Kiva XPS R-SI {r_si:.2f} ({round(thickness * 1000)} mm)"
+    # Four decimals: at 0.029 W/m-K the thickness changes by 0.03 mm per 0.001 m2K/W, so two
+    # decimals collided (1.760 and 1.764 both read "1.76 (51 mm)") and the second request reused
+    # the first thickness while reporting its own R-value.
+    name = f"Kiva XPS R-SI {r_si:.4f} ({thickness * 1000:.2f} mm)"
     existing = model.getStandardOpaqueMaterialByName(name)
     if existing.is_initialized():
-        return existing.get(), "reused"
+        found = existing.get()
+        if (math.isclose(found.thickness(), thickness, rel_tol=1e-6)
+                and math.isclose(found.conductivity(), XPS_CONDUCTIVITY_W_MK, rel_tol=1e-6)):
+            return found, "reused"
+        # Same name, different properties: someone edited it. Never silently adopt it.
+        name = f"{name} [kiva]"
+        existing = model.getStandardOpaqueMaterialByName(name)
+        if existing.is_initialized():
+            return existing.get(), "reused"
 
     material = openstudio.model.StandardOpaqueMaterial(model)
     material.setName(name)

--- a/mcp_server/skills/geometry/kiva_foundation.py
+++ b/mcp_server/skills/geometry/kiva_foundation.py
@@ -1,0 +1,354 @@
+"""Apply an EnergyPlus Kiva foundation model to a model's ground-contact surfaces.
+
+The detailed counterpart to weather/ground_temperatures.py. A surface whose boundary condition is
+`Foundation` ignores `Site:GroundTemperature:BuildingSurface` entirely and gets a solved 2D soil
+domain instead, including slab-edge losses and insulation geometry — the thing a single monthly
+temperature under the whole building cannot represent.
+
+Kiva needs foundation detail a gbXML export does not carry, so the workflow asks: the agent calls
+`get_foundation_options()`, puts the archetype menu to the user, and calls `set_kiva_foundation()`
+with their answer. Every applied value reports where it came from, because several of them are
+conventional starting points rather than anything sourced (see kiva_archetypes.py).
+
+SDK facts (probed, OpenStudio 3.11.0 / EnergyPlus 25.2.0):
+
+  - `model.getFoundationKivaSettings()` CREATES the unique object; `getOptionalFoundationKivaSettings()`
+    does not. Same hazard as the Site:GroundTemperature objects in Phase 1 — a read path must use
+    the optional form or a "get" tool silently mutates the session model.
+  - `Surface.setAdjacentFoundation(kiva)` sets the boundary condition to `Foundation` but **leaves
+    SunExposed/WindExposed intact** — fictitious solar gain on a buried slab. Call
+    `setOutsideBoundaryCondition("Foundation")` FIRST (that one derives NoSun/NoWind), then
+    `setAdjacentFoundation`.
+  - `Surface.createSurfacePropertyExposedFoundationPerimeter(method, value)` **returns an
+    initialized optional even when it rejected the input**. `"Calculate"` and any other unknown
+    string read back as `''`; an out-of-range fraction leaves the value unset. `is_initialized()` is
+    not a success signal — whitelist the method, range-check the value, then read both back and
+    compare. A second call returns an empty optional rather than overwriting, so re-applying needs
+    `resetSurfacePropertyExposedFoundationPerimeter()` first.
+  - `FoundationKiva.surfaces()` exists; EnergyPlus allows exactly one floor per Foundation object.
+  - `Surface.exposedPerimeter()` segfaults on a space-less surface — see kiva_eligibility.py.
+
+`BySegment` is a legal IDD method but is not offered: EnergyPlus cannot auto-correct a clockwise
+floor polygon under BySegment, OpenStudio exposes no segment API, and gbXML winding is exactly what
+`weld_coincident_vertices` exists to clean up.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import openstudio
+
+from mcp_server.config import OSCLI_GEM_PATH
+from mcp_server.model_manager import ensure_generation_unchanged, get_model_with_generation
+from mcp_server.skills.geometry.kiva_archetypes import (
+    MATCH_WALL_DEPTH,
+    MIN_EXPOSED_PERIMETER_M,
+    POSITION_EXTERIOR_VERTICAL,
+    POSITION_INTERIOR_HORIZONTAL,
+    PROVENANCE_COMPUTED,
+    PROVENANCE_COMPUTED_CLAMPED,
+    PROVENANCE_FALLBACK_FRACTION,
+    PROVENANCE_USER,
+    XPS_CONDUCTIVITY_W_MK,
+    XPS_DENSITY_KG_M3,
+    XPS_ROUGHNESS,
+    XPS_SPECIFIC_HEAT_J_KGK,
+    archetype_menu,
+    xps_thickness_m,
+)
+from mcp_server.skills.geometry.kiva_eligibility import (
+    KIVA_DOMAIN_WARN_THRESHOLD,
+    classify_foundation_candidates,
+    compute_exposed_perimeters,
+)
+
+# The two methods OpenStudio actually accepts. BySegment is legal in the IDD but deliberately not
+# offered (see the module docstring). Anything else is silently discarded by the SDK.
+PERIMETER_METHOD_TOTAL = "TotalExposedPerimeter"
+PERIMETER_METHOD_FRACTION = "ExposedPerimeterFraction"
+VALID_PERIMETER_METHODS = (PERIMETER_METHOD_TOTAL, PERIMETER_METHOD_FRACTION)
+
+PERIMETER_MODES = ("auto", "total", "fraction")
+
+_CODE_TARGET_GLOB = (
+    "ruby/*/gems/openstudio-standards-*/lib/openstudio-standards/standards/"
+    "ashrae_90_1/ashrae_90_1_2019/data/ashrae_90_1_2019.construction_properties.json"
+)
+
+
+def _model_climate_zone(model) -> str | None:
+    zones = model.getClimateZones().getClimateZones("ASHRAE")
+    if not zones:
+        return None
+    value = zones[0].value()
+    return value or None
+
+
+def code_ground_targets(climate_zone: str | None) -> dict[str, Any] | None:
+    """ASHRAE 90.1-2019 F-factor / C-factor targets for this climate zone.
+
+    Reported alongside the applied values as a cross-check, never used to derive them: the vendored
+    data is code *performance* per unit perimeter, and converting it into Kiva insulation geometry
+    would mean inverting Appendix A tables that are not vendored here. Returns None when the
+    standards gem or the climate zone is unavailable — this is a nicety, not a dependency.
+    """
+    if not climate_zone:
+        return None
+    digits = "".join(c for c in climate_zone if c.isdigit())
+    if not digits:
+        return None
+    wanted = f"ClimateZone {digits}"
+
+    matches = sorted(Path(OSCLI_GEM_PATH).glob(_CODE_TARGET_GLOB))
+    if not matches:
+        return None
+    try:
+        data = json.loads(matches[0].read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    rows = next((v for v in data.values() if isinstance(v, list)), [])
+    targets: dict[str, Any] = {"standard": "90.1-2019", "climate_zone": climate_zone}
+    for row in rows:
+        if not isinstance(row, dict) or row.get("climate_zone_set") != wanted:
+            continue
+        kind = row.get("standards_construction_type")
+        if row.get("intended_surface_type") == "GroundContactFloor" and row.get(
+            "assembly_maximum_f_factor",
+        ):
+            targets.setdefault("slab_max_f_factor", {})[kind] = row["assembly_maximum_f_factor"]
+        if row.get("intended_surface_type") == "GroundContactWall" and row.get(
+            "assembly_maximum_c_factor",
+        ):
+            targets.setdefault("below_grade_wall_max_c_factor", {})[kind] = row[
+                "assembly_maximum_c_factor"
+            ]
+    if len(targets) == 2:
+        return None
+    targets["note"] = (
+        "Code performance targets for comparison only — these are not the source of the insulation "
+        "values applied, and F/C-factor cannot be converted to Kiva geometry without ASHRAE 90.1 "
+        "Appendix A tables that are not available here."
+    )
+    return targets
+
+
+def read_kiva_state(model) -> dict[str, Any]:
+    """What Kiva content the model already carries. Creates nothing."""
+    settings = model.getOptionalFoundationKivaSettings()
+    foundations = model.getFoundationKivas()
+    kiva_surfaces = [
+        s.nameString() for s in model.getSurfaces()
+        if s.outsideBoundaryCondition() == "Foundation"
+    ]
+    return {
+        "settings_present": settings.is_initialized(),
+        "foundation_count": len(foundations),
+        "foundation_names": sorted(f.nameString() for f in foundations),
+        "kiva_surface_count": len(kiva_surfaces),
+        "kiva_surfaces": sorted(kiva_surfaces),
+    }
+
+
+def _insulation_material(model, r_si: float):
+    """Get or create the XPS material for this R-value.
+
+    Named deterministically so re-running the tool reuses the material rather than accumulating a
+    new one each time — the same reuse pattern the vendored tbd gem applies to its "XPS 25mm".
+    Built directly rather than through constructions.create_standard_opaque_material, which fetches
+    its own model and returns a dict with no handle to attach to a FoundationKiva.
+    """
+    thickness = xps_thickness_m(r_si)
+    name = f"Kiva XPS R-SI {r_si:.2f} ({round(thickness * 1000)} mm)"
+    existing = model.getStandardOpaqueMaterialByName(name)
+    if existing.is_initialized():
+        return existing.get(), "reused"
+
+    material = openstudio.model.StandardOpaqueMaterial(model)
+    material.setName(name)
+    material.setRoughness(XPS_ROUGHNESS)
+    material.setThickness(thickness)
+    material.setConductivity(XPS_CONDUCTIVITY_W_MK)
+    material.setDensity(XPS_DENSITY_KG_M3)
+    material.setSpecificHeat(XPS_SPECIFIC_HEAT_J_KGK)
+    return material, "created"
+
+
+def _wall_depth_for(model, wall_names: list[str]) -> float | None:
+    """How far below grade the paired walls reach — the depth a full-height insulation run needs."""
+    from mcp_server.skills.geometry.ground_contact import world_z_range
+
+    depths = []
+    for name in wall_names:
+        optional = model.getSurfaceByName(name)
+        if not optional.is_initialized():
+            continue
+        z_range = world_z_range(optional.get())
+        if z_range is not None:
+            depths.append(-z_range[0])
+    return round(max(depths), 3) if depths and max(depths) > 0 else None
+
+
+def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) -> None:
+    for spec in specs:
+        material, disposition = _insulation_material(model, spec.r_si_m2k_w)
+        depth = spec.depth_m
+        if depth == MATCH_WALL_DEPTH:
+            depth = wall_depth_m
+            if depth is None:
+                warnings.append(
+                    f"{spec.position} insulation asked to match the below-grade wall depth, but no "
+                    f"below-grade wall was paired to this floor; the insulation was not applied.",
+                )
+                continue
+        if spec.position == POSITION_EXTERIOR_VERTICAL:
+            if not kiva.setExteriorVerticalInsulationMaterial(material):
+                warnings.append("OpenStudio refused the exterior vertical insulation material.")
+                continue
+            if depth is not None and not kiva.setExteriorVerticalInsulationDepth(depth):
+                warnings.append(f"OpenStudio refused an exterior vertical insulation depth of {depth} m.")
+        elif spec.position == POSITION_INTERIOR_HORIZONTAL:
+            if not kiva.setInteriorHorizontalInsulationMaterial(material):
+                warnings.append("OpenStudio refused the interior horizontal insulation material.")
+                continue
+            if spec.width_m is not None and not kiva.setInteriorHorizontalInsulationWidth(spec.width_m):
+                warnings.append(
+                    f"OpenStudio refused an interior horizontal insulation width of {spec.width_m} m.",
+                )
+        provenance[f"{spec.position}_insulation"] = {
+            "r_si_m2k_w": spec.r_si_m2k_w,
+            "material": material.nameString(),
+            "material_disposition": disposition,
+            "depth_m": depth,
+            "width_m": spec.width_m,
+        }
+
+
+def _write_exposed_perimeter(surface, method: str, value: float) -> str | None:
+    """Create the perimeter object and verify it took. Returns an error string, or None."""
+    if surface.surfacePropertyExposedFoundationPerimeter().is_initialized():
+        surface.resetSurfacePropertyExposedFoundationPerimeter()
+    created = surface.createSurfacePropertyExposedFoundationPerimeter(method, value)
+    if not created.is_initialized():
+        return f"OpenStudio would not create an exposed perimeter object on '{surface.nameString()}'"
+
+    obj = created.get()
+    # is_initialized() is NOT a success signal here — an unknown method or an out-of-range value
+    # still hands back an object with the field silently unset.
+    if obj.exposedPerimeterCalculationMethod() != method:
+        return (
+            f"Exposed perimeter method did not take on '{surface.nameString()}': asked for "
+            f"{method!r}, model holds {obj.exposedPerimeterCalculationMethod()!r}"
+        )
+    return None
+
+
+def get_foundation_options(include_adiabatic: bool = False) -> dict[str, Any]:
+    """What the caller needs to decide before set_kiva_foundation, and what is already known."""
+    try:
+        model, generation = get_model_with_generation()
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+
+    try:
+        candidates = classify_foundation_candidates(model, include_adiabatic=include_adiabatic)
+        floor_names = [f["surface"] for f in candidates["eligible_floors"]]
+        perimeters, perimeter_warnings = compute_exposed_perimeters(model, floor_names)
+        for floor in candidates["eligible_floors"]:
+            floor["exposed_perimeter_m"] = perimeters.get(floor["surface"])
+
+        climate_zone = _model_climate_zone(model)
+        warnings = list(perimeter_warnings)
+        if len(floor_names) > KIVA_DOMAIN_WARN_THRESHOLD:
+            warnings.append(
+                f"{len(floor_names)} eligible floors means {len(floor_names)} separate Kiva 2D "
+                f"domains — EnergyPlus allows only one floor per Foundation object. Expect a large "
+                f"run-time increase; set_kiva_foundation requires confirm_many_domains=True above "
+                f"{KIVA_DOMAIN_WARN_THRESHOLD}.",
+            )
+        if not floor_names:
+            warnings.append(
+                "No eligible foundation floors. Check `blocked` for the reason, and note that a "
+                "slab still typed Outdoors is not at grade as far as this check is concerned — "
+                "repair_and_validate_gbxml_geometry reports those under ground_contact_missing.",
+            )
+
+        # Read-only: getOptional* throughout, so calling this never creates a settings object.
+        from mcp_server.skills.weather.ground_temperatures import read_ground_temperature_state
+
+        result = {
+            "ok": True,
+            **candidates,
+            "eligible_floor_count": len(floor_names),
+            "eligible_wall_count": len(candidates["eligible_walls"]),
+            "kiva_domains_if_applied": len(floor_names),
+            "existing_kiva": read_kiva_state(model),
+            "archetypes": archetype_menu(),
+            "climate_zone": climate_zone,
+            "code_targets": code_ground_targets(climate_zone),
+            "ground_temperatures": read_ground_temperature_state(model),
+            "warnings": warnings,
+            "next_step": (
+                "Show the archetype list and its parameter values to the user, ask which describes "
+                "their foundation, then call set_kiva_foundation with their answer. The insulation "
+                "R-values are conventional starting points, not code-derived — say so."
+            ),
+        }
+        ensure_generation_unchanged(generation)
+        return result
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to read foundation options: {e}"}
+
+
+def _resolve_perimeter(model, floor_names, mode, total_m, fraction, warnings):
+    """(per-floor {method, value, provenance}, error). Never guesses silently."""
+    if mode not in PERIMETER_MODES:
+        return None, f"Unknown exposed_perimeter_method '{mode}'. Valid: {list(PERIMETER_MODES)}"
+
+    if mode == "total":
+        if total_m is None:
+            return None, "exposed_perimeter_method='total' requires exposed_perimeter_m"
+        if total_m <= 0:
+            return None, f"exposed_perimeter_m must be greater than 0, got {total_m}"
+        if len(floor_names) > 1:
+            return None, (
+                f"exposed_perimeter_method='total' takes one number, but {len(floor_names)} floors "
+                f"were selected — one perimeter cannot describe several slabs. Use 'auto', or apply "
+                f"to one floor at a time."
+            )
+        return {floor_names[0]: (PERIMETER_METHOD_TOTAL, total_m, PROVENANCE_USER)}, None
+
+    if mode == "fraction":
+        if fraction is None:
+            return None, "exposed_perimeter_method='fraction' requires exposed_perimeter_fraction"
+        if not 0.0 <= fraction <= 1.0:
+            return None, (
+                f"exposed_perimeter_fraction must be between 0 and 1, got {fraction} — "
+                f"OpenStudio discards an out-of-range fraction without reporting it."
+            )
+        return dict.fromkeys(floor_names, (PERIMETER_METHOD_FRACTION, fraction, PROVENANCE_USER)), None
+
+    computed, compute_warnings = compute_exposed_perimeters(model, floor_names)
+    warnings.extend(compute_warnings)
+    resolved = {}
+    for name in floor_names:
+        value = computed.get(name)
+        if value is None:
+            resolved[name] = (PERIMETER_METHOD_FRACTION, 1.0, PROVENANCE_FALLBACK_FRACTION)
+            warnings.append(
+                f"Could not compute an exposed perimeter for '{name}'; fell back to an exposed "
+                f"fraction of 1.0. Supply exposed_perimeter_m if you have a measured value.",
+            )
+        elif value <= 0.0:
+            resolved[name] = (PERIMETER_METHOD_TOTAL, MIN_EXPOSED_PERIMETER_M,
+                              PROVENANCE_COMPUTED_CLAMPED)
+            warnings.append(
+                f"Floor '{name}' has no exposed edge (it is an interior bay); its perimeter was "
+                f"clamped to {MIN_EXPOSED_PERIMETER_M} m. Nearly all of its heat transfer is "
+                f"through the slab core.",
+            )
+        else:
+            resolved[name] = (PERIMETER_METHOD_TOTAL, value, PROVENANCE_COMPUTED)
+    return resolved, None

--- a/mcp_server/skills/geometry/kiva_foundation.py
+++ b/mcp_server/skills/geometry/kiva_foundation.py
@@ -192,7 +192,12 @@ def _wall_depth_for(model, wall_names: list[str]) -> float | None:
     return round(max(depths), 3) if depths and max(depths) > 0 else None
 
 
-def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) -> None:
+def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) -> str | None:
+    """Attach the insulation layers to one FoundationKiva. Returns an error string, or None.
+
+    A setter refusal is an error, not a warning: recording the requested extent while the object
+    kept its default would report insulation that is not in the model.
+    """
     for spec in specs:
         depth = spec.depth_m
         if depth == MATCH_WALL_DEPTH:
@@ -207,18 +212,14 @@ def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) ->
         material, disposition = _insulation_material(model, spec.r_si_m2k_w)
         if spec.position == POSITION_EXTERIOR_VERTICAL:
             if not kiva.setExteriorVerticalInsulationMaterial(material):
-                warnings.append("OpenStudio refused the exterior vertical insulation material.")
-                continue
+                return f"OpenStudio refused the exterior vertical insulation material on {kiva.nameString()}"
             if depth is not None and not kiva.setExteriorVerticalInsulationDepth(depth):
-                warnings.append(f"OpenStudio refused an exterior vertical insulation depth of {depth} m.")
+                return f"OpenStudio refused an exterior vertical insulation depth of {depth} m"
         elif spec.position == POSITION_INTERIOR_HORIZONTAL:
             if not kiva.setInteriorHorizontalInsulationMaterial(material):
-                warnings.append("OpenStudio refused the interior horizontal insulation material.")
-                continue
+                return f"OpenStudio refused the interior horizontal insulation material on {kiva.nameString()}"
             if spec.width_m is not None and not kiva.setInteriorHorizontalInsulationWidth(spec.width_m):
-                warnings.append(
-                    f"OpenStudio refused an interior horizontal insulation width of {spec.width_m} m.",
-                )
+                return f"OpenStudio refused an interior horizontal insulation width of {spec.width_m} m"
         provenance[f"{spec.position}_insulation"] = {
             "r_si_m2k_w": spec.r_si_m2k_w,
             "material": material.nameString(),
@@ -226,6 +227,7 @@ def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) ->
             "depth_m": depth,
             "width_m": spec.width_m,
         }
+    return None
 
 
 def _write_exposed_perimeter(surface, method: str, value: float) -> str | None:
@@ -335,10 +337,12 @@ def _resolve_perimeter(model, floor_names, mode, total_m, fraction, warnings):
     if mode == "fraction":
         if fraction is None:
             return None, "exposed_perimeter_method='fraction' requires exposed_perimeter_fraction"
-        if not 0.0 <= fraction <= 1.0:
+        if not 0.0 < fraction <= 1.0:
             return None, (
-                f"exposed_perimeter_fraction must be between 0 and 1, got {fraction} — "
-                f"OpenStudio discards an out-of-range fraction without reporting it."
+                f"exposed_perimeter_fraction must be greater than 0 and at most 1, got {fraction} "
+                f"— OpenStudio discards an out-of-range fraction without reporting it, and Kiva "
+                f"refuses a zero exposed perimeter (the computed path clamps zero to "
+                f"{MIN_EXPOSED_PERIMETER_M} m for the same reason)."
             )
         return dict.fromkeys(floor_names, (PERIMETER_METHOD_FRACTION, fraction, PROVENANCE_USER)), None
 

--- a/mcp_server/skills/geometry/kiva_foundation.py
+++ b/mcp_server/skills/geometry/kiva_foundation.py
@@ -208,31 +208,55 @@ def _insulation_material(model, r_si: float):
     return material, "created"
 
 
-def _wall_depth_for(model, wall_names: list[str]) -> float | None:
-    """How far below grade the paired walls reach — the depth a full-height insulation run needs."""
+def paired_wall_geometry(model, wall_names: list[str]) -> dict[str, Any] | None:
+    """World-coordinate extents of the walls paired to one floor, or None when there are none.
+
+    Two Foundation:Kiva fields are defined against these, and both were previously derived from
+    the wrong datum:
+      - Exterior Vertical Insulation Depth is "measured from the wall top to the bottom edge"
+        (Energy+.idd), so a full-height run is the wall's span top-to-bottom, not its depth
+        below grade. A basement wall from +0.9 to -3.0 needs 3.9, not 3.0.
+      - Wall Height Above Grade is "distance from the exterior grade to the wall top", so it is
+        the wall's z_max, not the archetype's 0.2 default.
+    Walls of differing height share one Foundation object; the largest span is used and
+    `mixed_heights` says so, since one field cannot match every wall exactly.
+    """
     from mcp_server.skills.geometry.ground_contact import world_z_range
 
-    depths = []
+    tops, bottoms, spans = [], [], []
     for name in wall_names:
         optional = model.getSurfaceByName(name)
         if not optional.is_initialized():
             continue
         z_range = world_z_range(optional.get())
-        if z_range is not None:
-            depths.append(-z_range[0])
-    return round(max(depths), 3) if depths and max(depths) > 0 else None
+        if z_range is None:
+            continue
+        bottoms.append(z_range[0])
+        tops.append(z_range[1])
+        spans.append(z_range[1] - z_range[0])
+    if not spans:
+        return None
+    return {
+        "top_m": round(max(tops), 3),
+        "bottom_m": round(min(bottoms), 3),
+        "span_m": round(max(spans), 3),
+        "mixed_heights": (max(spans) - min(spans)) > 0.01,
+        "span_range_m": [round(min(spans), 3), round(max(spans), 3)],
+    }
 
 
-def _apply_insulation(model, kiva, specs, wall_depth_m, provenance, warnings) -> str | None:
+def _apply_insulation(model, kiva, specs, wall_span_m, provenance, warnings) -> str | None:
     """Attach the insulation layers to one FoundationKiva. Returns an error string, or None.
 
-    A setter refusal is an error, not a warning: recording the requested extent while the object
-    kept its default would report insulation that is not in the model.
+    `wall_span_m` is the paired walls' top-to-bottom span, which is what MATCH_WALL_DEPTH
+    resolves to: the EnergyPlus depth field is measured from the wall top. A setter refusal is
+    an error, not a warning: recording the requested extent while the object kept its default
+    would report insulation that is not in the model.
     """
     for spec in specs:
         depth = spec.depth_m
         if depth == MATCH_WALL_DEPTH:
-            depth = wall_depth_m
+            depth = wall_span_m
             if depth is None:
                 warnings.append(
                     f"{spec.position} insulation asked to match the below-grade wall depth, but no "

--- a/mcp_server/skills/geometry/tools.py
+++ b/mcp_server/skills/geometry/tools.py
@@ -18,11 +18,15 @@ from mcp_server.skills.geometry.operations import (
 )
 from mcp_server.skills.geometry.patch_missing_surfaces import patch_missing_surfaces
 from mcp_server.skills.geometry.repair import repair_missing_roof_ceiling
+from mcp_server.skills.geometry.tools_kiva import register_kiva_tools
 from mcp_server.skills.geometry.trim_overlapping_surfaces import trim_overlapping_surfaces
 from mcp_server.skills.geometry.weld_coincident_vertices import weld_coincident_vertices
 
 
 def register(mcp):
+    # Kiva tools live in their own module: this file was already at the ~400 line budget.
+    register_kiva_tools(mcp)
+
     @mcp.tool(tags={"geometry"}, name="list_surfaces")
     def list_surfaces_tool(
         detailed: bool = False,

--- a/mcp_server/skills/geometry/tools_kiva.py
+++ b/mcp_server/skills/geometry/tools_kiva.py
@@ -99,7 +99,9 @@ def register_kiva_tools(mcp) -> None:
                 "total" uses exposed_perimeter_m, "fraction" uses exposed_perimeter_fraction.
             exposed_perimeter_m: Measured exposed perimeter in metres; single floor only.
             exposed_perimeter_fraction: Fraction of the slab edge exposed, 0 to 1.
-            wall_height_above_grade_m: Override the archetype's foundation wall height above grade.
+            wall_height_above_grade_m: Distance from grade to the wall top. Derived from the paired
+                below-grade walls' top when they exist (provenance computed_geometry); the
+                archetype value applies only to floors with no paired wall. Pass it to override.
             wall_depth_below_slab_m: Override the footing stem depth below the slab. Note this is
                 not the basement depth, which comes from the below-grade wall geometry.
             footing_depth_m: Override the footing depth.

--- a/mcp_server/skills/geometry/tools_kiva.py
+++ b/mcp_server/skills/geometry/tools_kiva.py
@@ -1,0 +1,143 @@
+"""MCP tools for EnergyPlus Kiva foundation modelling.
+
+Split out of geometry/tools.py, which was already at ~389 lines against the ~400 budget
+(CLAUDE.md rule 1) — the same sub-registrar pattern loop_operations/tools_air_loop.py uses.
+"""
+from __future__ import annotations
+
+from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+from mcp_server.skills.geometry.kiva_foundation import get_foundation_options
+
+
+def register_kiva_tools(mcp) -> None:
+    @mcp.tool(tags={"geometry"}, name="get_foundation_options")
+    def get_foundation_options_tool(include_adiabatic: bool = False):
+        """List the foundation modelling choices for this model before applying Kiva to it.
+
+        Call this before set_kiva_foundation. It reports which floors and below-grade walls
+        EnergyPlus would accept as Kiva surfaces, why each rejected surface was rejected, the
+        exposed perimeter computed from the building footprint, and the five foundation archetypes
+        with their full parameter sets — so the user can be shown the actual numbers rather than an
+        opaque name.
+
+        The archetype insulation R-values are conventional starting points, not derived from a code
+        table or a vendored dataset, and each archetype says so in its `basis`. The ASHRAE 90.1
+        F-factor / C-factor targets for the model's climate zone are reported alongside as a
+        cross-check, not as their source.
+
+        Also reports how many separate Kiva 2D domains would be created: EnergyPlus allows only one
+        floor per Foundation object, so a forty-slab model means forty domains and a much slower
+        simulation.
+
+        Read-only — creates no objects, including no FoundationKivaSettings.
+
+        Args:
+            include_adiabatic: Also consider Adiabatic surfaces. Off by default because
+                patch_missing_surfaces sets that condition deliberately on facets it could not
+                identify, and burying them would undo that decision.
+
+        Returns:
+            eligible_floors, eligible_walls, blocked, eligible_floor_count,
+            kiva_domains_if_applied, existing_kiva, archetypes, climate_zone, code_targets,
+            ground_temperatures, warnings, next_step
+        """
+        return get_foundation_options(include_adiabatic=include_adiabatic)
+
+    @mcp.tool(tags={"geometry"}, name="set_kiva_foundation")
+    def set_kiva_foundation_tool(
+        archetype: str,
+        floor_surface_names: list[str] | str | None = None,
+        include_below_grade_walls: bool = True,
+        include_adiabatic: bool = False,
+        exposed_perimeter_method: str = "auto",
+        exposed_perimeter_m: float | None = None,
+        exposed_perimeter_fraction: float | None = None,
+        wall_height_above_grade_m: float | None = None,
+        wall_depth_below_slab_m: float | None = None,
+        footing_depth_m: float | None = None,
+        interior_horizontal_insulation_r_si: float | None = None,
+        interior_horizontal_insulation_width_m: float | None = None,
+        exterior_vertical_insulation_r_si: float | None = None,
+        exterior_vertical_insulation_depth_m: float | None = None,
+        soil_conductivity_w_mk: float | None = None,
+        soil_density_kg_m3: float | None = None,
+        soil_specific_heat_j_kgk: float | None = None,
+        epw_path: str | None = None,
+        confirm_many_domains: bool = False,
+        overwrite: bool = False,
+        dry_run: bool = False,
+    ):
+        """Model foundation heat transfer with EnergyPlus Kiva, a 2D finite-difference soil solver.
+
+        The detailed alternative to set_ground_temperatures. A surface converted here gets the
+        Foundation boundary condition and a solved soil domain including slab-edge losses and
+        insulation geometry — and it then IGNORES Site:GroundTemperature:BuildingSurface entirely.
+        Use this when slab-edge heat transfer matters or the foundation is what is being studied;
+        use set_ground_temperatures for screening runs and models with no foundation information.
+
+        Ask the user which archetype describes their foundation before calling this, showing them
+        the parameter values from get_foundation_options. The insulation R-values are conventional
+        starting points rather than sourced figures; every applied value reports its provenance
+        (user / archetype / epw_header / openstudio_default / computed_geometry) so nothing implies
+        precision it does not have.
+
+        Costs and constraints worth knowing: EnergyPlus creates one 2D domain per floor and refuses
+        to run Kiva without a weather file; a Kiva surface may not carry windows or doors, may not
+        use massless construction layers, and a wall may not exceed four vertices. Ineligible
+        surfaces are refused with a reason rather than half-applied.
+
+        Changes the in-memory model — call save_osm_model to persist.
+
+        Args:
+            archetype: One of slab_on_grade_uninsulated, slab_on_grade_perimeter_insulated,
+                heated_basement_insulated, unheated_basement, crawlspace_vented.
+            floor_surface_names: Floors to convert. Defaults to every eligible floor.
+            include_below_grade_walls: Also attach below-grade walls that share an edge with a
+                converted floor. Walls pairing to no floor are reported and skipped.
+            include_adiabatic: Consider Adiabatic surfaces as candidates.
+            exposed_perimeter_method: "auto" computes it from the building footprint (recommended),
+                "total" uses exposed_perimeter_m, "fraction" uses exposed_perimeter_fraction.
+            exposed_perimeter_m: Measured exposed perimeter in metres; single floor only.
+            exposed_perimeter_fraction: Fraction of the slab edge exposed, 0 to 1.
+            wall_height_above_grade_m: Override the archetype's foundation wall height above grade.
+            wall_depth_below_slab_m: Override the footing stem depth below the slab. Note this is
+                not the basement depth, which comes from the below-grade wall geometry.
+            footing_depth_m: Override the footing depth.
+            interior_horizontal_insulation_r_si: Under-slab insulation R-value, m2K/W.
+            interior_horizontal_insulation_width_m: How far it extends inward from the wall.
+            exterior_vertical_insulation_r_si: Outside-face wall insulation R-value, m2K/W.
+            exterior_vertical_insulation_depth_m: How far down it runs.
+            soil_conductivity_w_mk: Override the soil conductivity, W/m-K.
+            soil_density_kg_m3: Override the soil density.
+            soil_specific_heat_j_kgk: Override the soil specific heat.
+            epw_path: EPW to read soil properties from. Defaults to the model's own weather file.
+            confirm_many_domains: Required to proceed past 20 eligible floors.
+            overwrite: Replace foundations on floors that already carry one.
+            dry_run: Return the plan without changing anything.
+
+        Returns:
+            plan, applied, warnings, code_targets, ground_temperature_interaction
+        """
+        return set_kiva_foundation(
+            archetype=archetype,
+            floor_surface_names=floor_surface_names,
+            include_below_grade_walls=include_below_grade_walls,
+            include_adiabatic=include_adiabatic,
+            exposed_perimeter_method=exposed_perimeter_method,
+            exposed_perimeter_m=exposed_perimeter_m,
+            exposed_perimeter_fraction=exposed_perimeter_fraction,
+            wall_height_above_grade_m=wall_height_above_grade_m,
+            wall_depth_below_slab_m=wall_depth_below_slab_m,
+            footing_depth_m=footing_depth_m,
+            interior_horizontal_insulation_r_si=interior_horizontal_insulation_r_si,
+            interior_horizontal_insulation_width_m=interior_horizontal_insulation_width_m,
+            exterior_vertical_insulation_r_si=exterior_vertical_insulation_r_si,
+            exterior_vertical_insulation_depth_m=exterior_vertical_insulation_depth_m,
+            soil_conductivity_w_mk=soil_conductivity_w_mk,
+            soil_density_kg_m3=soil_density_kg_m3,
+            soil_specific_heat_j_kgk=soil_specific_heat_j_kgk,
+            epw_path=epw_path,
+            confirm_many_domains=confirm_many_domains,
+            overwrite=overwrite,
+            dry_run=dry_run,
+        )

--- a/mcp_server/skills/geometry/tools_kiva.py
+++ b/mcp_server/skills/geometry/tools_kiva.py
@@ -103,10 +103,15 @@ def register_kiva_tools(mcp) -> None:
             wall_depth_below_slab_m: Override the footing stem depth below the slab. Note this is
                 not the basement depth, which comes from the below-grade wall geometry.
             footing_depth_m: Override the footing depth.
-            interior_horizontal_insulation_r_si: Under-slab insulation R-value, m2K/W.
+            interior_horizontal_insulation_r_si: Under-slab insulation R-value, m2K/W. Adding it
+                to an archetype that has no interior-horizontal layer also requires the width.
             interior_horizontal_insulation_width_m: How far it extends inward from the wall.
-            exterior_vertical_insulation_r_si: Outside-face wall insulation R-value, m2K/W.
-            exterior_vertical_insulation_depth_m: How far down it runs.
+                EnergyPlus refuses an interior-horizontal material without it.
+            exterior_vertical_insulation_r_si: Outside-face wall insulation R-value, m2K/W. Adding
+                it to an archetype that has no exterior-vertical layer also requires the depth.
+            exterior_vertical_insulation_depth_m: How far down it runs, measured from the WALL TOP
+                (the EnergyPlus definition), not from grade. EnergyPlus refuses an
+                exterior-vertical material without it.
             soil_conductivity_w_mk: Override the soil conductivity, W/m-K.
             soil_density_kg_m3: Override the soil density.
             soil_specific_heat_j_kgk: Override the soil specific heat.

--- a/mcp_server/skills/weather/epw_ground_temperatures.py
+++ b/mcp_server/skills/weather/epw_ground_temperatures.py
@@ -1,0 +1,280 @@
+"""Parse the GROUND TEMPERATURES record out of an EPW file header.
+
+Nothing else in this server reads an EPW header. `_estimate_climate_zone_from_epw`
+(weather/operations.py) skips the first 8 lines and reads data rows; the only other
+weather-sidecar parser is `parse_climate_zone_from_stat` in gbxml_import. So this is the
+first header reader, and it is deliberately kept free of `import openstudio` — the format
+handling is where the bugs live, and rule 4 says unit tests never import openstudio. Same
+trade `gbxml_import/zone_checks.py` makes, for the same reason.
+
+Record shape, verified against all three EPWs in tests/assets and a staged runs/**/in.epw:
+
+    GROUND TEMPERATURES,<n_sets>,[<depth_m>,<cond>,<dens>,<spec_heat>,<12 monthly C>] * n_sets
+
+e.g. Boston TMY3 (line 4, soil properties blank, depths written as `.5`, `2`, `4`):
+
+    GROUND TEMPERATURES,3,.5,,,,-0.29,-1.36,...,3.79,2,,,,3.63,...,4,,,,6.88,...
+
+Two things a reader is tempted to assume and must not:
+
+- **The depths are not guaranteed to be 0.5/2/4.** Callers ask for a target depth and get
+  the nearest available set plus the delta, never `sets[0]` / `sets[2]`.
+- **The record is not guaranteed to be line 4.** It is in every file we have, but the scan
+  is by keyword over the header, which costs nothing.
+
+The soil property fields are blank in every bundled EPW — that is the normal case, not a
+defect, and they parse to None rather than 0.0. A Kiva foundation model consumes them when
+a file does populate them, which is why they are carried at all.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from mcp_server.util import read_head_bounded
+
+GROUND_TEMPERATURE_KEYWORD = "GROUND TEMPERATURES"
+
+# The 8 EPW header lines before the data rows. DESIGN CONDITIONS alone runs to ~1.5 KB in the
+# bundled files, so 128 KB is ~2 orders of margin and never touches the 8760 data rows.
+EPW_HEADER_MAX_BYTES = 131_072
+MAX_HEADER_LINES = 8
+
+# depth, conductivity, density, specific heat, then 12 monthly temperatures.
+FIELDS_PER_SET = 16
+MONTHS_PER_SET = 12
+
+# A crafted header could declare n_sets=10**9; the cap is checked before any allocation.
+MAX_DEPTH_SETS = 24
+
+# Gross-corruption guards, not climate science. A 900 degree ground temperature is a broken
+# file. These will NOT catch a Fahrenheit file — see the spread warning in _validate_set.
+MIN_PLAUSIBLE_C = -60.0
+MAX_PLAUSIBLE_C = 60.0
+MAX_PLAUSIBLE_DEPTH_M = 100.0
+
+# Above this annual spread or mean, the file is likely not in Celsius. Warned, never rejected:
+# there is no bulletproof C/F detector and a real climate can be surprising.
+SUSPICIOUS_SPREAD_K = 40.0
+SUSPICIOUS_MEAN_C = 40.0
+
+
+class EpwGroundTemperatureError(ValueError):
+    """The EPW header carries no usable GROUND TEMPERATURES record.
+
+    Raised rather than returned because every caller in this package is an operation that
+    already wraps its body in try/except and turns exceptions into {"ok": False, ...}.
+    """
+
+
+@dataclass(frozen=True)
+class GroundTemperatureSet:
+    """One depth's worth of the EPW record: 12 monthly temperatures and the soil it assumed."""
+
+    depth_m: float
+    monthly_c: tuple[float, ...]
+    conductivity_w_mk: float | None
+    density_kg_m3: float | None
+    specific_heat_j_kgk: float | None
+
+
+def _parse_float(token: str, what: str, set_index: int) -> float:
+    text = token.strip()
+    if not text:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES set {set_index}: {what} is blank",
+        )
+    try:
+        return float(text)
+    except ValueError as e:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES set {set_index}: {what} is not a number ({token.strip()!r})",
+        ) from e
+
+
+def _parse_optional_float(token: str, what: str, set_index: int) -> float | None:
+    """Soil properties are blank in every bundled EPW. Blank is None, never 0.0."""
+    text = token.strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError as e:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES set {set_index}: {what} is not a number ({token.strip()!r})",
+        ) from e
+
+
+def _validate_set(gt_set: GroundTemperatureSet, set_index: int, warnings: list[str]) -> None:
+    if not 0.0 < gt_set.depth_m <= MAX_PLAUSIBLE_DEPTH_M:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES set {set_index}: implausible depth {gt_set.depth_m} m",
+        )
+    for month_index, value in enumerate(gt_set.monthly_c, start=1):
+        if not MIN_PLAUSIBLE_C <= value <= MAX_PLAUSIBLE_C:
+            raise EpwGroundTemperatureError(
+                f"GROUND TEMPERATURES set {set_index}: implausible temperature "
+                f"{value} C in month {month_index}",
+            )
+    spread = max(gt_set.monthly_c) - min(gt_set.monthly_c)
+    mean = sum(gt_set.monthly_c) / MONTHS_PER_SET
+    if spread > SUSPICIOUS_SPREAD_K or mean > SUSPICIOUS_MEAN_C:
+        warnings.append(
+            f"Ground temperatures at {gt_set.depth_m} m have an annual spread of "
+            f"{spread:.1f} K and a mean of {mean:.1f} — unusually large for soil. "
+            f"Check the EPW is in Celsius.",
+        )
+
+
+def parse_ground_temperature_header(line: str) -> tuple[list[GroundTemperatureSet], list[str]]:
+    """Parse one GROUND TEMPERATURES header line into its depth sets.
+
+    Returns (sets, warnings). Raises EpwGroundTemperatureError on anything that cannot be
+    parsed unambiguously — a missing month is never zero-filled and a blank temperature is
+    never treated as 0.0.
+    """
+    warnings: list[str] = []
+    tokens = line.split(",")
+    if not tokens or tokens[0].strip().upper() != GROUND_TEMPERATURE_KEYWORD:
+        raise EpwGroundTemperatureError(
+            f"Not a GROUND TEMPERATURES record: {line[:60]!r}",
+        )
+
+    # Real files carry a trailing comma; strip only trailing blanks so an interior blank
+    # (a genuinely missing field) still fails the arity check below.
+    fields = tokens[1:]
+    while fields and not fields[-1].strip():
+        fields.pop()
+
+    if not fields:
+        raise EpwGroundTemperatureError(
+            "GROUND TEMPERATURES record declares no depth-set count",
+        )
+
+    declared_text = fields[0].strip()
+    try:
+        declared = int(declared_text)
+    except ValueError as e:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES depth-set count is not an integer ({declared_text!r})",
+        ) from e
+    if declared <= 0:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES declares {declared} depth sets",
+        )
+    if declared > MAX_DEPTH_SETS:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES declares {declared} depth sets, above the "
+            f"{MAX_DEPTH_SETS} this reader accepts",
+        )
+
+    payload = fields[1:]
+    if len(payload) % FIELDS_PER_SET != 0:
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES carries {len(payload)} fields, not a multiple of "
+            f"{FIELDS_PER_SET} — a depth set is truncated",
+        )
+    actual = len(payload) // FIELDS_PER_SET
+    if actual == 0:
+        raise EpwGroundTemperatureError(
+            "GROUND TEMPERATURES record carries no depth-set data",
+        )
+    if actual != declared:
+        warnings.append(
+            f"EPW header declares {declared} ground temperature sets but carries {actual}; "
+            f"using the {actual} present.",
+        )
+
+    sets: list[GroundTemperatureSet] = []
+    for index in range(actual):
+        chunk = payload[index * FIELDS_PER_SET:(index + 1) * FIELDS_PER_SET]
+        monthly = tuple(
+            _parse_float(chunk[4 + month], f"month {month + 1} temperature", index)
+            for month in range(MONTHS_PER_SET)
+        )
+        gt_set = GroundTemperatureSet(
+            depth_m=_parse_float(chunk[0], "depth", index),
+            monthly_c=monthly,
+            conductivity_w_mk=_parse_optional_float(chunk[1], "soil conductivity", index),
+            density_kg_m3=_parse_optional_float(chunk[2], "soil density", index),
+            specific_heat_j_kgk=_parse_optional_float(chunk[3], "soil specific heat", index),
+        )
+        _validate_set(gt_set, index, warnings)
+        sets.append(gt_set)
+
+    seen: dict[float, int] = {}
+    deduped: list[GroundTemperatureSet] = []
+    for index, gt_set in enumerate(sets):
+        if gt_set.depth_m in seen:
+            warnings.append(
+                f"EPW header repeats depth {gt_set.depth_m} m (sets {seen[gt_set.depth_m]} "
+                f"and {index}); keeping the first.",
+            )
+            continue
+        seen[gt_set.depth_m] = index
+        deduped.append(gt_set)
+
+    return deduped, warnings
+
+
+def find_ground_temperature_line(header_text: str) -> str | None:
+    """The GROUND TEMPERATURES line from an EPW header blob, or None.
+
+    Scans the first MAX_HEADER_LINES by keyword rather than indexing line 4 — it is line 4
+    in every EPW we have, but that costs nothing to not rely on.
+    """
+    for line in header_text.splitlines()[:MAX_HEADER_LINES]:
+        if line.strip().upper().startswith(GROUND_TEMPERATURE_KEYWORD):
+            return line
+    return None
+
+
+def read_ground_temperature_sets(epw_path: Path) -> tuple[list[GroundTemperatureSet], list[str]]:
+    """Read and parse the GROUND TEMPERATURES record from an EPW file.
+
+    Uses util.read_head_bounded, which refuses symlinks and non-regular files and never
+    slurps the 8760 data rows. Raises EpwGroundTemperatureError; the caller turns that into
+    {"ok": False, ...}.
+    """
+    try:
+        raw = read_head_bounded(epw_path, EPW_HEADER_MAX_BYTES)
+    except ValueError as e:
+        raise EpwGroundTemperatureError(f"Cannot read EPW header: {e}") from e
+
+    text = raw.decode("utf-8", errors="replace")
+    if "\n" not in text:
+        # A header this long with no line break is not an EPW — it is the degenerate input
+        # the bounded read exists to survive (cf. the billion-laughs case in gbxml deltas).
+        raise EpwGroundTemperatureError(
+            f"No line break in the first {EPW_HEADER_MAX_BYTES} bytes — not an EPW header",
+        )
+
+    lines = text.splitlines()
+    if len(raw) == EPW_HEADER_MAX_BYTES and not text.endswith(("\n", "\r")):
+        # The read cut mid-line; that last fragment is not a record.
+        lines.pop()
+
+    line = find_ground_temperature_line("\n".join(lines))
+    if line is None:
+        raise EpwGroundTemperatureError(
+            f"EPW header has no {GROUND_TEMPERATURE_KEYWORD} record: {epw_path.name}",
+        )
+    return parse_ground_temperature_header(line)
+
+
+def nearest_depth_set(
+    sets: list[GroundTemperatureSet],
+    target_m: float,
+) -> tuple[GroundTemperatureSet, float]:
+    """The set whose depth is nearest `target_m`, with the absolute delta in metres.
+
+    Never an index lookup: EPW depths are commonly 0.5/2/4 but nothing guarantees it, and a
+    file with a single 2 m set must still answer a 4 m request (with a delta the caller can
+    warn about).
+
+    Ties break to the shallower depth, so the choice is deterministic across files.
+    """
+    if not sets:
+        raise EpwGroundTemperatureError("No ground temperature sets to choose from")
+    best = min(sets, key=lambda s: (abs(s.depth_m - target_m), s.depth_m))
+    return best, abs(best.depth_m - target_m)

--- a/mcp_server/skills/weather/epw_ground_temperatures.py
+++ b/mcp_server/skills/weather/epw_ground_temperatures.py
@@ -179,6 +179,13 @@ def parse_ground_temperature_header(line: str) -> tuple[list[GroundTemperatureSe
         raise EpwGroundTemperatureError(
             "GROUND TEMPERATURES record carries no depth-set data",
         )
+    if actual > MAX_DEPTH_SETS:
+        # The declared count is advisory (a mismatch is only warned about below), so the cap has
+        # to bind on what the record actually carries or it binds on nothing.
+        raise EpwGroundTemperatureError(
+            f"GROUND TEMPERATURES carries {actual} depth sets, above the {MAX_DEPTH_SETS} this "
+            f"reader accepts",
+        )
     if actual != declared:
         warnings.append(
             f"EPW header declares {declared} ground temperature sets but carries {actual}; "

--- a/mcp_server/skills/weather/ground_temperatures.py
+++ b/mcp_server/skills/weather/ground_temperatures.py
@@ -214,7 +214,9 @@ def _model_weather_epw(model) -> Path | None:
         return None
 
     candidate = Path(str(url_path.get()))
-    if candidate.is_absolute() and candidate.is_file() and is_path_allowed(candidate):
+    # Allowlist before existence: the url is caller-controlled, and is_file() on a path outside
+    # the allowed roots would be an existence probe even though the result is never returned.
+    if candidate.is_absolute() and is_path_allowed(candidate) and candidate.is_file():
         return candidate
 
     found = find_epw_by_name(candidate.name)
@@ -256,6 +258,20 @@ def _resolve_epw(model, generation: int, epw_path: str | None) -> tuple[Path | N
         "file (absent or unresolvable). Pass epw_path, or set the model's weather with "
         "change_building_location."
     )
+
+
+def _kiva_interaction(model) -> dict[str, int]:
+    """How many surfaces Kiva governs versus how many BuildingSurface still reaches.
+
+    The mirror of set_kiva_foundation's ground_temperature_interaction: a Foundation surface
+    ignores Site:GroundTemperature:BuildingSurface, so writing it after Kiva can be a no-op
+    that looks effective unless this says so.
+    """
+    conditions = [s.outsideBoundaryCondition() for s in model.getSurfaces()]
+    return {
+        "foundation_surface_count": sum(1 for c in conditions if c == "Foundation"),
+        "ground_surface_count": sum(1 for c in conditions if c.startswith("Ground")),
+    }
 
 
 def _write_monthly(obj, values: list[float], label: str) -> str | None:
@@ -423,6 +439,18 @@ def set_ground_temperatures(
             applied[label] = entry
 
         after = read_ground_temperature_state(model)
+        interaction = _kiva_interaction(model)
+        if interaction["foundation_surface_count"] > 0 and "Site:GroundTemperature:BuildingSurface" in applied:
+            warnings.append(
+                f"{interaction['foundation_surface_count']} surface(s) use Kiva (Foundation boundary "
+                f"condition) and ignore Site:GroundTemperature:BuildingSurface entirely. It "
+                + (
+                    f"still applies to the {interaction['ground_surface_count']} remaining Ground "
+                    f"surface(s)."
+                    if interaction["ground_surface_count"] else
+                    "applies to no surface in this model — writing it changed nothing thermally."
+                ),
+            )
         ensure_generation_unchanged(generation)
         return {
             "ok": True,
@@ -434,6 +462,7 @@ def set_ground_temperatures(
             "skipped": skipped,
             "warnings": warnings,
             "ground_temperatures": after,
+            "kiva_interaction": interaction,
             "note": "Changes the in-memory model; call save_osm_model to persist.",
         }
     except Exception as e:

--- a/mcp_server/skills/weather/ground_temperatures.py
+++ b/mcp_server/skills/weather/ground_temperatures.py
@@ -221,10 +221,12 @@ def _resolve_epw(model, generation: int, epw_path: str | None) -> tuple[Path | N
         candidate = Path(epw_path)
         if candidate.suffix.lower() != ".epw":
             return None, f"Not an EPW file (expected .epw): {epw_path}"
-        if not candidate.is_file():
-            return None, f"EPW file not found: {epw_path}"
+        # Allowlist before existence, so a path outside it gets the same answer whether or
+        # not a file is there — the existence check must not double as a probe.
         if not is_path_allowed(candidate):
             return None, f"EPW path not allowed: {epw_path}. {path_denied_hint()}"
+        if not candidate.is_file():
+            return None, f"EPW file not found: {epw_path}"
         return candidate, "argument"
 
     from mcp_server.skills.gbxml_import.gbxml_source_state import get_epw_for_model

--- a/mcp_server/skills/weather/ground_temperatures.py
+++ b/mcp_server/skills/weather/ground_temperatures.py
@@ -132,25 +132,33 @@ def read_ground_temperature_state(model) -> dict[str, Any]:
 
 def _missing_from_state(state: dict[str, Any], kiva_surface_count: int = 0,
                        ground_surface_count: int = 0) -> dict[str, Any]:
-    missing = [
-        _IDF_NAMES[key] for key in _OBJECT_KEYS
+    unset = [
+        key for key in _OBJECT_KEYS
         if state[key]["state"] in ("absent", "defaulted", "partial")
     ]
+    # Every ground-coupled surface is solved by Kiva, which ignores BuildingSurface outright.
+    # Flagging it then would nag the user for having done the higher-fidelity thing, so it is
+    # reported as superseded rather than missing. The other three are inert with or without
+    # Kiva (no GHX, no F/C-factor constructions) and stay in the list on the same terms as before.
+    all_kiva = kiva_surface_count > 0 and ground_surface_count == 0
+    superseded = [_IDF_NAMES[k] for k in unset if all_kiva and k == "building_surface"]
+    missing = [_IDF_NAMES[k] for k in unset if _IDF_NAMES[k] not in superseded]
     result: dict[str, Any] = {
         "ground_temperatures_missing": bool(missing),
         "ground_temperatures_missing_count": len(missing),
         "ground_temperatures_state": {k: state[k]["state"] for k in _OBJECT_KEYS},
+        "kiva_foundation_surface_count": kiva_surface_count,
     }
-    result["kiva_foundation_surface_count"] = kiva_surface_count
+    if superseded:
+        result["ground_temperatures_superseded_by_kiva"] = superseded
     if missing:
         result["ground_temperatures_missing_objects"] = missing
-        if kiva_surface_count > 0 and ground_surface_count == 0:
-            # Every ground-coupled surface is solved by Kiva, which ignores these objects. Nagging
-            # about them would punish the user for having done the higher-fidelity thing.
+        if all_kiva:
             result["ground_temperatures_hint"] = (
                 f"All {kiva_surface_count} ground-coupled surface(s) use Kiva, which solves its own "
-                f"2D soil domain and ignores Site:GroundTemperature:BuildingSurface — these objects "
-                f"would be inert here."
+                f"2D soil domain and ignores Site:GroundTemperature:BuildingSurface. The remaining "
+                f"objects would be inert here: Shallow and Deep feed ground heat exchangers, "
+                f"FCfactorMethod affects only F/C-factor constructions."
             )
         else:
             result["ground_temperatures_hint"] = (

--- a/mcp_server/skills/weather/ground_temperatures.py
+++ b/mcp_server/skills/weather/ground_temperatures.py
@@ -1,0 +1,430 @@
+"""Apply an EPW header's ground temperatures to the loaded model's Site:GroundTemperature:* objects.
+
+A gbXML translation arrives with none of these objects set, so EnergyPlus falls back to its
+own defaults on every Ground-boundary surface. The project EPW already carries measured
+values and import_gbxml already requires that EPW — nothing read it until now.
+
+**The EPW values are UNDISTURBED soil temperatures — an open field, no building on it.** The
+repo's own weather assets say so (tests/assets/USA_MA_Boston-Logan...stat:498-500, and the
+same text in the Austin .stat):
+
+    **These ground temperatures should NOT BE USED in the GroundTemperatures object to
+    compute building floor losses.
+    The temperatures for 0.5 m depth can be used for GroundTemperatures:Surface.
+    The temperatures for 4.0 m depth can be used for GroundTemperatures:Deep.
+
+So raw EPW values go to Shallow, Deep and FCfactorMethod, and BuildingSurface — the only one
+that drives a slab's heat balance — gets a derived value instead. Boston's January 0.5 m
+figure is -0.29 C; feeding that to BuildingSurface would produce grossly overstated floor
+losses. Kiva (the Foundation boundary condition) is the higher-fidelity answer for anyone who
+needs real slab-edge heat transfer; this tool is the fast, approximate one.
+
+Honest scope, because four written objects can read as four improvements:
+  - Shallow/Deep feed ground heat exchangers and Site:GroundDomain. On a model with no GHX
+    they are inert.
+  - FCfactorMethod affects only F/C-factor constructions, which a gbXML import rarely has.
+    EnergyPlus derives this object from the weather file when it is absent, so writing it is
+    a deliberate override rather than a repair.
+  - BuildingSurface is the one that changes the floor heat balance.
+
+SDK facts (dev/probes/probe_ground_temperatures.py, OpenStudio 3.11.0):
+  - The four classes are UniqueModelObjects and the PLAIN getter CREATES the object
+    (objects 0 -> 1). getOptional<Class>() does not. A read path must use the optional form
+    or a "get" tool silently mutates the session model — the same hazard weather/operations.py
+    already documents at :240 and sidesteps at :295 with getOptionalWeatherFile().
+  - Per-month named accessors differ by class (setJanuaryGroundTemperature on BuildingSurface
+    and FCfactorMethod, setJanuarySurfaceGroundTemperature on Shallow,
+    setJanuaryDeepGroundTemperature on Deep) — but all four share a uniform
+    setAllMonthlyTemperatures(list_of_12) -> bool, getTemperatureByMonth(1..12),
+    isMonthDefaulted(1..12), resetAllMonths(). This module uses only the uniform four, so
+    there are no per-class name tables and no string dispatch.
+  - setAllMonthlyTemperatures accepts a plain Python list and clears all 12 defaulted flags.
+  - Setting one month leaves the others defaulted, so a mixed ("partial") state is real.
+  - IDD defaults differ per class: BuildingSurface 18.0, FCfactorMethod 13.0, Shallow 13.0,
+    Deep 16.0 — there is no single "18 C everywhere" assumption to lean on.
+  - An all-defaulted object IS written to the saved OSM and survives a reload, so presence is
+    not evidence that anyone chose a value. Detection has to use isMonthDefaulted.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from mcp_server.config import is_path_allowed, path_denied_hint
+from mcp_server.model_manager import ensure_generation_unchanged, get_model_with_generation
+from mcp_server.skills.weather.epw_ground_temperatures import (
+    EpwGroundTemperatureError,
+    GroundTemperatureSet,
+    nearest_depth_set,
+    read_ground_temperature_sets,
+)
+from mcp_server.skills.weather.zone_heating_setpoints import zone_heating_setpoints
+
+BUILDING_SURFACE_METHODS = ("setpoint_offset", "epw_raw", "constant", "none")
+
+# Below the indoor temperature, per the EnergyPlus Slab-preprocessor rule of thumb. A rule of
+# thumb is all this is — see the module docstring's Kiva note.
+SETPOINT_OFFSET_C = 2.0
+
+SHALLOW_TARGET_DEPTH_M = 0.5
+FCFACTOR_TARGET_DEPTH_M = 0.5
+DEEP_TARGET_DEPTH_M = 4.0
+
+# A nearest-available depth further than this from what was asked for changes the seasonal
+# swing enough to be worth saying out loud.
+DEPTH_MISMATCH_WARN_M = 1.0
+
+MONTHS = 12
+MIN_PLAUSIBLE_C = -60.0
+MAX_PLAUSIBLE_C = 60.0
+
+_OBJECT_KEYS = ("building_surface", "fcfactor_method", "shallow", "deep")
+_IDF_NAMES = {
+    "building_surface": "Site:GroundTemperature:BuildingSurface",
+    "fcfactor_method": "Site:GroundTemperature:FCfactorMethod",
+    "shallow": "Site:GroundTemperature:Shallow",
+    "deep": "Site:GroundTemperature:Deep",
+}
+
+
+def _state_from_optional(optional) -> dict[str, Any]:
+    """Side-effect-free state of one Site:GroundTemperature:* object.
+
+    absent    -> the unique object is not in the model
+    defaulted -> present, every month still the IDD default: carries no information
+    partial   -> present, some months chosen: somebody wrote a few deliberately
+    set       -> present, all 12 chosen
+    """
+    if not optional.is_initialized():
+        return {"state": "absent", "monthly_c": None, "months_set": 0}
+
+    obj = optional.get()
+    defaulted = [obj.isMonthDefaulted(m) for m in range(1, MONTHS + 1)]
+    months_set = sum(1 for d in defaulted if not d)
+    if months_set == 0:
+        state = "defaulted"
+    elif months_set < MONTHS:
+        state = "partial"
+    else:
+        state = "set"
+    return {
+        "state": state,
+        "monthly_c": [round(obj.getTemperatureByMonth(m), 3) for m in range(1, MONTHS + 1)],
+        "months_set": months_set,
+    }
+
+
+def read_ground_temperature_state(model) -> dict[str, Any]:
+    """Per-object state of the model's four ground-temperature objects.
+
+    Never creates anything: four direct getOptional* calls, no dispatch. Safe to call from a
+    read tool.
+    """
+    return {
+        "building_surface": _state_from_optional(
+            model.getOptionalSiteGroundTemperatureBuildingSurface()),
+        "fcfactor_method": _state_from_optional(
+            model.getOptionalSiteGroundTemperatureFCfactorMethod()),
+        "shallow": _state_from_optional(model.getOptionalSiteGroundTemperatureShallow()),
+        "deep": _state_from_optional(model.getOptionalSiteGroundTemperatureDeep()),
+    }
+
+
+def _missing_from_state(state: dict[str, Any], kiva_surface_count: int = 0,
+                       ground_surface_count: int = 0) -> dict[str, Any]:
+    missing = [
+        _IDF_NAMES[key] for key in _OBJECT_KEYS
+        if state[key]["state"] in ("absent", "defaulted", "partial")
+    ]
+    result: dict[str, Any] = {
+        "ground_temperatures_missing": bool(missing),
+        "ground_temperatures_missing_count": len(missing),
+        "ground_temperatures_state": {k: state[k]["state"] for k in _OBJECT_KEYS},
+    }
+    result["kiva_foundation_surface_count"] = kiva_surface_count
+    if missing:
+        result["ground_temperatures_missing_objects"] = missing
+        if kiva_surface_count > 0 and ground_surface_count == 0:
+            # Every ground-coupled surface is solved by Kiva, which ignores these objects. Nagging
+            # about them would punish the user for having done the higher-fidelity thing.
+            result["ground_temperatures_hint"] = (
+                f"All {kiva_surface_count} ground-coupled surface(s) use Kiva, which solves its own "
+                f"2D soil domain and ignores Site:GroundTemperature:BuildingSurface — these objects "
+                f"would be inert here."
+            )
+        else:
+            result["ground_temperatures_hint"] = (
+                "EnergyPlus falls back to its own per-object defaults (BuildingSurface 18 C). "
+                "Apply the project EPW's values with set_ground_temperatures(), or model the "
+                "foundation directly with set_kiva_foundation() when slab-edge heat transfer "
+                "matters."
+            )
+    return result
+
+
+def find_missing_ground_temperatures() -> dict[str, Any]:
+    """Report-only check of the loaded model's ground temperatures.
+
+    Shaped to be merged into repair_and_validate_gbxml_geometry's result without touching its
+    `ok`, exactly like find_missing_ground_contact. Needs no EPW and never mutates.
+    """
+    try:
+        model, generation = get_model_with_generation()
+        conditions = [s.outsideBoundaryCondition() for s in model.getSurfaces()]
+        result = {
+            "ok": True,
+            **_missing_from_state(
+                read_ground_temperature_state(model),
+                kiva_surface_count=sum(1 for c in conditions if c == "Foundation"),
+                ground_surface_count=sum(1 for c in conditions if c.startswith("Ground")),
+            ),
+        }
+        ensure_generation_unchanged(generation)
+        return result
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to check ground temperatures: {e}"}
+
+
+def _model_weather_epw(model) -> Path | None:
+    """The EPW the model's own WeatherFile points at, if it can be reached safely.
+
+    Deliberately not weather.operations.resolve_model_weather_epw: that takes a saved OSM
+    path and re-loads it from disk, while this tool works on the in-memory session model that
+    may never have been saved (and that function creates a unique object on its throwaway
+    copy). An absolute url is honoured only inside the allowlist — a model's weather url is
+    caller-controlled and must not reach another tenant's file.
+    """
+    from mcp_server.skills.weather.operations import find_epw_by_name
+
+    optional = model.getOptionalWeatherFile()
+    if not optional.is_initialized():
+        return None
+    url_path = optional.get().path()
+    if not url_path.is_initialized():
+        return None
+
+    candidate = Path(str(url_path.get()))
+    if candidate.is_absolute() and candidate.is_file() and is_path_allowed(candidate):
+        return candidate
+
+    found = find_epw_by_name(candidate.name)
+    if found is not None and is_path_allowed(found):
+        return found
+    return None
+
+
+def _resolve_epw(model, generation: int, epw_path: str | None) -> tuple[Path | None, str]:
+    """(epw, source) or (None, reason). Sources: argument, gbxml_import_stash, model_weather_file."""
+    if epw_path is not None:
+        candidate = Path(epw_path)
+        if candidate.suffix.lower() != ".epw":
+            return None, f"Not an EPW file (expected .epw): {epw_path}"
+        if not candidate.is_file():
+            return None, f"EPW file not found: {epw_path}"
+        if not is_path_allowed(candidate):
+            return None, f"EPW path not allowed: {epw_path}. {path_denied_hint()}"
+        return candidate, "argument"
+
+    from mcp_server.skills.gbxml_import.gbxml_source_state import get_epw_for_model
+
+    stashed = get_epw_for_model(generation)
+    if stashed is not None:
+        candidate = Path(stashed)
+        # Run retention may have swept the staged copy — that is a miss, not an error.
+        if candidate.is_file() and is_path_allowed(candidate):
+            return candidate, "gbxml_import_stash"
+
+    from_model = _model_weather_epw(model)
+    if from_model is not None:
+        return from_model, "model_weather_file"
+
+    return None, (
+        "No EPW to read ground temperatures from. Tried: the epw_path argument (not given), "
+        "the EPW stashed by import_gbxml for this model (none), and the model's own weather "
+        "file (absent or unresolvable). Pass epw_path, or set the model's weather with "
+        "change_building_location."
+    )
+
+
+def _write_monthly(obj, values: list[float], label: str) -> str | None:
+    """Write 12 monthly temperatures. Returns an error string, or None on success."""
+    if not obj.setAllMonthlyTemperatures(values):
+        return f"OpenStudio refused the monthly temperatures for {label}"
+    return None
+
+
+def _building_surface_values(
+    model,
+    method: str,
+    constant_c: float | None,
+    shallow_set: GroundTemperatureSet,
+) -> tuple[list[float] | None, dict[str, Any]]:
+    """(values or None, detail). None means "write nothing", and detail says why."""
+    if method == "none":
+        return None, {"reason": "building_surface_method='none'"}
+
+    if method == "constant":
+        return [constant_c] * MONTHS, {
+            "source": "constant",
+            "constant_c": constant_c,
+        }
+
+    if method == "epw_raw":
+        return list(shallow_set.monthly_c), {
+            "source": "epw_raw_against_guidance",
+            "depth_m": shallow_set.depth_m,
+        }
+
+    setpoints = zone_heating_setpoints(model)
+    if setpoints["mean_c"] is None:
+        return None, {
+            "reason": (
+                f"{setpoints['skip_reason']} — cannot derive a setpoint offset. Run this after "
+                f"thermostats exist, or pass building_surface_method='constant' with "
+                f"building_surface_constant_c, or 'epw_raw' to accept the undisturbed values."
+            ),
+            "zones_with_thermostat": setpoints["zones_with_thermostat"],
+        }
+
+    value = round(setpoints["mean_c"] - SETPOINT_OFFSET_C, 3)
+    return [value] * MONTHS, {
+        "source": "setpoint_offset",
+        "mean_heating_setpoint_c": round(setpoints["mean_c"], 3),
+        "offset_c": SETPOINT_OFFSET_C,
+        "zone_count": setpoints["zone_count"],
+        "setpoint_spread_warning": setpoints["spread_warning"],
+    }
+
+
+def set_ground_temperatures(
+    epw_path: str | None = None,
+    building_surface_method: str = "setpoint_offset",
+    building_surface_constant_c: float | None = None,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Apply an EPW header's ground temperatures to the loaded model. See the module docstring."""
+    if building_surface_method not in BUILDING_SURFACE_METHODS:
+        return {
+            "ok": False,
+            "error": f"Unknown building_surface_method '{building_surface_method}'. "
+                     f"Valid: {list(BUILDING_SURFACE_METHODS)}",
+        }
+    if building_surface_method == "constant":
+        if building_surface_constant_c is None:
+            return {
+                "ok": False,
+                "error": "building_surface_method='constant' requires building_surface_constant_c",
+            }
+        if not MIN_PLAUSIBLE_C <= building_surface_constant_c <= MAX_PLAUSIBLE_C:
+            return {
+                "ok": False,
+                "error": f"building_surface_constant_c {building_surface_constant_c} is outside "
+                         f"{MIN_PLAUSIBLE_C}..{MAX_PLAUSIBLE_C} C",
+            }
+
+    try:
+        model, generation = get_model_with_generation()
+    except RuntimeError as e:
+        return {"ok": False, "error": str(e)}
+
+    try:
+        warnings: list[str] = []
+        if building_surface_constant_c is not None and building_surface_method != "constant":
+            warnings.append(
+                f"building_surface_constant_c was given but building_surface_method is "
+                f"'{building_surface_method}'; the value is unused.",
+            )
+
+        epw, source = _resolve_epw(model, generation, epw_path)
+        if epw is None:
+            return {"ok": False, "error": source}
+
+        try:
+            sets, parse_warnings = read_ground_temperature_sets(epw)
+        except EpwGroundTemperatureError as e:
+            return {"ok": False, "error": str(e), "epw_path": str(epw), "epw_source": source}
+        warnings.extend(parse_warnings)
+
+        shallow_set, shallow_delta = nearest_depth_set(sets, SHALLOW_TARGET_DEPTH_M)
+        fcfactor_set, fcfactor_delta = nearest_depth_set(sets, FCFACTOR_TARGET_DEPTH_M)
+        deep_set, deep_delta = nearest_depth_set(sets, DEEP_TARGET_DEPTH_M)
+        for target, chosen, delta in (
+            (SHALLOW_TARGET_DEPTH_M, shallow_set, shallow_delta),
+            (DEEP_TARGET_DEPTH_M, deep_set, deep_delta),
+        ):
+            if delta > DEPTH_MISMATCH_WARN_M:
+                warnings.append(
+                    f"Nearest available depth to {target} m is {chosen.depth_m} m "
+                    f"({delta:.1f} m away); its seasonal swing will not match the depth asked for.",
+                )
+
+        before = read_ground_temperature_state(model)
+        surface_values, surface_detail = _building_surface_values(
+            model, building_surface_method, building_surface_constant_c, shallow_set,
+        )
+        if building_surface_method == "epw_raw":
+            warnings.append(
+                "building_surface_method='epw_raw' writes UNDISTURBED soil temperatures to "
+                "Site:GroundTemperature:BuildingSurface. The EPW's own .stat says these "
+                '"should NOT BE USED in the GroundTemperatures object to compute building '
+                'floor losses" — expect overstated slab heat loss.',
+            )
+
+        planned: list[tuple[str, Any, list[float] | None, dict[str, Any]]] = [
+            ("building_surface", model.getSiteGroundTemperatureBuildingSurface,
+             surface_values, surface_detail),
+            ("fcfactor_method", model.getSiteGroundTemperatureFCfactorMethod,
+             list(fcfactor_set.monthly_c),
+             {"source": "epw_raw", "depth_m": fcfactor_set.depth_m,
+              "depth_delta_m": round(fcfactor_delta, 3),
+              "note": "affects F/C-factor constructions only"}),
+            ("shallow", model.getSiteGroundTemperatureShallow,
+             list(shallow_set.monthly_c),
+             {"source": "epw_raw", "depth_m": shallow_set.depth_m,
+              "depth_delta_m": round(shallow_delta, 3),
+              "note": "feeds ground heat exchangers, not the floor heat balance"}),
+            ("deep", model.getSiteGroundTemperatureDeep,
+             list(deep_set.monthly_c),
+             {"source": "epw_raw", "depth_m": deep_set.depth_m,
+              "depth_delta_m": round(deep_delta, 3),
+              "note": "feeds ground heat exchangers, not the floor heat balance"}),
+        ]
+
+        applied: dict[str, Any] = {}
+        skipped: dict[str, Any] = {}
+        for key, getter, values, detail in planned:
+            label = _IDF_NAMES[key]
+            if values is None:
+                skipped[label] = detail.get("reason", "not requested")
+                continue
+            if before[key]["state"] in ("set", "partial") and not overwrite:
+                skipped[label] = (
+                    f"already {before[key]['state']} — pass overwrite=True to replace it"
+                )
+                continue
+            error = _write_monthly(getter(), values, label)
+            if error is not None:
+                return {"ok": False, "error": error, "epw_path": str(epw)}
+            entry = {"monthly_c": [round(v, 3) for v in values], **detail}
+            if before[key]["state"] in ("set", "partial"):
+                entry["replaced_monthly_c"] = before[key]["monthly_c"]
+            applied[label] = entry
+
+        after = read_ground_temperature_state(model)
+        ensure_generation_unchanged(generation)
+        return {
+            "ok": True,
+            "epw_path": str(epw),
+            "epw_source": source,
+            "depth_sets_available": [s.depth_m for s in sets],
+            "building_surface_method": building_surface_method,
+            "applied": applied,
+            "skipped": skipped,
+            "warnings": warnings,
+            "ground_temperatures": after,
+            "note": "Changes the in-memory model; call save_osm_model to persist.",
+        }
+    except Exception as e:
+        return {"ok": False, "error": f"Failed to set ground temperatures: {e}"}

--- a/mcp_server/skills/weather/operations.py
+++ b/mcp_server/skills/weather/operations.py
@@ -292,9 +292,20 @@ def get_weather_info() -> dict[str, Any]:
     try:
         model = get_model()
         ashrae_climate_zone = _model_ashrae_climate_zone(model)
+        # Computed before the no-weather-file return below: ground temperatures are
+        # independent of OS:WeatherFile, and a gbXML import that lost its weather reference is
+        # exactly the model whose ground temperatures someone needs to see.
+        # Local import avoids a cycle — ground_temperatures imports find_epw_by_name from here.
+        from mcp_server.skills.weather.ground_temperatures import read_ground_temperature_state
+        ground_temperatures = read_ground_temperature_state(model)
         wf = model.getOptionalWeatherFile()
         if not wf.is_initialized():
-            return {"ok": True, "weather_file": None, "ashrae_climate_zone": ashrae_climate_zone}
+            return {
+                "ok": True,
+                "weather_file": None,
+                "ashrae_climate_zone": ashrae_climate_zone,
+                "ground_temperatures": ground_temperatures,
+            }
 
         weather = wf.get()
         info: dict[str, Any] = {}
@@ -319,7 +330,12 @@ def get_weather_info() -> dict[str, Any]:
         if url and url.is_initialized():
             info["url"] = str(url.get())
 
-        return {"ok": True, "weather_file": info, "ashrae_climate_zone": ashrae_climate_zone}
+        return {
+            "ok": True,
+            "weather_file": info,
+            "ashrae_climate_zone": ashrae_climate_zone,
+            "ground_temperatures": ground_temperatures,
+        }
 
     except RuntimeError as e:
         return {"ok": False, "error": str(e)}

--- a/mcp_server/skills/weather/tools.py
+++ b/mcp_server/skills/weather/tools.py
@@ -1,6 +1,7 @@
 """MCP tool definitions for weather, design days, simulation control, and run periods."""
 from __future__ import annotations
 
+from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 from mcp_server.skills.weather.operations import (
     add_design_day,
     get_run_period,
@@ -21,6 +22,56 @@ def register(mcp):
         Returns name, path, and whether .ddy/.stat companion files exist.
         """
         return list_weather_files()
+
+    @mcp.tool(tags={"simulation"}, name="set_ground_temperatures")
+    def set_ground_temperatures_tool(
+        epw_path: str | None = None,
+        building_surface_method: str = "setpoint_offset",
+        building_surface_constant_c: float | None = None,
+        overwrite: bool = False,
+    ):
+        """Apply an EPW weather file's ground temperatures to the model's Site:GroundTemperature objects.
+
+        A gbXML-translated model has no ground temperatures, so EnergyPlus uses its own
+        defaults (18 C every month on Ground-boundary surfaces). This reads the EPW header's
+        GROUND TEMPERATURES record and writes Shallow, Deep and FCfactorMethod from the
+        nearest available depths (0.5 m and 4.0 m), reporting the depth actually used.
+
+        BuildingSurface is treated differently on purpose. EPW ground temperatures are
+        UNDISTURBED soil — an open field, no building — and the EPW's own .stat file says
+        they "should NOT BE USED in the GroundTemperatures object to compute building floor
+        losses". Boston's January value is -0.29 C; writing that to BuildingSurface overstates
+        slab heat loss badly. So BuildingSurface gets a value derived from the model's own
+        heating setpoints instead, unless you ask otherwise.
+
+        Be aware which objects actually matter for your model: BuildingSurface drives the
+        floor heat balance; Shallow and Deep feed ground heat exchangers and are inert without
+        one; FCfactorMethod affects only F/C-factor constructions. For real slab-edge heat
+        transfer, use Kiva instead (the Foundation boundary condition).
+
+        Changes the in-memory model — call save_osm_model to persist.
+
+        Args:
+            epw_path: EPW to read. Defaults to the EPW import_gbxml used for this model, then
+                to the model's own weather file.
+            building_surface_method: "setpoint_offset" (default) writes mean heating setpoint
+                minus 2 C, and writes nothing if the model has no thermostats; "epw_raw"
+                writes the undisturbed 0.5 m values and warns; "constant" writes
+                building_surface_constant_c; "none" leaves the object alone.
+            building_surface_constant_c: Required by building_surface_method="constant".
+            overwrite: Replace objects that already carry chosen values. Default False skips
+                them and says so.
+
+        Returns:
+            applied, skipped, warnings, epw_path, epw_source, depth_sets_available,
+            building_surface_method, ground_temperatures
+        """
+        return set_ground_temperatures(
+            epw_path=epw_path,
+            building_surface_method=building_surface_method,
+            building_surface_constant_c=building_surface_constant_c,
+            overwrite=overwrite,
+        )
 
     @mcp.tool(tags={"simulation"}, name="get_weather_info")
     def get_weather_info_tool():

--- a/mcp_server/skills/weather/zone_heating_setpoints.py
+++ b/mcp_server/skills/weather/zone_heating_setpoints.py
@@ -1,0 +1,134 @@
+"""Read a representative heating setpoint off the model's thermostats.
+
+Exists to feed the `setpoint_offset` derivation in ground_temperatures.py: the EPW's
+undisturbed soil temperatures must not go into Site:GroundTemperature:BuildingSurface, and
+the documented substitute is a value a couple of degrees below the indoor temperature. That
+needs a number, and OpenStudio stores setpoints as *schedules*.
+
+Kept free of `import openstudio` on purpose (CLAUDE.md rule 4). Everything here is a plain
+method call on a duck-typed object, so the part most likely to be wrong — which number in a
+setback schedule is "the" setpoint — gets unit coverage with fakes and no container. Same
+trade gbxml_import/zone_checks.py makes; like that module, this one therefore does NOT
+import osm_helpers.is_conditioned_zone (importing it would drag openstudio into the test's
+collection).
+
+**The rule: per zone, the MAXIMUM value the heating schedule ever takes.** A real thermostat
+is a ScheduleRuleset with a setback — probed on OpenStudio 3.11.0, a 21.1 occupied / 15.6
+setback ruleset reads back as defaultDaySchedule().values() == [21.1] and
+scheduleRules()[0].daySchedule().values() == [15.6]. Averaging those gives ~18 C for reasons
+that have nothing to do with ground physics; the occupied setpoint is the one that
+characterises the space above the slab.
+
+Floor-area weighting is deliberately not applied: floor areas are unreliable on exactly the
+broken-enclosure models this feature targets (see zero_volume_zone_count in zone_checks.py).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# A "setpoint" outside this band is a unit error or a placeholder, not a building.
+MIN_PLAUSIBLE_SETPOINT_C = 5.0
+MAX_PLAUSIBLE_SETPOINT_C = 35.0
+
+# Above this spread the unweighted mean stops describing any real space; reported, not fatal.
+WIDE_SPREAD_K = 8.0
+
+
+def _schedule_max_value(schedule) -> tuple[float | None, str]:
+    """The largest value a heating setpoint schedule ever takes.
+
+    Returns (value, reason). `value` is None when the concrete schedule type is not one we
+    can read cheaply, and `reason` then names the shortfall — never a guess.
+    """
+    ruleset = schedule.to_ScheduleRuleset()
+    if ruleset.is_initialized():
+        rs = ruleset.get()
+        values: list[float] = list(rs.defaultDaySchedule().values())
+        for rule in rs.scheduleRules():
+            values.extend(rule.daySchedule().values())
+        if not values:
+            return None, "schedule ruleset carries no values"
+        return max(values), "schedule_ruleset_max"
+
+    constant = schedule.to_ScheduleConstant()
+    if constant.is_initialized():
+        return constant.get().value(), "schedule_constant"
+
+    return None, "unsupported schedule type (not a ScheduleRuleset or ScheduleConstant)"
+
+
+def _zone_heating_setpoint(zone) -> tuple[float | None, str]:
+    """(setpoint, reason) for one thermal zone. None when nothing usable is attached."""
+    thermostat = zone.thermostatSetpointDualSetpoint()
+    if not thermostat.is_initialized():
+        return None, "no dual-setpoint thermostat"
+
+    schedule = thermostat.get().heatingSetpointTemperatureSchedule()
+    if not schedule.is_initialized():
+        return None, "thermostat has no heating setpoint schedule"
+
+    value, reason = _schedule_max_value(schedule.get())
+    if value is None:
+        return None, reason
+    if not MIN_PLAUSIBLE_SETPOINT_C <= value <= MAX_PLAUSIBLE_SETPOINT_C:
+        return None, f"implausible heating setpoint {value} C"
+    return value, reason
+
+
+def zone_heating_setpoints(model) -> dict[str, Any]:
+    """Per-zone design heating setpoints and their unweighted mean.
+
+    `mean_c` is None when no zone yielded a usable setpoint; `skip_reason` then says why in
+    one line, so a caller can report it rather than inventing a temperature.
+    """
+    setpoints: list[tuple[str, float]] = []
+    skipped: list[dict[str, str]] = []
+    zones_with_thermostat = 0
+
+    for zone in model.getThermalZones():
+        name = zone.nameString()
+        if zone.thermostatSetpointDualSetpoint().is_initialized():
+            zones_with_thermostat += 1
+        value, reason = _zone_heating_setpoint(zone)
+        if value is None:
+            skipped.append({"zone": name, "reason": reason})
+            continue
+        setpoints.append((name, value))
+
+    result: dict[str, Any] = {
+        "setpoints_c": setpoints,
+        "zone_count": len(setpoints),
+        "zones_with_thermostat": zones_with_thermostat,
+        "zones_skipped": skipped,
+        "method": "schedule_max_per_zone",
+    }
+
+    if not setpoints:
+        result.update({
+            "mean_c": None,
+            "min_c": None,
+            "max_c": None,
+            "spread_warning": None,
+            "skip_reason": (
+                "no thermostat in the model"
+                if zones_with_thermostat == 0
+                else "no zone has a readable heating setpoint schedule"
+            ),
+        })
+        return result
+
+    values = [v for _, v in setpoints]
+    spread = max(values) - min(values)
+    result.update({
+        "mean_c": sum(values) / len(values),
+        "min_c": min(values),
+        "max_c": max(values),
+        "skip_reason": None,
+        "spread_warning": (
+            f"Heating setpoints span {spread:.1f} K across {len(values)} zones "
+            f"({min(values):.1f}-{max(values):.1f} C); their mean describes no single space."
+            if spread > WIDE_SPREAD_K
+            else None
+        ),
+    })
+    return result

--- a/tests/llm/test_03_eval_cases.py
+++ b/tests/llm/test_03_eval_cases.py
@@ -93,6 +93,9 @@ SKILL_CONTEXT_PREFIX = {
 }
 GBXML_MODEL_TOOLS = {
     "repair_and_validate_gbxml_geometry",
+    "set_ground_temperatures",
+    "get_foundation_options",
+    "set_kiva_foundation",
     "list_spaces",
     "get_model_summary",
     "validate_model",

--- a/tests/test_epw_ground_temperatures.py
+++ b/tests/test_epw_ground_temperatures.py
@@ -16,6 +16,7 @@ import pytest
 
 from mcp_server.skills.weather.epw_ground_temperatures import (
     EPW_HEADER_MAX_BYTES,
+    MAX_DEPTH_SETS,
     EpwGroundTemperatureError,
     find_ground_temperature_line,
     nearest_depth_set,
@@ -238,6 +239,17 @@ def test_declared_count_mismatch_warns_and_uses_the_actual_sets():
 
     assert [s.depth_m for s in sets] == [0.5, 4.0]
     assert any("declares 3" in w and "carries 2" in w for w in warnings), warnings
+
+
+def test_oversized_record_is_rejected_even_when_the_declared_count_is_small():
+    # Regression: the depth-set cap was checked only against the declared count, and a declared
+    # count that disagreed with the payload was merely warned about — so a record declaring 1
+    # set while carrying 25 was parsed in full
+    one_set = ",".join(["0.5", "", "", ""] + ["10"] * 12)
+    line = "GROUND TEMPERATURES,1," + ",".join([one_set] * (MAX_DEPTH_SETS + 1))
+
+    with pytest.raises(EpwGroundTemperatureError, match=f"carries {MAX_DEPTH_SETS + 1} depth sets"):
+        parse_ground_temperature_header(line)
 
 
 def test_duplicate_depth_keeps_the_first_and_warns():

--- a/tests/test_epw_ground_temperatures.py
+++ b/tests/test_epw_ground_temperatures.py
@@ -1,0 +1,382 @@
+"""Unit tests for the EPW GROUND TEMPERATURES header parser.
+
+No openstudio, no Docker, no MCP client — the parser is pure by design (CLAUDE.md rule 4),
+so the format handling that carries all the risk gets covered without a container. Same
+tier as tests/test_gbxml_zone_checks.py.
+
+The three real-EPW cases read tests/assets directly; they are the ground truth for the
+format and would catch a parser that only works on synthetic input.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.skills.weather.epw_ground_temperatures import (
+    EPW_HEADER_MAX_BYTES,
+    EpwGroundTemperatureError,
+    find_ground_temperature_line,
+    nearest_depth_set,
+    parse_ground_temperature_header,
+    read_ground_temperature_sets,
+)
+
+pytestmark = pytest.mark.unit
+
+ASSETS = Path(__file__).parent / "assets"
+BOSTON = ASSETS / "USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+AUSTIN = ASSETS / "USA_TX_Austin-Camp.Mabry.ANGB.722544_TMYx.2009-2023.epw"
+GOLDEN = ASSETS / "USA_CO_Golden-NREL.724666_TMY3.epw"
+
+_TWELVE = "1,2,3,4,5,6,7,8,9,10,11,12"
+
+
+def _line(*sets: str, declared: int | None = None) -> str:
+    """A GROUND TEMPERATURES record from pre-built set chunks."""
+    n = len(sets) if declared is None else declared
+    return f"GROUND TEMPERATURES,{n}," + ",".join(sets)
+
+
+def _set(depth: str = "0.5", soil: str = ",,,,", months: str = _TWELVE) -> str:
+    return f"{depth}{soil}{months}"
+
+
+def _writable_dir() -> Path:
+    """A directory the path allowlist accepts.
+
+    pytest's tmp_path is /tmp, which is_path_allowed rejects (see tests/test_gbxml_deltas.py).
+    The parser itself does not gate paths, but keeping every temp file under the run root
+    means these fixtures stay usable if a gated caller is ever added here.
+    """
+    from mcp_server.config import user_run_root
+
+    d = user_run_root() / "pytest_epw_ground_temps" / uuid4().hex[:10]
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# --------------------------------------------------------------------------- real fixtures
+
+
+def test_parses_boston_fixture_header_exactly():
+    # Validates: the real Boston TMY3 record — three depths, exact endpoint values, and soil
+    # properties absent rather than zero
+    sets, warnings = read_ground_temperature_sets(BOSTON)
+
+    assert [s.depth_m for s in sets] == [0.5, 2.0, 4.0], sets
+    assert sets[0].monthly_c[0] == -0.29
+    assert sets[0].monthly_c[11] == 3.79
+    assert sets[2].monthly_c[0] == 6.88
+    assert sets[2].monthly_c[11] == 9.84
+    assert len(sets[0].monthly_c) == 12
+    assert sets[0].conductivity_w_mk is None
+    assert sets[0].density_kg_m3 is None
+    assert sets[0].specific_heat_j_kgk is None
+    assert warnings == []
+
+
+def test_parses_austin_fixture_header_exactly():
+    # Validates: a second real file, so Boston passing is not a coincidence
+    sets, warnings = read_ground_temperature_sets(AUSTIN)
+
+    assert [s.depth_m for s in sets] == [0.5, 2.0, 4.0], sets
+    assert sets[0].monthly_c[0] == 13.34
+    assert sets[2].monthly_c[0] == 18.56
+    assert sets[2].monthly_c[7] == 25.27
+    assert warnings == []
+
+
+def test_parses_golden_fixture_header_exactly():
+    # Validates: the third bundled EPW, which ships without .stat/.ddy companions
+    sets, warnings = read_ground_temperature_sets(GOLDEN)
+
+    assert [s.depth_m for s in sets] == [0.5, 2.0, 4.0], sets
+    assert sets[0].monthly_c[0] == -0.60
+    assert sets[2].monthly_c[0] == 4.84
+    assert warnings == []
+
+
+def test_leading_dot_depth_parses_as_half_a_metre():
+    # Regression: every bundled EPW writes the shallow depth as `.5`, not `0.5`
+    sets, _ = parse_ground_temperature_header(_line(_set(depth=".5")))
+
+    assert sets[0].depth_m == 0.5
+
+
+# --------------------------------------------------------------------------- soil properties
+
+
+def test_blank_soil_properties_are_none_not_zero():
+    # Regression: 0.0 conductivity is a physically meaningful (and wrong) value; blank must
+    # stay absent so a Kiva caller can tell "not stated" from "zero"
+    sets, _ = parse_ground_temperature_header(_line(_set(soil=",,,,")))
+
+    assert sets[0].conductivity_w_mk is None
+    assert sets[0].density_kg_m3 is None
+    assert sets[0].specific_heat_j_kgk is None
+
+
+def test_populated_soil_properties_are_parsed():
+    # Validates: the Kiva path — no bundled EPW populates these, so this case is synthetic only
+    sets, _ = parse_ground_temperature_header(_line(_set(soil=",1.95,1842,419,")))
+
+    assert sets[0].conductivity_w_mk == 1.95
+    assert sets[0].density_kg_m3 == 1842.0
+    assert sets[0].specific_heat_j_kgk == 419.0
+
+
+def test_non_numeric_soil_property_is_rejected():
+    # Validates: a garbage soil field is an error, not silently dropped to None
+    with pytest.raises(EpwGroundTemperatureError, match="soil conductivity"):
+        parse_ground_temperature_header(_line(_set(soil=",abc,,,")))
+
+
+# --------------------------------------------------------------------------- malformed input
+
+
+def test_record_with_no_depth_set_count_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="no depth-set count"):
+        parse_ground_temperature_header("GROUND TEMPERATURES,")
+
+
+def test_zero_declared_sets_is_rejected():
+    # Validates: distinct message from "record missing" — the line is present but empty
+    with pytest.raises(EpwGroundTemperatureError, match="declares 0 depth sets"):
+        parse_ground_temperature_header("GROUND TEMPERATURES,0")
+
+
+def test_negative_declared_sets_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="declares -1 depth sets"):
+        parse_ground_temperature_header("GROUND TEMPERATURES,-1")
+
+
+def test_absurd_declared_set_count_is_rejected_before_allocating():
+    # Regression: a crafted header must not drive an allocation loop
+    with pytest.raises(EpwGroundTemperatureError, match="above the 24 this reader accepts"):
+        parse_ground_temperature_header("GROUND TEMPERATURES,1000000000")
+
+
+def test_non_numeric_declared_count_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="not an integer"):
+        parse_ground_temperature_header("GROUND TEMPERATURES,three,.5,,,," + _TWELVE)
+
+
+def test_eleven_monthly_values_is_rejected():
+    # Validates: a truncated set fails the arity check rather than being zero-padded
+    short = "0.5,,,,1,2,3,4,5,6,7,8,9,10,11"
+    with pytest.raises(EpwGroundTemperatureError, match="not a multiple of 16"):
+        parse_ground_temperature_header(_line(short))
+
+
+def test_non_numeric_temperature_is_rejected_naming_the_month():
+    bad = "0.5,,,,1,2,3,NA,5,6,7,8,9,10,11,12"
+    with pytest.raises(EpwGroundTemperatureError, match="month 4 temperature"):
+        parse_ground_temperature_header(_line(bad))
+
+
+def test_blank_temperature_is_rejected():
+    # Validates: a blank temperature is an error even though a blank soil field is not
+    bad = "0.5,,,,1,2,,4,5,6,7,8,9,10,11,12"
+    with pytest.raises(EpwGroundTemperatureError, match="month 3 temperature is blank"):
+        parse_ground_temperature_header(_line(bad))
+
+
+def test_blank_depth_is_rejected():
+    bad = ",,,,1,2,3,4,5,6,7,8,9,10,11,12"
+    with pytest.raises(EpwGroundTemperatureError, match="depth is blank"):
+        parse_ground_temperature_header(_line(bad))
+
+
+def test_implausible_depth_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="implausible depth"):
+        parse_ground_temperature_header(_line(_set(depth="500")))
+
+
+def test_zero_depth_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="implausible depth"):
+        parse_ground_temperature_header(_line(_set(depth="0")))
+
+
+def test_implausible_temperature_is_rejected():
+    bad = "0.5,,,,1,2,900,4,5,6,7,8,9,10,11,12"
+    with pytest.raises(EpwGroundTemperatureError, match=r"implausible temperature 900\.0 C in month 3"):
+        parse_ground_temperature_header(_line(bad))
+
+
+def test_line_that_is_not_a_ground_temperature_record_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="Not a GROUND TEMPERATURES record"):
+        parse_ground_temperature_header("LOCATION,Boston,MA,USA")
+
+
+# --------------------------------------------------------------------------- tolerated quirks
+
+
+def test_trailing_comma_is_tolerated():
+    # Validates: real EPWs end the record with a trailing comma
+    sets, warnings = parse_ground_temperature_header(_line(_set()) + ",")
+
+    assert len(sets) == 1
+    assert warnings == []
+
+
+def test_declared_count_mismatch_warns_and_uses_the_actual_sets():
+    # Validates: a miscounted header is recoverable — use what is there and say so
+    sets, warnings = parse_ground_temperature_header(
+        _line(_set(depth="0.5"), _set(depth="4"), declared=3),
+    )
+
+    assert [s.depth_m for s in sets] == [0.5, 4.0]
+    assert any("declares 3" in w and "carries 2" in w for w in warnings), warnings
+
+
+def test_duplicate_depth_keeps_the_first_and_warns():
+    sets, warnings = parse_ground_temperature_header(
+        _line(_set(depth="0.5"), _set(depth="0.5")),
+    )
+
+    assert [s.depth_m for s in sets] == [0.5]
+    assert any("repeats depth" in w for w in warnings), warnings
+
+
+def test_fahrenheit_like_values_warn_but_still_parse():
+    # Validates: an honest partial defence — the bounds catch corruption, not a unit error,
+    # so a suspicious spread is surfaced rather than rejected
+    warm = "0.5,,,,40,41,42,43,44,45,50,55,52,48,44,41"
+    sets, warnings = parse_ground_temperature_header(_line(warm))
+
+    assert len(sets) == 1
+    assert any("Celsius" in w for w in warnings), warnings
+
+
+# --------------------------------------------------------------------------- line location
+
+
+def test_record_is_found_when_it_is_not_on_line_four():
+    # Regression: the record is line 4 in every bundled EPW, but the scan must not hardcode it
+    header = "\n".join(
+        ["LOCATION,x", "DESIGN CONDITIONS,0", "TYPICAL/EXTREME PERIODS,0", "HOLIDAYS,No",
+         _line(_set())],
+    )
+
+    assert find_ground_temperature_line(header) is not None
+
+
+def test_record_past_the_header_scan_window_is_not_found():
+    # Validates: a record on line 9 is past the EPW header and is not treated as one
+    header = "\n".join(["FILLER"] * 8 + [_line(_set())])
+
+    assert find_ground_temperature_line(header) is None
+
+
+# --------------------------------------------------------------------------- bounded reading
+
+
+def test_reads_only_the_header_of_an_oversized_file():
+    # Validates: the 8760 data rows are never slurped — the file here is far larger than the
+    # bounded read, and the record still parses
+    path = _writable_dir() / "big.epw"
+    header = "\n".join(["LOCATION,x", "DESIGN CONDITIONS,0", "TYPICAL,0", _line(_set())])
+    filler = "\n".join("1,1,1,0,0,fill" for _ in range(200_000))
+    path.write_text(f"{header}\n{filler}\n", encoding="utf-8")
+
+    assert path.stat().st_size > EPW_HEADER_MAX_BYTES
+    sets, _ = read_ground_temperature_sets(path)
+    assert len(sets) == 1
+
+
+def test_single_enormous_line_is_rejected_rather_than_parsed():
+    # Regression: the degenerate input the bounded read exists to survive (cf. the
+    # billion-laughs case in tests/test_gbxml_deltas.py)
+    path = _writable_dir() / "oneline.epw"
+    path.write_text("x" * (EPW_HEADER_MAX_BYTES * 2), encoding="utf-8")
+
+    with pytest.raises(EpwGroundTemperatureError, match="No line break"):
+        read_ground_temperature_sets(path)
+
+
+def test_file_without_a_ground_temperature_record_is_rejected():
+    path = _writable_dir() / "nogt.epw"
+    path.write_text("LOCATION,x\nDESIGN CONDITIONS,0\nDATA PERIODS,1\n", encoding="utf-8")
+
+    with pytest.raises(EpwGroundTemperatureError, match="no GROUND TEMPERATURES record"):
+        read_ground_temperature_sets(path)
+
+
+def test_missing_file_is_rejected_as_unreadable():
+    with pytest.raises(EpwGroundTemperatureError, match="Cannot read EPW header"):
+        read_ground_temperature_sets(_writable_dir() / "absent.epw")
+
+
+def test_directory_is_rejected_as_not_a_regular_file():
+    with pytest.raises(EpwGroundTemperatureError, match="Cannot read EPW header"):
+        read_ground_temperature_sets(_writable_dir())
+
+
+def test_non_utf8_bytes_in_the_header_are_tolerated():
+    # Validates: the repo's own .stat files carry latin-1 degree signs, so this is not
+    # hypothetical for weather sidecars
+    path = _writable_dir() / "latin1.epw"
+    path.write_bytes(b"COMMENTS 1,45\xb0C soil\n" + _line(_set()).encode() + b"\n")
+
+    sets, _ = read_ground_temperature_sets(path)
+    assert len(sets) == 1
+
+
+# --------------------------------------------------------------------------- depth selection
+
+
+def test_nearest_depth_prefers_an_exact_match():
+    # Validates: the 0.5/4.0 split the .stat guidance calls for, on a real file
+    sets, _ = read_ground_temperature_sets(BOSTON)
+
+    shallow, shallow_delta = nearest_depth_set(sets, 0.5)
+    deep, deep_delta = nearest_depth_set(sets, 4.0)
+
+    assert (shallow.depth_m, shallow_delta) == (0.5, 0.0)
+    assert (deep.depth_m, deep_delta) == (4.0, 0.0)
+    assert deep.monthly_c[0] == 6.88
+    assert shallow.monthly_c[0] == -0.29
+
+
+def test_nearest_depth_on_nonstandard_depths():
+    # Regression: 0.5/2/4 is the common case, not a guarantee — selection must not index
+    sets, _ = parse_ground_temperature_header(_line(_set(depth="1"), _set(depth="3")))
+
+    assert nearest_depth_set(sets, 0.5) == (sets[0], 0.5)
+    assert nearest_depth_set(sets, 4.0) == (sets[1], 1.0)
+
+
+def test_nearest_depth_with_a_single_set_serves_every_target():
+    sets, _ = parse_ground_temperature_header(_line(_set(depth="2")))
+
+    assert nearest_depth_set(sets, 0.5) == (sets[0], 1.5)
+    assert nearest_depth_set(sets, 4.0) == (sets[0], 2.0)
+
+
+def test_nearest_depth_tie_breaks_to_the_shallower_set():
+    # Validates: deterministic choice, so two files with the same depths never disagree
+    sets, _ = parse_ground_temperature_header(_line(_set(depth="3"), _set(depth="5")))
+
+    chosen, delta = nearest_depth_set(sets, 4.0)
+    assert (chosen.depth_m, delta) == (3.0, 1.0)
+
+
+def test_depth_order_in_the_file_does_not_change_the_selection():
+    # Regression: guards against a reintroduced sets[0] / sets[2] index lookup
+    forward, _ = parse_ground_temperature_header(
+        _line(_set(depth="0.5"), _set(depth="2"), _set(depth="4")),
+    )
+    reversed_, _ = parse_ground_temperature_header(
+        _line(_set(depth="4"), _set(depth="2"), _set(depth="0.5")),
+    )
+
+    assert nearest_depth_set(forward, 4.0)[0].depth_m == 4.0
+    assert nearest_depth_set(reversed_, 4.0)[0].depth_m == 4.0
+    assert nearest_depth_set(reversed_, 0.5)[0].depth_m == 0.5
+
+
+def test_nearest_depth_on_an_empty_list_is_rejected():
+    with pytest.raises(EpwGroundTemperatureError, match="No ground temperature sets"):
+        nearest_depth_set([], 0.5)

--- a/tests/test_epw_ground_temperatures.py
+++ b/tests/test_epw_ground_temperatures.py
@@ -137,6 +137,7 @@ def test_non_numeric_soil_property_is_rejected():
 
 
 def test_record_with_no_depth_set_count_is_rejected():
+    # Validates: a record cut off right after the keyword is a named error, not an IndexError on the count field
     with pytest.raises(EpwGroundTemperatureError, match="no depth-set count"):
         parse_ground_temperature_header("GROUND TEMPERATURES,")
 
@@ -148,6 +149,7 @@ def test_zero_declared_sets_is_rejected():
 
 
 def test_negative_declared_sets_is_rejected():
+    # Validates: a negative count is rejected up front instead of driving an empty loop that yields zero sets
     with pytest.raises(EpwGroundTemperatureError, match="declares -1 depth sets"):
         parse_ground_temperature_header("GROUND TEMPERATURES,-1")
 
@@ -159,6 +161,7 @@ def test_absurd_declared_set_count_is_rejected_before_allocating():
 
 
 def test_non_numeric_declared_count_is_rejected():
+    # Validates: a non-integer count is reported by name, not as a raw ValueError escaping int()
     with pytest.raises(EpwGroundTemperatureError, match="not an integer"):
         parse_ground_temperature_header("GROUND TEMPERATURES,three,.5,,,," + _TWELVE)
 
@@ -171,6 +174,7 @@ def test_eleven_monthly_values_is_rejected():
 
 
 def test_non_numeric_temperature_is_rejected_naming_the_month():
+    # Validates: a non-numeric monthly value is rejected and the error names the offending month
     bad = "0.5,,,,1,2,3,NA,5,6,7,8,9,10,11,12"
     with pytest.raises(EpwGroundTemperatureError, match="month 4 temperature"):
         parse_ground_temperature_header(_line(bad))
@@ -184,28 +188,33 @@ def test_blank_temperature_is_rejected():
 
 
 def test_blank_depth_is_rejected():
+    # Validates: a blank depth field gets a depth-specific message, not a ValueError from float('')
     bad = ",,,,1,2,3,4,5,6,7,8,9,10,11,12"
     with pytest.raises(EpwGroundTemperatureError, match="depth is blank"):
         parse_ground_temperature_header(_line(bad))
 
 
 def test_implausible_depth_is_rejected():
+    # Validates: a 500 m depth trips the plausibility bound instead of being accepted as a valid set
     with pytest.raises(EpwGroundTemperatureError, match="implausible depth"):
         parse_ground_temperature_header(_line(_set(depth="500")))
 
 
 def test_zero_depth_is_rejected():
+    # Validates: depth 0 is rejected — the lower plausibility bound is exclusive, a zero-depth set is meaningless
     with pytest.raises(EpwGroundTemperatureError, match="implausible depth"):
         parse_ground_temperature_header(_line(_set(depth="0")))
 
 
 def test_implausible_temperature_is_rejected():
+    # Validates: a 900 C value trips the temperature bound and the error names both the value and the month
     bad = "0.5,,,,1,2,900,4,5,6,7,8,9,10,11,12"
     with pytest.raises(EpwGroundTemperatureError, match=r"implausible temperature 900\.0 C in month 3"):
         parse_ground_temperature_header(_line(bad))
 
 
 def test_line_that_is_not_a_ground_temperature_record_is_rejected():
+    # Validates: a LOCATION line is refused outright rather than having its fields parsed as depth sets
     with pytest.raises(EpwGroundTemperatureError, match="Not a GROUND TEMPERATURES record"):
         parse_ground_temperature_header("LOCATION,Boston,MA,USA")
 
@@ -232,6 +241,7 @@ def test_declared_count_mismatch_warns_and_uses_the_actual_sets():
 
 
 def test_duplicate_depth_keeps_the_first_and_warns():
+    # Validates: a repeated depth collapses to the first set and warns, so nearest_depth_set never sees an ambiguous tie
     sets, warnings = parse_ground_temperature_header(
         _line(_set(depth="0.5"), _set(depth="0.5")),
     )
@@ -297,6 +307,7 @@ def test_single_enormous_line_is_rejected_rather_than_parsed():
 
 
 def test_file_without_a_ground_temperature_record_is_rejected():
+    # Validates: an EPW header lacking the record is a named error, not an empty set list handed to the caller
     path = _writable_dir() / "nogt.epw"
     path.write_text("LOCATION,x\nDESIGN CONDITIONS,0\nDATA PERIODS,1\n", encoding="utf-8")
 
@@ -305,11 +316,13 @@ def test_file_without_a_ground_temperature_record_is_rejected():
 
 
 def test_missing_file_is_rejected_as_unreadable():
+    # Validates: a missing path is wrapped in EpwGroundTemperatureError, not a raw FileNotFoundError through MCP
     with pytest.raises(EpwGroundTemperatureError, match="Cannot read EPW header"):
         read_ground_temperature_sets(_writable_dir() / "absent.epw")
 
 
 def test_directory_is_rejected_as_not_a_regular_file():
+    # Validates: a directory path is wrapped in EpwGroundTemperatureError, not a raw IsADirectoryError
     with pytest.raises(EpwGroundTemperatureError, match="Cannot read EPW header"):
         read_ground_temperature_sets(_writable_dir())
 
@@ -349,6 +362,7 @@ def test_nearest_depth_on_nonstandard_depths():
 
 
 def test_nearest_depth_with_a_single_set_serves_every_target():
+    # Validates: a one-set file serves both the shallow and deep targets with correct deltas instead of failing
     sets, _ = parse_ground_temperature_header(_line(_set(depth="2")))
 
     assert nearest_depth_set(sets, 0.5) == (sets[0], 1.5)
@@ -378,5 +392,6 @@ def test_depth_order_in_the_file_does_not_change_the_selection():
 
 
 def test_nearest_depth_on_an_empty_list_is_rejected():
+    # Validates: an empty set list raises a named error rather than min() failing on an empty sequence
     with pytest.raises(EpwGroundTemperatureError, match="No ground temperature sets"):
         nearest_depth_set([], 0.5)

--- a/tests/test_gbxml_import.py
+++ b/tests/test_gbxml_import.py
@@ -207,6 +207,19 @@ def test_repair_and_validate_gbxml_geometry_on_real_import():
                 assert flagged["aim2860"]["has_floor"] is True, flagged
                 assert flagged["aim2860"]["has_roofceiling"] is True, flagged
 
+                # A translated model sets none of the Site:GroundTemperature:* objects, so
+                # EnergyPlus silently falls back to its own defaults. Reported here on the
+                # same terms as ground contact: report-only, and `ok` is already False above
+                # for the geometry reasons — this key must not be what decides that.
+                assert result["ground_temperatures_missing"] is True, result
+                assert result["ground_temperatures_missing_count"] == 4, result
+                assert result["ground_temperatures_state"] == {
+                    "building_surface": "absent",
+                    "fcfactor_method": "absent",
+                    "shallow": "absent",
+                    "deep": "absent",
+                }, result
+
     asyncio.run(_run())
 
 

--- a/tests/test_ground_temperatures.py
+++ b/tests/test_ground_temperatures.py
@@ -1,0 +1,518 @@
+"""Tests for set_ground_temperatures / read_ground_temperature_state — requires OpenStudio (Docker).
+
+Driven in-process, like tests/test_ground_contact.py, because the assertions turn on SDK
+behaviour (which unique objects exist, which months are defaulted) that no MCP response
+exposes directly, and because building the model here makes every asserted value exact.
+
+SDK facts (dev/probes/probe_ground_temperatures.py, OpenStudio 3.11.0):
+  - The plain Model.get<Class>() getter CREATES the unique object; getOptional<Class>() does
+    not. A read path must use the optional form or a "get" tool mutates the session model.
+  - All four classes share setAllMonthlyTemperatures(list_of_12) -> bool,
+    getTemperatureByMonth(1..12), isMonthDefaulted(1..12), resetAllMonths(), even though their
+    per-month named accessors differ (setJanuaryGroundTemperature vs
+    setJanuarySurfaceGroundTemperature vs setJanuaryDeepGroundTemperature).
+  - IDD defaults differ: BuildingSurface 18.0, FCfactorMethod 13.0, Shallow 13.0, Deep 16.0.
+  - Setting one month leaves the rest defaulted, so a "partial" state is reachable.
+
+Boston TMY3 ground temperatures (tests/assets/USA_MA_Boston-Logan...epw line 4), which every
+expected value below traces to:
+    0.5 m  Jan -0.29  Dec  3.79
+    4.0 m  Jan  6.88  Dec  9.84
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+BOSTON_EPW = "/repo/tests/assets/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+AUSTIN_EPW = "/repo/tests/assets/USA_TX_Austin-Camp.Mabry.ANGB.722544_TMYx.2009-2023.epw"
+
+BOSTON_SHALLOW_JAN = -0.29
+BOSTON_SHALLOW_DEC = 3.79
+BOSTON_DEEP_JAN = 6.88
+BOSTON_DEEP_DEC = 9.84
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _allowed_dir() -> Path:
+    """A writable directory the path allowlist accepts — pytest's tmp_path (/tmp) is not."""
+    from mcp_server.config import user_run_root
+
+    d = user_run_root() / "pytest_ground_temps" / uuid4().hex[:10]
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _load_empty_model() -> None:
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    osm_path = _allowed_dir() / "empty.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(osm_path)), True)
+    load_model(osm_path)
+
+
+def _load_model_with_thermostats(setpoints_c=(21.1, 21.1), setback_c: float | None = 15.6) -> None:
+    """A model whose zones carry dual-setpoint thermostats on ScheduleRulesets."""
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    model = openstudio.model.Model()
+    for index, setpoint in enumerate(setpoints_c):
+        zone = openstudio.model.ThermalZone(model)
+        zone.setName(f"Zone {index + 1}")
+        schedule = openstudio.model.ScheduleRuleset(model)
+        schedule.defaultDaySchedule().addValue(openstudio.Time(0, 24, 0, 0), setpoint)
+        if setback_c is not None:
+            setback_day = openstudio.model.ScheduleDay(model)
+            setback_day.addValue(openstudio.Time(0, 24, 0, 0), setback_c)
+            openstudio.model.ScheduleRule(schedule, setback_day).setApplySaturday(True)
+        thermostat = openstudio.model.ThermostatSetpointDualSetpoint(model)
+        thermostat.setHeatingSetpointTemperatureSchedule(schedule)
+        zone.setThermostatSetpointDualSetpoint(thermostat)
+
+    osm_path = _allowed_dir() / "thermostats.osm"
+    model.save(openstudio.toPath(str(osm_path)), True)
+    load_model(osm_path)
+
+
+def _months(key: str) -> list[float]:
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.weather.ground_temperatures import read_ground_temperature_state
+
+    return read_ground_temperature_state(get_model())[key]["monthly_c"]
+
+
+# --------------------------------------------------------------------------- applying values
+
+
+def test_applies_boston_epw_values_at_the_right_depths():
+    # Validates: the 0.5 m / 4.0 m split the EPW's own .stat calls for. Deep must carry the
+    # 4 m values, not the 0.5 m ones — getting the depths backwards is the easiest mistake
+    # here and produces a plausible-looking but wrong model.
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="none")
+
+    assert result["ok"] is True, result
+    assert result["depth_sets_available"] == [0.5, 2.0, 4.0]
+    assert result["epw_source"] == "argument"
+
+    shallow = _months("shallow")
+    deep = _months("deep")
+    fcfactor = _months("fcfactor_method")
+
+    assert shallow[0] == BOSTON_SHALLOW_JAN
+    assert shallow[11] == BOSTON_SHALLOW_DEC
+    assert deep[0] == BOSTON_DEEP_JAN
+    assert deep[11] == BOSTON_DEEP_DEC
+    assert fcfactor[0] == BOSTON_SHALLOW_JAN
+    assert deep[0] != shallow[0]
+
+    applied = result["applied"]
+    assert applied["Site:GroundTemperature:Shallow"]["depth_m"] == 0.5
+    assert applied["Site:GroundTemperature:Deep"]["depth_m"] == 4.0
+    assert applied["Site:GroundTemperature:Deep"]["depth_delta_m"] == 0.0
+
+
+def test_austin_values_differ_from_boston():
+    # Validates: the tool reads the EPW it was given, not a cached or hardcoded table
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    assert set_ground_temperatures(epw_path=AUSTIN_EPW, building_surface_method="none")["ok"]
+
+    assert _months("shallow")[0] == 13.34
+    assert _months("deep")[0] == 18.56
+
+
+def test_building_surface_uses_the_occupied_setpoint_minus_two():
+    # Validates: setpoint_offset takes the occupied 21.1, not the 15.6 setback and not their
+    # mean — so BuildingSurface lands at 19.1 for all 12 months
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_model_with_thermostats(setpoints_c=(21.1, 21.1), setback_c=15.6)
+    result = set_ground_temperatures(epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    detail = result["applied"]["Site:GroundTemperature:BuildingSurface"]
+    assert detail["source"] == "setpoint_offset"
+    assert detail["mean_heating_setpoint_c"] == 21.1
+    assert detail["offset_c"] == 2.0
+    assert _months("building_surface") == [19.1] * 12
+    # And it is emphatically not the undisturbed soil profile.
+    assert _months("building_surface")[0] != BOSTON_SHALLOW_JAN
+
+
+def test_building_surface_skipped_when_the_model_has_no_thermostats():
+    # Regression: a gbXML import may arrive without thermostats. The other three objects must
+    # still be written and ok must stay True — a skipped BuildingSurface is a reported
+    # outcome, not a failure.
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    reason = result["skipped"]["Site:GroundTemperature:BuildingSurface"]
+    assert "no thermostat in the model" in reason
+    assert "building_surface_constant_c" in reason
+    assert _months("building_surface") is None
+    assert _months("deep")[0] == BOSTON_DEEP_JAN
+
+
+def test_epw_raw_applies_undisturbed_values_and_warns_loudly():
+    # Validates: the escape hatch works, and never silently — the .stat's own wording travels
+    # with the result
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="epw_raw")
+
+    assert result["ok"] is True, result
+    assert _months("building_surface")[0] == BOSTON_SHALLOW_JAN
+    assert any("should NOT BE USED" in w for w in result["warnings"]), result["warnings"]
+
+
+def test_constant_method_writes_the_given_value():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(
+        epw_path=BOSTON_EPW, building_surface_method="constant", building_surface_constant_c=18.5,
+    )
+
+    assert result["ok"] is True, result
+    assert _months("building_surface") == [18.5] * 12
+
+
+def test_none_method_leaves_building_surface_absent():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="none")
+
+    assert result["ok"] is True, result
+    assert _months("building_surface") is None
+    assert result["skipped"]["Site:GroundTemperature:BuildingSurface"] == (
+        "building_surface_method='none'"
+    )
+
+
+# --------------------------------------------------------------------------- argument errors
+
+
+def test_constant_method_without_a_value_is_rejected():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="constant")
+
+    assert result["ok"] is False
+    assert "requires building_surface_constant_c" in result["error"]
+
+
+def test_implausible_constant_is_rejected():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(
+        epw_path=BOSTON_EPW, building_surface_method="constant", building_surface_constant_c=500.0,
+    )
+
+    assert result["ok"] is False
+    assert "outside" in result["error"]
+
+
+def test_unknown_building_surface_method_is_rejected_listing_the_valid_ones():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="kiva")
+
+    assert result["ok"] is False
+    assert "setpoint_offset" in result["error"]
+    assert "epw_raw" in result["error"]
+
+
+def test_no_model_loaded_reports_instead_of_raising():
+    # Validates: the operations contract — never raise through MCP (CLAUDE.md rule 5)
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    result = set_ground_temperatures(epw_path=BOSTON_EPW)
+
+    assert result["ok"] is False
+    assert "error" in result
+
+
+def test_missing_epw_is_rejected():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path="/repo/tests/assets/does_not_exist.epw")
+
+    assert result["ok"] is False
+    assert "not found" in result["error"]
+
+
+def test_non_epw_suffix_is_rejected():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(
+        epw_path="/repo/tests/assets/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.stat",
+    )
+
+    assert result["ok"] is False
+    assert "Not an EPW file" in result["error"]
+
+
+def test_epw_without_a_ground_temperature_record_reports_and_writes_nothing():
+    # Validates: a parse failure leaves the model untouched rather than half-written
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    bad = _allowed_dir() / "headerless.epw"
+    bad.write_text("LOCATION,x,,,,,,,0,0,0,0\nDESIGN CONDITIONS,0\n", encoding="utf-8")
+
+    result = set_ground_temperatures(epw_path=str(bad))
+
+    assert result["ok"] is False
+    assert "GROUND TEMPERATURES" in result["error"]
+    assert _months("deep") is None
+
+
+def test_no_epw_anywhere_names_every_route_it_tried():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures()
+
+    assert result["ok"] is False
+    assert "epw_path" in result["error"]
+    assert "import_gbxml" in result["error"]
+    assert "change_building_location" in result["error"]
+
+
+# --------------------------------------------------------------------------- read-back
+
+
+def test_reading_state_does_not_create_the_unique_objects():
+    # Regression: the plain Model.get<Class>() getter creates the object as a side effect
+    # (probed on 3.11.0). If read_ground_temperature_state used it, the first call would make
+    # every model look like it already had ground temperatures — and a later save would
+    # persist four all-defaulted objects nobody asked for.
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.weather.ground_temperatures import read_ground_temperature_state
+
+    _load_empty_model()
+    model = get_model()
+    idd = openstudio.model.SiteGroundTemperatureDeep.iddObjectType()
+    assert len(model.getObjectsByType(idd)) == 0
+
+    for _ in range(3):
+        state = read_ground_temperature_state(model)
+        assert state["deep"]["state"] == "absent"
+
+    assert len(model.getObjectsByType(idd)) == 0
+
+
+def test_get_weather_info_reports_ground_temperatures_without_a_weather_file():
+    # Regression: get_weather_info early-returns when OS:WeatherFile is absent, which is
+    # exactly the gbXML-import case. The ground block must survive that return.
+    from mcp_server.skills.weather.operations import get_weather_info
+
+    _load_empty_model()
+    info = get_weather_info()
+
+    assert info["ok"] is True, info
+    assert info["weather_file"] is None
+    assert info["ground_temperatures"]["deep"]["state"] == "absent"
+
+
+def test_get_weather_info_reflects_applied_values():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+    from mcp_server.skills.weather.operations import get_weather_info
+
+    _load_empty_model()
+    assert set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="none")["ok"]
+
+    deep = get_weather_info()["ground_temperatures"]["deep"]
+    assert deep["state"] == "set"
+    assert deep["months_set"] == 12
+    assert deep["monthly_c"][0] == BOSTON_DEEP_JAN
+
+
+def test_a_defaulted_object_is_reported_as_missing_not_set():
+    # Regression: an all-defaulted object is written to the OSM and survives reload, so
+    # presence is not evidence anyone chose a value. A typical OSM ships BuildingSurface and
+    # Deep already present at their defaults.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.weather.ground_temperatures import (
+        find_missing_ground_temperatures,
+        read_ground_temperature_state,
+    )
+
+    _load_empty_model()
+    model = get_model()
+    created = model.getSiteGroundTemperatureDeep()   # create, choose nothing
+    assert created.getTemperatureByMonth(1) == 16.0
+
+    assert read_ground_temperature_state(model)["deep"]["state"] == "defaulted"
+    report = find_missing_ground_temperatures()
+    assert report["ground_temperatures_missing"] is True
+    assert "Site:GroundTemperature:Deep" in report["ground_temperatures_missing_objects"]
+
+
+def test_a_partially_written_object_is_reported_as_partial():
+    # Validates: setting one month leaves the other 11 defaulted; that half-written state is
+    # worse than either extreme and must be visible rather than rounded to "set"
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.weather.ground_temperatures import read_ground_temperature_state
+
+    _load_empty_model()
+    model = get_model()
+    model.getSiteGroundTemperatureDeep().setTemperatureByMonth(1, 5.0)
+
+    state = read_ground_temperature_state(model)["deep"]
+    assert state["state"] == "partial"
+    assert state["months_set"] == 1
+
+
+# --------------------------------------------------------------------------- overwrite guard
+
+
+def test_existing_values_are_not_replaced_without_overwrite():
+    # Validates: idempotence, and that a hand-tuned set is not silently stomped
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    assert set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="none")["ok"]
+
+    second = set_ground_temperatures(epw_path=AUSTIN_EPW, building_surface_method="none")
+
+    assert second["ok"] is True, second
+    assert "overwrite=True" in second["skipped"]["Site:GroundTemperature:Deep"]
+    assert _months("deep")[0] == BOSTON_DEEP_JAN
+
+
+def test_overwrite_replaces_and_reports_the_previous_values():
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    assert set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="none")["ok"]
+
+    second = set_ground_temperatures(
+        epw_path=AUSTIN_EPW, building_surface_method="none", overwrite=True,
+    )
+
+    assert second["ok"] is True, second
+    entry = second["applied"]["Site:GroundTemperature:Deep"]
+    assert entry["replaced_monthly_c"][0] == BOSTON_DEEP_JAN
+    assert _months("deep")[0] == 18.56
+
+
+# --------------------------------------------------------------------------- report contract
+
+
+def test_report_flags_a_fresh_model_and_clears_after_applying():
+    from mcp_server.skills.weather.ground_temperatures import (
+        find_missing_ground_temperatures,
+        set_ground_temperatures,
+    )
+
+    _load_model_with_thermostats()
+    before = find_missing_ground_temperatures()
+    assert before["ok"] is True, before
+    assert before["ground_temperatures_missing"] is True
+    assert before["ground_temperatures_missing_count"] == 4
+    assert before["ground_temperatures_state"]["deep"] == "absent"
+
+    assert set_ground_temperatures(epw_path=BOSTON_EPW)["ok"]
+
+    after = find_missing_ground_temperatures()
+    assert after["ground_temperatures_missing"] is False
+    assert after["ground_temperatures_missing_count"] == 0
+
+
+def test_report_with_no_model_loaded_reports_instead_of_raising():
+    from mcp_server.skills.weather.ground_temperatures import find_missing_ground_temperatures
+
+    result = find_missing_ground_temperatures()
+
+    assert result["ok"] is False
+    assert "error" in result
+
+
+# --------------------------------------------------------------------------- depth handling
+
+
+def test_single_depth_epw_serves_deep_from_the_nearest_set_and_warns():
+    # Validates: nearest-available depth selection, and that a 3.5 m substitution is not
+    # allowed to pass silently
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    one_set = _allowed_dir() / "one_depth.epw"
+    months = ",".join(str(v) for v in [-0.29, -1.36, 0.53, 3.49, 11.23, 17.2,
+                                       21.23, 22.45, 20.36, 15.73, 9.53, 3.79])
+    one_set.write_text(
+        "LOCATION,x,,,,,,,0,0,0,0\n"
+        "DESIGN CONDITIONS,0\n"
+        "TYPICAL/EXTREME PERIODS,0\n"
+        f"GROUND TEMPERATURES,1,0.5,,,,{months}\n",
+        encoding="utf-8",
+    )
+
+    result = set_ground_temperatures(epw_path=str(one_set), building_surface_method="none")
+
+    assert result["ok"] is True, result
+    assert result["depth_sets_available"] == [0.5]
+    assert result["applied"]["Site:GroundTemperature:Deep"]["depth_delta_m"] == 3.5
+    assert _months("deep")[0] == BOSTON_SHALLOW_JAN
+    assert any("3.5 m away" in w for w in result["warnings"]), result["warnings"]
+
+
+def test_save_and_reload_preserves_the_applied_values():
+    # Validates: the write actually reaches the file, not just the in-memory model
+    import openstudio
+
+    from mcp_server.model_manager import get_model, load_model
+    from mcp_server.skills.weather.ground_temperatures import (
+        read_ground_temperature_state,
+        set_ground_temperatures,
+    )
+
+    _load_empty_model()
+    assert set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="none")["ok"]
+
+    osm_path = _allowed_dir() / "saved.osm"
+    assert get_model().save(openstudio.toPath(str(osm_path)), True)
+    load_model(osm_path)
+
+    deep = read_ground_temperature_state(get_model())["deep"]
+    assert deep["state"] == "set"
+    assert deep["monthly_c"][0] == BOSTON_DEEP_JAN

--- a/tests/test_ground_temperatures.py
+++ b/tests/test_ground_temperatures.py
@@ -196,6 +196,8 @@ def test_epw_raw_applies_undisturbed_values_and_warns_loudly():
 
 
 def test_constant_method_writes_the_given_value():
+    # Validates: building_surface_method="constant" writes the caller's value to all 12 months
+    # of BuildingSurface, ignoring both the EPW profile and any thermostat-derived setpoint
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -208,6 +210,8 @@ def test_constant_method_writes_the_given_value():
 
 
 def test_none_method_leaves_building_surface_absent():
+    # Validates: building_surface_method="none" never creates the BuildingSurface object (so a
+    # Kiva/other-source user gets no stray unique object) and the skip is reported by name
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -224,6 +228,8 @@ def test_none_method_leaves_building_surface_absent():
 
 
 def test_constant_method_without_a_value_is_rejected():
+    # Validates: "constant" with no building_surface_constant_c is an argument error naming the
+    # missing parameter, not a silent fall-through to the IDD default of 18.0
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -234,6 +240,8 @@ def test_constant_method_without_a_value_is_rejected():
 
 
 def test_implausible_constant_is_rejected():
+    # Validates: the plausibility range guard on building_surface_constant_c — a 500 C value
+    # (unit mix-up) is refused before any object is written, and the error says it was out of range
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -246,6 +254,8 @@ def test_implausible_constant_is_rejected():
 
 
 def test_unknown_building_surface_method_is_rejected_listing_the_valid_ones():
+    # Validates: an unrecognised building_surface_method is rejected with the accepted choices
+    # in the error text, so an LLM caller can self-correct without reading the docstring
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -267,6 +277,8 @@ def test_no_model_loaded_reports_instead_of_raising():
 
 
 def test_missing_epw_is_rejected():
+    # Validates: a nonexistent epw_path yields ok=False with a "not found" message rather than
+    # an unhandled OSError escaping through MCP
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -276,7 +288,23 @@ def test_missing_epw_is_rejected():
     assert "not found" in result["error"]
 
 
+def test_disallowed_epw_path_is_refused_before_existence_is_checked():
+    # Validates: the allowlist check runs before is_file(), so a caller outside the allowed roots
+    # cannot tell from the error whether a file exists there — "not found" vs "not allowed" would
+    # be an existence probe on another tenant's tree
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _load_empty_model()
+    result = set_ground_temperatures(epw_path="/etc/does_not_exist.epw")
+
+    assert result["ok"] is False
+    assert "not allowed" in result["error"]
+    assert "not found" not in result["error"]
+
+
 def test_non_epw_suffix_is_rejected():
+    # Validates: the .epw suffix check — handing the sibling .stat file (an easy mistake, it
+    # also holds ground temperatures) is refused instead of being parsed as EPW header lines
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -304,6 +332,8 @@ def test_epw_without_a_ground_temperature_record_reports_and_writes_nothing():
 
 
 def test_no_epw_anywhere_names_every_route_it_tried():
+    # Validates: with no epw_path argument, no gbXML-import EPW and no OS:WeatherFile, the error
+    # lists all three routes (epw_path / import_gbxml / change_building_location) the caller can take
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -354,6 +384,8 @@ def test_get_weather_info_reports_ground_temperatures_without_a_weather_file():
 
 
 def test_get_weather_info_reflects_applied_values():
+    # Validates: get_weather_info's ground_temperatures block reads the live model — after
+    # set_ground_temperatures, Deep reports state="set", months_set=12 and the Boston Jan value
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
     from mcp_server.skills.weather.operations import get_weather_info
 
@@ -420,6 +452,8 @@ def test_existing_values_are_not_replaced_without_overwrite():
 
 
 def test_overwrite_replaces_and_reports_the_previous_values():
+    # Validates: overwrite=True actually replaces the 12 months (Boston -> Austin) and echoes the
+    # displaced values in replaced_monthly_c so the caller can see what was lost
     from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
 
     _load_empty_model()
@@ -439,6 +473,8 @@ def test_overwrite_replaces_and_reports_the_previous_values():
 
 
 def test_report_flags_a_fresh_model_and_clears_after_applying():
+    # Validates: find_missing_ground_temperatures' contract — a fresh model reports all 4 objects
+    # missing (count=4, state "absent"), and one set_ground_temperatures call drives it to 0/False
     from mcp_server.skills.weather.ground_temperatures import (
         find_missing_ground_temperatures,
         set_ground_temperatures,
@@ -459,6 +495,8 @@ def test_report_flags_a_fresh_model_and_clears_after_applying():
 
 
 def test_report_with_no_model_loaded_reports_instead_of_raising():
+    # Validates: the no-model guard on find_missing_ground_temperatures returns ok=False with an
+    # error instead of raising through MCP (CLAUDE.md rule 5)
     from mcp_server.skills.weather.ground_temperatures import find_missing_ground_temperatures
 
     result = find_missing_ground_temperatures()

--- a/tests/test_ground_temperatures.py
+++ b/tests/test_ground_temperatures.py
@@ -331,6 +331,30 @@ def test_epw_without_a_ground_temperature_record_reports_and_writes_nothing():
     assert _months("deep") is None
 
 
+def test_no_argument_call_uses_the_epw_stashed_by_import_gbxml():
+    # Validates: the documented workflow — import_gbxml then set_ground_temperatures() with no
+    # arguments — reads the staged EPW that import stashed for this model generation, reports
+    # that route, and applies that file's values
+    from uuid import uuid4
+
+    from mcp_server.skills.gbxml_import.operations import import_gbxml_op
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    imported = import_gbxml_op("/repo/tests/assets/2026_11Ja_path1.xml", BOSTON_EPW,
+                               run_name=f"pytest_gt_stash_{uuid4().hex[:8]}")
+    assert imported["ok"] is True, imported
+
+    result = set_ground_temperatures()
+
+    assert result["ok"] is True, result
+    assert result["epw_source"] == "gbxml_import_stash"
+    assert result["epw_path"] != BOSTON_EPW
+    assert result["epw_path"].endswith(".epw")
+    assert "/weather/" in result["epw_path"]
+    assert _months("deep")[0] == BOSTON_DEEP_JAN
+    assert _months("shallow")[11] == BOSTON_SHALLOW_DEC
+
+
 def test_no_epw_anywhere_names_every_route_it_tried():
     # Validates: with no epw_path argument, no gbXML-import EPW and no OS:WeatherFile, the error
     # lists all three routes (epw_path / import_gbxml / change_building_location) the caller can take

--- a/tests/test_kiva_archetypes.py
+++ b/tests/test_kiva_archetypes.py
@@ -30,6 +30,7 @@ from mcp_server.skills.geometry.kiva_archetypes import (
     PROVENANCE_EXISTING,
     PROVENANCE_USER,
     XPS_CONDUCTIVITY_W_MK,
+    IncompleteInsulationError,
     UnknownArchetypeError,
     archetype_menu,
     get_archetype,
@@ -328,6 +329,46 @@ def test_existing_model_soil_value_is_reported_and_not_overwritten():
     assert resolved["soil_density_kg_m3"].provenance == PROVENANCE_USER
     # Still defaulted on the model, blank in the EPW: IDD default, not written.
     assert resolved["soil_specific_heat_j_kgk"].provenance == PROVENANCE_DEFAULT
+
+
+@pytest.mark.parametrize(("overrides", "argument"), [
+    ({"interior_horizontal_r_si": 2.0}, "interior_horizontal_insulation_width_m"),
+    ({"exterior_vertical_r_si": 2.0}, "exterior_vertical_insulation_depth_m"),
+])
+def test_r_value_at_a_position_the_archetype_lacks_needs_its_extent(overrides, argument):
+    # Regression: an R-value override for a position the archetype does not insulate produced a
+    # layer with a material and no width/depth; OpenStudio wrote it and EnergyPlus terminated
+    # fatally ("material defined, but no ... width/depth provided") after the tool said ok
+    with pytest.raises(IncompleteInsulationError) as excinfo:
+        resolve_insulation("slab_on_grade_uninsulated", overrides)
+
+    assert excinfo.value.argument == argument
+    assert argument in str(excinfo.value)
+
+
+def test_r_value_with_its_extent_adds_the_layer():
+    # Validates: the same override is valid once the extent comes with it, and both carry user
+    # provenance
+    specs, warnings = resolve_insulation(
+        "slab_on_grade_uninsulated",
+        {"interior_horizontal_r_si": 2.0, "interior_horizontal_width_m": 0.9},
+    )
+
+    assert warnings == []
+    assert [s.position for s in specs] == [POSITION_INTERIOR_HORIZONTAL]
+    assert specs[0].width_m == 0.9
+    assert specs[0].provenance["width_m"] == PROVENANCE_USER
+
+
+def test_r_value_override_on_an_insulated_archetype_keeps_the_inherited_extent():
+    # Validates: overriding only the R-value where the archetype already supplies the extent is
+    # complete — the inherited depth satisfies the requirement
+    specs, _ = resolve_insulation(
+        "slab_on_grade_perimeter_insulated", {"exterior_vertical_r_si": 3.52},
+    )
+
+    assert specs[0].r_si_m2k_w == 3.52
+    assert specs[0].depth_m == 0.6
 
 
 def test_insulation_layers_carry_per_field_provenance():

--- a/tests/test_kiva_archetypes.py
+++ b/tests/test_kiva_archetypes.py
@@ -27,6 +27,7 @@ from mcp_server.skills.geometry.kiva_archetypes import (
     PROVENANCE_DEFAULT,
     PROVENANCE_DEFAULT_AGREES,
     PROVENANCE_EPW,
+    PROVENANCE_EXISTING,
     PROVENANCE_USER,
     XPS_CONDUCTIVITY_W_MK,
     UnknownArchetypeError,
@@ -307,6 +308,42 @@ def test_user_soil_override_beats_the_epw():
 
     assert resolved["soil_conductivity_w_mk"].value == 2.2
     assert resolved["soil_conductivity_w_mk"].provenance == PROVENANCE_USER
+
+
+def test_existing_model_soil_value_is_reported_and_not_overwritten():
+    # Regression: a FoundationKivaSettings object already carrying custom soil values was reported
+    # as `openstudio_default` with written=False, so the plan misstated what the simulation uses
+    resolved, _ = resolve_soil_properties(
+        _FakeGroundTemperatureSet(conductivity_w_mk=1.95),
+        {"soil_density_kg_m3": 1900.0},
+        existing={"soil_conductivity_w_mk": 2.4, "soil_density_kg_m3": 1700.0,
+                  "soil_specific_heat_j_kgk": None},
+    )
+
+    assert resolved["soil_conductivity_w_mk"].value == 2.4
+    assert resolved["soil_conductivity_w_mk"].provenance == PROVENANCE_EXISTING
+    assert resolved["soil_conductivity_w_mk"].write is False
+    # A caller value still beats the model's own.
+    assert resolved["soil_density_kg_m3"].value == 1900.0
+    assert resolved["soil_density_kg_m3"].provenance == PROVENANCE_USER
+    # Still defaulted on the model, blank in the EPW: IDD default, not written.
+    assert resolved["soil_specific_heat_j_kgk"].provenance == PROVENANCE_DEFAULT
+
+
+def test_insulation_layers_carry_per_field_provenance():
+    # Regression: resolve_insulation dropped whether each value came from the user or the
+    # archetype, so dry_run could not show provenance for the insulation at all
+    specs, _ = resolve_insulation(
+        "slab_on_grade_perimeter_insulated", {"exterior_vertical_depth_m": 1.2},
+    )
+
+    assert len(specs) == 1
+    layer = specs[0].as_plan()
+    assert layer["r_si_m2k_w"] == {"value": CONVENTIONAL_R_SI,
+                                   "provenance": "archetype:slab_on_grade_perimeter_insulated"}
+    assert layer["depth_m"] == {"value": 1.2, "provenance": PROVENANCE_USER}
+    assert layer["width_m"] == {"value": None,
+                                "provenance": "archetype:slab_on_grade_perimeter_insulated"}
 
 
 def test_soil_with_no_epw_at_all_defaults_quietly():

--- a/tests/test_kiva_archetypes.py
+++ b/tests/test_kiva_archetypes.py
@@ -1,0 +1,331 @@
+"""Unit tests for mcp_server.skills.geometry.kiva_archetypes.
+
+Pure Python — no openstudio, no Docker. The archetype table and the provenance merge carry all the
+judgment in the Kiva feature, so they get covered without a container. Same tier as
+tests/test_epw_ground_temperatures.py and tests/test_gbxml_zone_checks.py.
+
+The soil-property tests duck-type GroundTemperatureSet rather than importing it, matching how
+kiva_archetypes itself avoids the dependency.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from mcp_server.skills.geometry.kiva_archetypes import (
+    ARCHETYPES,
+    CONVENTIONAL_R_SI,
+    IDD_FOOTING_DEPTH_M,
+    IDD_SOIL_CONDUCTIVITY_W_MK,
+    IDD_SOIL_DENSITY_KG_M3,
+    IDD_SOIL_SPECIFIC_HEAT_J_KGK,
+    IDD_WALL_HEIGHT_ABOVE_GRADE_M,
+    MATCH_WALL_DEPTH,
+    POSITION_EXTERIOR_VERTICAL,
+    POSITION_INTERIOR_HORIZONTAL,
+    PROVENANCE_DEFAULT,
+    PROVENANCE_DEFAULT_AGREES,
+    PROVENANCE_EPW,
+    PROVENANCE_USER,
+    XPS_CONDUCTIVITY_W_MK,
+    UnknownArchetypeError,
+    archetype_menu,
+    get_archetype,
+    resolve_insulation,
+    resolve_kiva_parameters,
+    resolve_soil_properties,
+    xps_thickness_m,
+)
+
+pytestmark = pytest.mark.unit
+
+ALL_NAMES = [
+    "slab_on_grade_uninsulated",
+    "slab_on_grade_perimeter_insulated",
+    "heated_basement_insulated",
+    "unheated_basement",
+    "crawlspace_vented",
+]
+
+
+@dataclass(frozen=True)
+class _FakeGroundTemperatureSet:
+    """Duck-types epw_ground_temperatures.GroundTemperatureSet's soil fields."""
+
+    conductivity_w_mk: float | None = None
+    density_kg_m3: float | None = None
+    specific_heat_j_kgk: float | None = None
+
+
+# --------------------------------------------------------------------------- the table
+
+
+def test_the_five_archetypes_are_present():
+    # Validates: the menu the interview offers is exactly the five agreed types
+    assert sorted(ARCHETYPES) == sorted(ALL_NAMES)
+
+
+@pytest.mark.parametrize("name", ALL_NAMES)
+def test_every_archetype_is_complete(name):
+    # Validates: no archetype can hand the writer a None it would dereference
+    a = get_archetype(name)
+
+    assert a.name == name
+    assert len(a.label) > 3
+    assert len(a.description) > 20
+    assert len(a.basis) > 20
+    assert isinstance(a.wall_height_above_grade_m, float)
+    assert isinstance(a.wall_depth_below_slab_m, float)
+    assert isinstance(a.footing_depth_m, float)
+
+
+@pytest.mark.parametrize("name", ALL_NAMES)
+def test_every_archetype_states_its_basis(name):
+    # Regression: the numbers below are conventional, not sourced. If a basis string ever goes
+    # missing, a made-up R-value starts reading as authoritative in the tool response.
+    basis = get_archetype(name).basis
+
+    assert "conventional starting point" in basis or "no insulation to source" in basis
+
+
+def test_uninsulated_archetypes_carry_no_insulation():
+    # Validates: "uninsulated" is a deliberate modelling choice, not a gap in the table
+    assert get_archetype("slab_on_grade_uninsulated").insulation == ()
+    assert get_archetype("unheated_basement").insulation == ()
+
+
+def test_insulated_archetypes_carry_the_expected_position():
+    # Validates: slab-edge insulation goes on the outside face; crawlspace insulation lies
+    # horizontally inward. Swapping them silently changes the physics.
+    slab = get_archetype("slab_on_grade_perimeter_insulated").insulation
+    assert [s.position for s in slab] == [POSITION_EXTERIOR_VERTICAL]
+    assert slab[0].depth_m == 0.6
+
+    crawl = get_archetype("crawlspace_vented").insulation
+    assert [s.position for s in crawl] == [POSITION_INTERIOR_HORIZONTAL]
+    assert crawl[0].width_m == 0.6
+
+
+def test_heated_basement_insulation_depth_defers_to_geometry():
+    # Regression: basement depth is NOT a Kiva input — it comes from the below-grade wall
+    # surfaces. The archetype must not invent a depth that contradicts the model.
+    spec = get_archetype("heated_basement_insulated").insulation[0]
+
+    assert spec.depth_m == MATCH_WALL_DEPTH
+
+
+def test_unknown_archetype_lists_the_valid_names():
+    with pytest.raises(UnknownArchetypeError) as excinfo:
+        get_archetype("walkout_basement")
+
+    for name in ALL_NAMES:
+        assert name in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- R to thickness
+
+
+def test_r_si_converts_to_xps_thickness():
+    # Validates: the vendored XPS conductivity is what turns an R-value into a Material thickness
+    assert xps_thickness_m(CONVENTIONAL_R_SI) == pytest.approx(0.05104, abs=1e-5)
+    assert xps_thickness_m(1.0) == pytest.approx(XPS_CONDUCTIVITY_W_MK)
+
+
+def test_non_positive_r_value_is_rejected():
+    with pytest.raises(ValueError, match="must be positive"):
+        xps_thickness_m(0.0)
+
+
+# --------------------------------------------------------------------------- geometry provenance
+
+
+def test_archetype_value_equal_to_the_idd_default_is_not_claimed_as_the_archetypes():
+    # Regression: wall_height_above_grade 0.2 is BOTH the archetype value and the IDD default.
+    # Reporting "archetype:..." for a field nobody writes makes provenance theatre.
+    resolved, warnings = resolve_kiva_parameters("slab_on_grade_uninsulated")
+
+    height = resolved["wall_height_above_grade_m"]
+    assert height.value == IDD_WALL_HEIGHT_ABOVE_GRADE_M
+    assert height.provenance == PROVENANCE_DEFAULT_AGREES
+    assert height.write is False
+    assert warnings == []
+
+
+def test_archetype_value_differing_from_the_default_is_written_and_attributed():
+    # Validates: the crawlspace raises the stem wall above the 0.2 default, so it must be written
+    resolved, _ = resolve_kiva_parameters("crawlspace_vented")
+
+    height = resolved["wall_height_above_grade_m"]
+    assert height.value == 0.6
+    assert height.provenance == "archetype:crawlspace_vented"
+    assert height.write is True
+
+
+def test_user_override_beats_the_archetype():
+    resolved, _ = resolve_kiva_parameters(
+        "crawlspace_vented", {"wall_height_above_grade_m": 0.45},
+    )
+
+    height = resolved["wall_height_above_grade_m"]
+    assert height.value == 0.45
+    assert height.provenance == PROVENANCE_USER
+    assert height.write is True
+
+
+def test_user_override_equal_to_the_default_is_still_written_as_user():
+    # Validates: an explicit request is honoured and attributed, even when it matches the default
+    resolved, _ = resolve_kiva_parameters(
+        "crawlspace_vented", {"footing_depth_m": IDD_FOOTING_DEPTH_M},
+    )
+
+    footing = resolved["footing_depth_m"]
+    assert footing.provenance == PROVENANCE_USER
+    assert footing.write is True
+
+
+def test_overriding_one_field_leaves_the_others_at_their_archetype_provenance():
+    resolved, _ = resolve_kiva_parameters(
+        "crawlspace_vented", {"wall_depth_below_slab_m": 0.9},
+    )
+
+    assert resolved["wall_depth_below_slab_m"].provenance == PROVENANCE_USER
+    assert resolved["wall_height_above_grade_m"].provenance == "archetype:crawlspace_vented"
+
+
+def test_none_overrides_are_ignored_rather_than_written_as_null():
+    # Validates: the tool signature is all-optional kwargs, so None means "not supplied"
+    resolved, _ = resolve_kiva_parameters(
+        "crawlspace_vented", {"wall_height_above_grade_m": None},
+    )
+
+    assert resolved["wall_height_above_grade_m"].provenance == "archetype:crawlspace_vented"
+
+
+def test_unrecognised_geometry_override_warns_rather_than_silently_vanishing():
+    _, warnings = resolve_kiva_parameters(
+        "crawlspace_vented", {"wall_thickness_m": 0.3},
+    )
+
+    assert any("wall_thickness_m" in w for w in warnings), warnings
+
+
+# --------------------------------------------------------------------------- insulation merge
+
+
+def test_insulation_defaults_to_the_archetypes_layers():
+    specs, warnings = resolve_insulation("slab_on_grade_perimeter_insulated")
+
+    assert [s.position for s in specs] == [POSITION_EXTERIOR_VERTICAL]
+    assert specs[0].r_si_m2k_w == CONVENTIONAL_R_SI
+    assert warnings == []
+
+
+def test_r_value_override_replaces_the_archetype_value_and_keeps_the_extent():
+    specs, _ = resolve_insulation(
+        "slab_on_grade_perimeter_insulated", {"exterior_vertical_r_si": 3.52},
+    )
+
+    assert specs[0].r_si_m2k_w == 3.52
+    assert specs[0].depth_m == 0.6
+
+
+def test_adding_a_position_the_archetype_does_not_use():
+    # Validates: a user can insulate under the slab of an otherwise-bare archetype
+    specs, warnings = resolve_insulation(
+        "slab_on_grade_uninsulated",
+        {"interior_horizontal_r_si": 1.76, "interior_horizontal_width_m": 1.2},
+    )
+
+    assert [s.position for s in specs] == [POSITION_INTERIOR_HORIZONTAL]
+    assert specs[0].width_m == 1.2
+    assert warnings == []
+
+
+def test_extent_without_an_r_value_on_an_uninsulated_archetype_warns():
+    # Validates: a width with no insulation to apply it to is a mistake, not a silent no-op
+    specs, warnings = resolve_insulation(
+        "slab_on_grade_uninsulated", {"interior_horizontal_width_m": 1.2},
+    )
+
+    assert specs == []
+    assert any("no R-value given" in w for w in warnings), warnings
+
+
+# --------------------------------------------------------------------------- soil properties
+
+
+def test_soil_falls_back_to_openstudio_defaults_when_the_epw_is_blank():
+    # Regression: every EPW bundled with this repo leaves the soil fields blank, so this is the
+    # normal path — and nothing should be written, or we create a settings object nobody asked for
+    resolved, warnings = resolve_soil_properties(_FakeGroundTemperatureSet())
+
+    assert resolved["soil_conductivity_w_mk"].value == IDD_SOIL_CONDUCTIVITY_W_MK
+    assert resolved["soil_density_kg_m3"].value == IDD_SOIL_DENSITY_KG_M3
+    assert resolved["soil_specific_heat_j_kgk"].value == IDD_SOIL_SPECIFIC_HEAT_J_KGK
+    assert all(r.provenance == PROVENANCE_DEFAULT for r in resolved.values())
+    assert all(r.write is False for r in resolved.values())
+    assert any("no soil properties" in w for w in warnings), warnings
+
+
+def test_soil_seeds_from_a_populated_epw_header():
+    resolved, _ = resolve_soil_properties(
+        _FakeGroundTemperatureSet(conductivity_w_mk=1.95, density_kg_m3=1900.0,
+                                  specific_heat_j_kgk=430.0),
+    )
+
+    assert resolved["soil_conductivity_w_mk"].value == 1.95
+    assert resolved["soil_conductivity_w_mk"].provenance == PROVENANCE_EPW
+    assert resolved["soil_conductivity_w_mk"].write is True
+    assert resolved["soil_density_kg_m3"].provenance == PROVENANCE_EPW
+
+
+def test_a_partially_populated_epw_header_mixes_provenance():
+    # Validates: one supplied field must not drag the other two into claiming an EPW origin
+    resolved, _ = resolve_soil_properties(
+        _FakeGroundTemperatureSet(conductivity_w_mk=1.95),
+    )
+
+    assert resolved["soil_conductivity_w_mk"].provenance == PROVENANCE_EPW
+    assert resolved["soil_density_kg_m3"].provenance == PROVENANCE_DEFAULT
+
+
+def test_user_soil_override_beats_the_epw():
+    resolved, _ = resolve_soil_properties(
+        _FakeGroundTemperatureSet(conductivity_w_mk=1.95),
+        {"soil_conductivity_w_mk": 2.2},
+    )
+
+    assert resolved["soil_conductivity_w_mk"].value == 2.2
+    assert resolved["soil_conductivity_w_mk"].provenance == PROVENANCE_USER
+
+
+def test_soil_with_no_epw_at_all_defaults_quietly():
+    resolved, warnings = resolve_soil_properties(None)
+
+    assert all(r.provenance == PROVENANCE_DEFAULT for r in resolved.values())
+    assert warnings == []
+
+
+# --------------------------------------------------------------------------- the menu
+
+
+def test_menu_shows_every_archetype_with_its_numbers_and_basis():
+    # Validates: the user sees the actual parameter set before choosing — the only honest way to
+    # offer defaults nobody sourced
+    menu = archetype_menu()
+
+    assert len(menu) == len(ALL_NAMES)
+    entry = next(e for e in menu if e["name"] == "slab_on_grade_perimeter_insulated")
+    assert entry["wall_height_above_grade_m"] == IDD_WALL_HEIGHT_ABOVE_GRADE_M
+    assert "conventional starting point" in entry["basis"]
+    assert entry["insulation"][0]["position"] == POSITION_EXTERIOR_VERTICAL
+    assert entry["insulation"][0]["thickness_m"] == pytest.approx(0.051, abs=1e-3)
+    assert entry["insulation"][0]["material"] == "XPS"
+
+
+def test_menu_reports_the_geometry_deferred_depth_verbatim():
+    menu = archetype_menu()
+    entry = next(e for e in menu if e["name"] == "heated_basement_insulated")
+
+    assert entry["insulation"][0]["depth_m"] == MATCH_WALL_DEPTH

--- a/tests/test_kiva_archetypes.py
+++ b/tests/test_kiva_archetypes.py
@@ -116,6 +116,7 @@ def test_heated_basement_insulation_depth_defers_to_geometry():
 
 
 def test_unknown_archetype_lists_the_valid_names():
+    # Validates: a mistyped archetype name gets the full menu in the error so the agent can self-correct in one step
     with pytest.raises(UnknownArchetypeError) as excinfo:
         get_archetype("walkout_basement")
 
@@ -133,6 +134,7 @@ def test_r_si_converts_to_xps_thickness():
 
 
 def test_non_positive_r_value_is_rejected():
+    # Validates: R <= 0 is rejected before it becomes a zero or negative XPS Material thickness
     with pytest.raises(ValueError, match="must be positive"):
         xps_thickness_m(0.0)
 
@@ -163,6 +165,7 @@ def test_archetype_value_differing_from_the_default_is_written_and_attributed():
 
 
 def test_user_override_beats_the_archetype():
+    # Validates: an explicit geometry override wins over the archetype value and is attributed to the user
     resolved, _ = resolve_kiva_parameters(
         "crawlspace_vented", {"wall_height_above_grade_m": 0.45},
     )
@@ -185,6 +188,7 @@ def test_user_override_equal_to_the_default_is_still_written_as_user():
 
 
 def test_overriding_one_field_leaves_the_others_at_their_archetype_provenance():
+    # Validates: provenance is per-field — overriding one value must not relabel the untouched ones
     resolved, _ = resolve_kiva_parameters(
         "crawlspace_vented", {"wall_depth_below_slab_m": 0.9},
     )
@@ -203,6 +207,7 @@ def test_none_overrides_are_ignored_rather_than_written_as_null():
 
 
 def test_unrecognised_geometry_override_warns_rather_than_silently_vanishing():
+    # Validates: a misspelled override key is warned about by name rather than dropped silently
     _, warnings = resolve_kiva_parameters(
         "crawlspace_vented", {"wall_thickness_m": 0.3},
     )
@@ -214,6 +219,7 @@ def test_unrecognised_geometry_override_warns_rather_than_silently_vanishing():
 
 
 def test_insulation_defaults_to_the_archetypes_layers():
+    # Validates: with no overrides the archetype's own layers come back at CONVENTIONAL_R_SI with no warnings
     specs, warnings = resolve_insulation("slab_on_grade_perimeter_insulated")
 
     assert [s.position for s in specs] == [POSITION_EXTERIOR_VERTICAL]
@@ -222,6 +228,7 @@ def test_insulation_defaults_to_the_archetypes_layers():
 
 
 def test_r_value_override_replaces_the_archetype_value_and_keeps_the_extent():
+    # Validates: an R override changes only the R-value; the archetype's 0.6 m extent survives the merge
     specs, _ = resolve_insulation(
         "slab_on_grade_perimeter_insulated", {"exterior_vertical_r_si": 3.52},
     )
@@ -269,6 +276,7 @@ def test_soil_falls_back_to_openstudio_defaults_when_the_epw_is_blank():
 
 
 def test_soil_seeds_from_a_populated_epw_header():
+    # Validates: populated EPW soil fields are written and attributed to the EPW, not left at the IDD defaults
     resolved, _ = resolve_soil_properties(
         _FakeGroundTemperatureSet(conductivity_w_mk=1.95, density_kg_m3=1900.0,
                                   specific_heat_j_kgk=430.0),
@@ -291,6 +299,7 @@ def test_a_partially_populated_epw_header_mixes_provenance():
 
 
 def test_user_soil_override_beats_the_epw():
+    # Validates: a user soil value outranks an EPW-supplied one and is attributed to the user
     resolved, _ = resolve_soil_properties(
         _FakeGroundTemperatureSet(conductivity_w_mk=1.95),
         {"soil_conductivity_w_mk": 2.2},
@@ -301,6 +310,7 @@ def test_user_soil_override_beats_the_epw():
 
 
 def test_soil_with_no_epw_at_all_defaults_quietly():
+    # Validates: None (no EPW) yields IDD defaults without the 'no soil properties' warning a blank header gets
     resolved, warnings = resolve_soil_properties(None)
 
     assert all(r.provenance == PROVENANCE_DEFAULT for r in resolved.values())
@@ -325,6 +335,7 @@ def test_menu_shows_every_archetype_with_its_numbers_and_basis():
 
 
 def test_menu_reports_the_geometry_deferred_depth_verbatim():
+    # Validates: the MATCH_WALL_DEPTH sentinel passes through the menu unchanged rather than rendered as a number
     menu = archetype_menu()
     entry = next(e for e in menu if e["name"] == "heated_basement_insulated")
 

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -52,6 +52,9 @@ pytestmark = [
 ]
 
 BOSTON_EPW = "/repo/tests/assets/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+# A Revit-exported residential model with a real basement: 292 surfaces, 1 declared Ground
+# surface, walls -3.05 m to +0.91 m, two 6-vertex walls. The geometry the wall pairing is for.
+REVIT_BASEMENT_GBXML = "/repo/tests/assets/2026_11Ja_path1.xml"
 
 # Four 10x10 quadrants of a 20x20 building: each floor has two outer edges, so 20.0 m exposed
 # each and 80.0 m for the footprint.
@@ -1037,6 +1040,51 @@ def test_matched_interior_surfaces_are_not_kiva_candidates():
     assert ceiling.adjacentSurface().get().nameString() == names["upper_floor"]
     for name in names["partition_walls"]:
         assert _surface(name).outsideBoundaryCondition() == "Surface"
+
+
+def test_real_revit_basement_export_pairs_every_buried_wall():
+    # Validates: wall pairing on a real export, not synthetic geometry — Revit slivers and
+    # unwelded vertices are exactly what shared-edge matching could miss. On this fixture every
+    # buried 4-vertex wall must land on the one basement floor, in its zone, with the insulation
+    # depth taken from the wall geometry, and the two 6-vertex walls refused by name.
+    from uuid import uuid4
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.gbxml_import.operations import import_gbxml_op
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_foundation import get_foundation_options
+
+    imported = import_gbxml_op(REVIT_BASEMENT_GBXML, BOSTON_EPW,
+                               run_name=f"pytest_kiva_revit_{uuid4().hex[:8]}")
+    assert imported["ok"] is True, imported
+
+    options = get_foundation_options()
+    assert options["ok"] is True, options
+    assert options["eligible_floor_count"] == 1
+    floor = options["eligible_floors"][0]
+    assert floor["surface"] == "su-b-0-u-f-19"
+    assert floor["outside_boundary_condition"] == "Ground"
+    assert floor["exposed_perimeter_m"] == pytest.approx(41.6241, abs=0.01)
+    assert options["eligible_wall_count"] == 15
+    assert len(options["blocked"]) == 2, options["blocked"]
+    for blocked in options["blocked"]:
+        assert blocked["reasons"] == ["wall has 6 vertices; Kiva walls are limited to 4"]
+
+    result = set_kiva_foundation(archetype="heated_basement_insulated", epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert result["applied"]["floors"] == ["su-b-0-u-f-19"]
+    assert len(result["applied"]["walls"]) == 15
+    assert not any("was not applied" in w for w in result["warnings"]), result["warnings"]
+    kivas = get_model().getFoundationKivas()
+    assert len(kivas) == 1
+    assert len(kivas[0].surfaces()) == 16
+    assert kivas[0].exteriorVerticalInsulationDepth().get() == pytest.approx(3.048, abs=0.01)
+    zones = {s.space().get().thermalZone().get().nameString() for s in kivas[0].surfaces()}
+    assert zones == {"0 Basement (Unconditioned)"}
+    perimeter = result["applied"]["foundations"][0]["exposed_perimeter"]
+    assert perimeter["value"] == pytest.approx(41.6241, abs=0.01)
+    assert perimeter["provenance"] == "computed_geometry"
 
 
 # --------------------------------------------------------------------------- guards elsewhere

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -925,6 +925,9 @@ def test_ground_temperature_report_goes_quiet_once_every_surface_uses_kiva():
     _build_quadrants()
     before = find_missing_ground_temperatures()
     assert before["kiva_foundation_surface_count"] == 0
+    assert before["ground_temperatures_missing_count"] == 4
+    assert "Site:GroundTemperature:BuildingSurface" in before["ground_temperatures_missing_objects"]
+    assert "ground_temperatures_superseded_by_kiva" not in before
     assert "set_ground_temperatures()" in before["ground_temperatures_hint"]
     assert "set_kiva_foundation()" in before["ground_temperatures_hint"]
 
@@ -932,6 +935,11 @@ def test_ground_temperature_report_goes_quiet_once_every_surface_uses_kiva():
                                include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
 
     after = find_missing_ground_temperatures()
-    assert after["kiva_foundation_surface_count"] == 4
-    assert "would be inert here" in after["ground_temperatures_hint"]
     assert after["ok"] is True
+    assert after["kiva_foundation_surface_count"] == 4
+    # BuildingSurface is no longer "missing": Kiva ignores it. The other three stay listed.
+    assert after["ground_temperatures_superseded_by_kiva"] == [
+        "Site:GroundTemperature:BuildingSurface"]
+    assert after["ground_temperatures_missing_count"] == 3
+    assert "Site:GroundTemperature:BuildingSurface" not in after["ground_temperatures_missing_objects"]
+    assert "would be inert here" in after["ground_temperatures_hint"]

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -436,6 +436,54 @@ def test_out_of_range_perimeter_fraction_is_refused_before_the_sdk_sees_it():
     assert "at most 1" in result["error"]
 
 
+@pytest.mark.parametrize(("argument", "missing", "dry_run"), [
+    ("interior_horizontal_insulation_r_si", "interior_horizontal_insulation_width_m", False),
+    ("exterior_vertical_insulation_r_si", "exterior_vertical_insulation_depth_m", False),
+    ("interior_horizontal_insulation_r_si", "interior_horizontal_insulation_width_m", True),
+])
+def test_insulation_without_its_extent_is_refused_before_anything_is_written(argument, missing, dry_run):
+    # Regression: an R-value for a position the archetype does not insulate was applied with no
+    # width/depth and reported ok; EnergyPlus 25.2 then failed fatally on the half-specified
+    # Foundation:Kiva. Dry run approved the same plan. Both must refuse and name the argument.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated", include_below_grade_walls=False,
+        epw_path=BOSTON_EPW, dry_run=dry_run, **{argument: 2.0},
+    )
+
+    assert result["ok"] is False, result
+    assert result["missing_argument"] == missing
+    assert missing in result["error"]
+    model = get_model()
+    assert len(model.getFoundationKivas()) == 0
+    assert not any(m.nameString().startswith("Kiva XPS") for m in model.getStandardOpaqueMaterials())
+    assert not any(s.outsideBoundaryCondition() == "Foundation" for s in model.getSurfaces())
+
+
+def test_insulation_with_its_extent_is_written_in_full():
+    # Validates: the same override with the width lands on every FoundationKiva with both the
+    # material and the extent, which is the complete specification EnergyPlus accepts
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated", include_below_grade_walls=False,
+        epw_path=BOSTON_EPW, interior_horizontal_insulation_r_si=2.0,
+        interior_horizontal_insulation_width_m=0.9,
+    )
+
+    assert result["ok"] is True, result
+    kivas = get_model().getFoundationKivas()
+    assert len(kivas) == len(floors)
+    for kiva in kivas:
+        assert kiva.interiorHorizontalInsulationMaterial().is_initialized()
+        assert kiva.interiorHorizontalInsulationWidth().get() == pytest.approx(0.9)
+
+
 def test_zero_perimeter_fraction_is_refused():
     # Regression: the fraction range check accepted 0.0 while the total path required > 0 and the
     # computed path clamped zero to 1 mm — the explicit-fraction route could write the zero

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -646,6 +646,50 @@ def test_excluding_walls_leaves_them_alone():
         assert _surface(name).outsideBoundaryCondition() != "Foundation"
 
 
+def test_below_grade_floor_gets_its_real_exposed_perimeter():
+    # Regression: joinAllPolygons and Surface.exposedPerimeter assert |z| <= tolerance, so a
+    # basement floor at -2.5 m scored 0.0 and was clamped to 1 mm as an "interior bay" — every
+    # basement got a foundation with no exposed edge. The footprint is now scored at z = 0.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_eligibility import compute_exposed_perimeters
+
+    floor, _walls = _build_basement()
+    perimeters, warnings = compute_exposed_perimeters(get_model(), [floor])
+    assert perimeters == {floor: pytest.approx(40.0, abs=0.001)}, (perimeters, warnings)
+
+    result = set_kiva_foundation(archetype="unheated_basement", epw_path=BOSTON_EPW)
+    assert result["ok"] is True, result
+    exposed = result["applied"]["foundations"][0]["exposed_perimeter"]
+    assert exposed["method"] == "TotalExposedPerimeter"
+    assert exposed["value"] == pytest.approx(40.0, abs=0.001)
+    assert exposed["provenance"] == "computed_geometry"
+    assert not any("interior bay" in w for w in result["warnings"]), result["warnings"]
+
+
+def test_paired_walls_longer_than_the_exposed_perimeter_are_refused():
+    # Validates: EnergyPlus refuses a Foundation:Kiva whose wall surfaces have "a combined length
+    # greater than the exposed perimeter of the foundation" (severe, at run time). Four 10 m walls
+    # against a stated 10 m perimeter must be refused here, with nothing written.
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floor, walls = _build_basement()
+    result = set_kiva_foundation(
+        archetype="unheated_basement", include_below_grade_walls=True,
+        exposed_perimeter_method="total", exposed_perimeter_m=10.0, epw_path=BOSTON_EPW,
+    )
+
+    assert result["ok"] is False, result
+    assert "exposed perimeter" in result["error"]
+    detail = result["wall_length_exceeds_perimeter"][floor]
+    assert detail["paired_wall_length_m"] == pytest.approx(40.0, abs=0.01)
+    assert detail["exposed_perimeter_m"] == pytest.approx(10.0, abs=0.001)
+    assert sorted(detail["walls"]) == walls
+    assert _surface(floor).outsideBoundaryCondition() != "Foundation"
+    for name in walls:
+        assert _surface(name).outsideBoundaryCondition() != "Foundation"
+
+
 def test_basement_insulation_depth_comes_from_the_wall_geometry():
     # Regression: basement depth is NOT a Kiva input. The archetype defers with MATCH_WALL_DEPTH
     # and the writer must resolve it from the paired walls, not invent a number.

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -319,6 +319,36 @@ def test_insulated_archetype_creates_and_reuses_one_xps_material():
 # --------------------------------------------------------------------------- refusals
 
 
+def test_close_r_values_get_distinct_materials():
+    # Regression: the material name rounded R to two decimals, so 1.760 and 1.764 resolved to the
+    # same "Kiva XPS R-SI 1.76 (51 mm)" and the second run reused the first thickness while
+    # reporting the newer R-value
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_archetypes import xps_thickness_m
+
+    _build_quadrants()
+    first = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                include_below_grade_walls=False, epw_path=BOSTON_EPW,
+                                exterior_vertical_insulation_r_si=1.760)
+    assert first["ok"] is True, first
+    second = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW,
+                                 exterior_vertical_insulation_r_si=1.764, overwrite=True)
+    assert second["ok"] is True, second
+
+    # (material_disposition reports the last floor written, which reuses the material the first
+    # floor of the same run created — so it says "reused" here by design.)
+    xps = {m.nameString(): m.thickness() for m in get_model().getStandardOpaqueMaterials()
+           if m.nameString().startswith("Kiva XPS")}
+    assert len(xps) == 2, xps
+    assert sorted(xps.values()) == pytest.approx(
+        sorted([xps_thickness_m(1.760), xps_thickness_m(1.764)]), rel=1e-6)
+    for kiva in get_model().getFoundationKivas():
+        material = kiva.exteriorVerticalInsulationMaterial().get().to_StandardOpaqueMaterial().get()
+        assert material.thickness() == pytest.approx(xps_thickness_m(1.764), rel=1e-6)
+
+
 def test_massless_construction_layer_is_refused():
     # Validates: EnergyPlus refuses a Foundation surface with no-mass layers. exampleModel's own
     # floors use "CP02 CARPET PAD", so this is the real case, not a contrived one.

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -377,6 +377,8 @@ def test_requested_surface_that_is_not_eligible_aborts_with_nothing_written():
 
 
 def test_unknown_archetype_is_refused_with_the_valid_names():
+    # Validates: a mistyped archetype is refused with the full valid list in the response, so an
+    # agent can self-correct in one step instead of guessing names
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
 
     _build_quadrants()
@@ -416,6 +418,8 @@ def test_total_perimeter_across_several_floors_is_refused():
 
 
 def test_reapplying_without_overwrite_is_refused():
+    # Validates: idempotence guard — a floor that already carries a Foundation object is not
+    # silently re-pointed; the error names the overwrite flag that allows it
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
 
     _build_quadrants()
@@ -429,6 +433,8 @@ def test_reapplying_without_overwrite_is_refused():
 
 
 def test_no_model_loaded_reports_instead_of_raising():
+    # Validates: the operations contract (CLAUDE.md rule 5) — both Kiva tools return ok=False
+    # with no model loaded rather than raising RuntimeError through MCP
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
     from mcp_server.skills.geometry.kiva_foundation import get_foundation_options
 
@@ -488,6 +494,8 @@ def test_blank_epw_soil_leaves_settings_uncreated():
 
 
 def test_user_soil_override_creates_settings_and_reports_provenance():
+    # Validates: a caller-supplied soil property is the one case that must create the unique
+    # FoundationKivaSettings object, land on it, and be attributed to the user
     from mcp_server.model_manager import get_model
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
 
@@ -505,6 +513,8 @@ def test_user_soil_override_creates_settings_and_reports_provenance():
 
 
 def test_dry_run_changes_nothing():
+    # Validates: dry_run returns the full plan for the user to inspect while creating no
+    # FoundationKiva objects — the preview must not be a partial apply
     from mcp_server.model_manager import get_model
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
 

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -212,6 +212,136 @@ def test_exposed_perimeter_matches_the_joined_footprint():
     assert sum(perimeters.values()) == pytest.approx(80.0, abs=0.01)
 
 
+def _build_grid(cells, dz: float = 0.0, size: float = 10.0) -> dict[tuple[int, int], str]:
+    """One 10x10 space per (i, j) cell, floors given a Kiva-acceptable construction; returns floor names."""
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.constructions.operations import assign_construction_to_surface
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+
+    _load_empty_model()
+    construction = _slab_construction()
+    model = get_model()
+    floors = {}
+    for (i, j) in cells:
+        x, y = size * i, size * j
+        name = f"Cell {i}{j}"
+        created = create_space_from_floor_print(
+            name=name, floor_vertices=[[x, y], [x + size, y], [x + size, y + size], [x, y + size]],
+            floor_to_ceiling_height=3.0,
+        )
+        assert created["ok"] is True, created
+        space = next(s for s in model.getSpaces() if s.nameString() == name)
+        zone = openstudio.model.ThermalZone(model)
+        zone.setName(f"{name} Zone")
+        space.setThermalZone(zone)
+        for surface in space.surfaces():
+            if dz:
+                moved = openstudio.Point3dVector([
+                    openstudio.Point3d(v.x(), v.y(), v.z() + dz) for v in surface.vertices()
+                ])
+                assert surface.setVertices(moved)
+            assert assign_construction_to_surface(
+                surface_name=surface.nameString(), construction_name=construction,
+            )["ok"]
+            if surface.surfaceType() == "Floor":
+                floors[(i, j)] = surface.nameString()
+    return floors
+
+
+COURTYARD = [(i, j) for i in range(3) for j in range(3) if (i, j) != (1, 1)]
+
+
+@pytest.mark.parametrize("dz", [0.0, -2.5])
+def test_courtyard_edges_stay_exposed(dz):
+    # Regression: joinAllPolygons fills holes, so a 3x3 ring of 10 m slabs around an open
+    # courtyard scored 120 m (the outside only) instead of 160 m — the four edge slabs got 10 m
+    # instead of 20 m and no warning said anything was missing. At grade and below grade.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import compute_exposed_perimeters
+
+    floors = _build_grid(COURTYARD, dz=dz)
+    perimeters, warnings = compute_exposed_perimeters(get_model(), list(floors.values()))
+
+    assert warnings == []
+    assert perimeters == {name: pytest.approx(20.0, abs=1e-3) for name in floors.values()}, perimeters
+    assert sum(perimeters.values()) == pytest.approx(160.0, abs=1e-3)
+
+
+def test_single_courtyard_facing_slab_scores_against_every_neighbour():
+    # Validates: selecting one floor still uses all candidate floors as neighbours — the edge
+    # slab's two covered edges come from floors that were not selected
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_eligibility import compute_exposed_perimeters
+
+    floors = _build_grid(COURTYARD)
+    edge_slab = floors[(1, 0)]
+    perimeters, _ = compute_exposed_perimeters(get_model(), [edge_slab])
+    assert perimeters == {edge_slab: pytest.approx(20.0, abs=1e-3)}
+
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated", floor_surface_names=[edge_slab],
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+    assert result["ok"] is True, result
+    written = _surface(edge_slab).surfacePropertyExposedFoundationPerimeter().get()
+    assert written.totalExposedPerimeter().get() == pytest.approx(20.0, abs=1e-3)
+
+
+def test_unequal_subdivision_and_disjoint_wings_score_by_interval():
+    # Validates: a neighbour whose shared edge is shorter than this floor's (T-junction) covers
+    # only its own stretch, and two separate wings do not cover each other at all
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import compute_exposed_perimeters
+
+    floors = _build_grid([(0, 0), (1, 0)])              # A 0..10, B 10..20 (10 m tall)
+    model = get_model()
+    b = _surface(floors[(1, 0)])
+    # Shrink B to 10..20 x 0..5: it now covers only half of A's east edge.
+    assert b.setVertices(openstudio.Point3dVector([
+        openstudio.Point3d(v.x(), min(v.y(), 5.0), v.z()) for v in b.vertices()
+    ]))
+    # A detached wing far away, 10x10.
+    from mcp_server.skills.constructions.operations import assign_construction_to_surface
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+    created = create_space_from_floor_print(name="Wing", floor_vertices=[[50, 50], [60, 50], [60, 60], [50, 60]],
+                                            floor_to_ceiling_height=3.0)
+    assert created["ok"] is True, created
+    wing = next(s.nameString() for s in model.getSurfaces()
+                if s.surfaceType() == "Floor" and s.space().get().nameString() == "Wing")
+    assert assign_construction_to_surface(surface_name=wing, construction_name="Kiva Test Slab")["ok"]
+
+    perimeters, warnings = compute_exposed_perimeters(model, [floors[(0, 0)], floors[(1, 0)], wing])
+
+    assert warnings == []
+    assert perimeters[floors[(0, 0)]] == pytest.approx(35.0, abs=1e-3)   # 40 - 5 covered by B
+    assert perimeters[floors[(1, 0)]] == pytest.approx(25.0, abs=1e-3)   # 30 - 5 covered by A
+    assert perimeters[wing] == pytest.approx(40.0, abs=1e-3)
+
+
+def test_duplicated_footprint_is_reported_and_not_treated_as_a_neighbour():
+    # Validates: two floors with the same footprint (a duplicated surface) would otherwise cover
+    # each other completely and both score zero; instead both keep their perimeter and the
+    # duplication is named
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import compute_exposed_perimeters
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+
+    floors = _build_grid([(0, 0)])
+    created = create_space_from_floor_print(name="Twin", floor_vertices=[[0, 0], [10, 0], [10, 10], [0, 10]],
+                                            floor_to_ceiling_height=3.0)
+    assert created["ok"] is True, created
+    twin = next(s.nameString() for s in get_model().getSurfaces()
+                if s.surfaceType() == "Floor" and s.space().get().nameString() == "Twin")
+
+    perimeters, warnings = compute_exposed_perimeters(get_model(), [floors[(0, 0)], twin])
+
+    assert perimeters == {floors[(0, 0)]: pytest.approx(40.0), twin: pytest.approx(40.0)}
+    assert len(warnings) == 1 and "same footprint" in warnings[0], warnings
+
+
 def test_interior_bay_has_no_exposed_edge_and_is_clamped():
     # Validates: a slab surrounded on all sides scores zero, and Kiva rejects a zero perimeter, so
     # it is clamped and warned about rather than written as 0.

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -675,6 +675,99 @@ def test_basement_archetype_on_a_slab_model_is_refused():
     assert "no below-grade walls" in result["error"]
 
 
+def _build_stacked_basement() -> dict[str, object]:
+    """Two basement levels plus a neighbour, matched, so interior floors and partitions exist.
+
+    Lower (z -5..-2.5) and Lower2 beside it share a partition wall; Upper (z -2.5..0) sits on
+    Lower, so Upper's floor is matched to Lower's ceiling. Only the two bottom floors and the
+    exterior below-grade walls touch soil.
+    """
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.constructions.operations import assign_construction_to_surface
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print, match_surfaces
+
+    _load_empty_model()
+    construction = _slab_construction()
+    model = get_model()
+
+    def build(name, footprint, dz):
+        created = create_space_from_floor_print(
+            name=name, floor_vertices=footprint, floor_to_ceiling_height=2.5,
+        )
+        assert created["ok"] is True, created
+        space = next(s for s in model.getSpaces() if s.nameString() == name)
+        zone = openstudio.model.ThermalZone(model)
+        zone.setName(f"{name} Zone")
+        space.setThermalZone(zone)
+        for surface in space.surfaces():
+            moved = openstudio.Point3dVector([
+                openstudio.Point3d(v.x(), v.y(), v.z() + dz) for v in surface.vertices()
+            ])
+            assert surface.setVertices(moved)
+            assign_construction_to_surface(
+                surface_name=surface.nameString(), construction_name=construction,
+            )
+        return space
+
+    lower = build("Lower", QUADRANTS["SW"], -5.0)
+    lower2 = build("Lower2", QUADRANTS["SE"], -5.0)
+    upper = build("Upper", QUADRANTS["SW"], -2.5)
+    matched = match_surfaces()
+    assert matched["ok"] is True, matched
+    # Upper floor <-> Lower ceiling, and the Lower <-> Lower2 partition: two pairs, four surfaces.
+    assert matched["matched_surfaces"] == 4, matched
+
+    def one(space, kind):
+        return next(s.nameString() for s in space.surfaces() if s.surfaceType() == kind)
+
+    partition = sorted(
+        s.nameString() for s in [*lower.surfaces(), *lower2.surfaces()]
+        if s.surfaceType() == "Wall" and s.outsideBoundaryCondition() == "Surface"
+    )
+    assert len(partition) == 2, partition
+    return {
+        "lower_floor": one(lower, "Floor"),
+        "lower2_floor": one(lower2, "Floor"),
+        "upper_floor": one(upper, "Floor"),
+        "lower_ceiling": one(lower, "RoofCeiling"),
+        "partition_walls": partition,
+    }
+
+
+def test_matched_interior_surfaces_are_not_kiva_candidates():
+    # Regression: eligibility filtered only Adiabatic, so a matched interior floor (a two-storey
+    # basement, a crawlspace modelled as a zone) and buried partition walls were converted to
+    # Foundation, and setOutsideBoundaryCondition dropped their partners to Outdoors/SunExposed
+    # 2.5 m underground. ground_contact.py already excludes "Surface"; this path must too.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_eligibility import classify_foundation_candidates
+
+    names = _build_stacked_basement()
+    candidates = classify_foundation_candidates(get_model())
+    floors = sorted(f["surface"] for f in candidates["eligible_floors"])
+    walls = sorted(w["surface"] for w in candidates["eligible_walls"])
+
+    assert floors == sorted([names["lower_floor"], names["lower2_floor"]]), floors
+    assert names["upper_floor"] not in floors
+    assert not set(names["partition_walls"]) & set(walls), walls
+    # 3 exterior walls on each lower space plus Upper's 4, all fully buried; no partitions.
+    assert len(walls) == 10, walls
+
+    result = set_kiva_foundation(archetype="unheated_basement", epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert sorted(result["applied"]["floors"]) == floors
+    assert _surface(names["upper_floor"]).outsideBoundaryCondition() == "Surface"
+    ceiling = _surface(names["lower_ceiling"])
+    assert ceiling.outsideBoundaryCondition() == "Surface"
+    assert ceiling.adjacentSurface().get().nameString() == names["upper_floor"]
+    for name in names["partition_walls"]:
+        assert _surface(name).outsideBoundaryCondition() == "Surface"
+
+
 # --------------------------------------------------------------------------- guards elsewhere
 
 

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -400,7 +400,51 @@ def test_out_of_range_perimeter_fraction_is_refused_before_the_sdk_sees_it():
     )
 
     assert result["ok"] is False
-    assert "between 0 and 1" in result["error"]
+    assert "at most 1" in result["error"]
+
+
+def test_zero_perimeter_fraction_is_refused():
+    # Regression: the fraction range check accepted 0.0 while the total path required > 0 and the
+    # computed path clamped zero to 1 mm — the explicit-fraction route could write the zero
+    # exposed perimeter Kiva refuses
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated", include_below_grade_walls=False,
+        exposed_perimeter_method="fraction", exposed_perimeter_fraction=0.0, epw_path=BOSTON_EPW,
+    )
+
+    assert result["ok"] is False
+    assert "greater than 0" in result["error"]
+    assert len(get_model().getFoundationKivas()) == 0
+
+
+@pytest.mark.parametrize(("argument", "value"), [
+    ("soil_conductivity_w_mk", -1.0),
+    ("soil_density_kg_m3", 0.0),
+    ("exterior_vertical_insulation_depth_m", -0.5),
+    ("interior_horizontal_insulation_width_m", 0.0),
+    ("footing_depth_m", -0.3),
+])
+def test_non_positive_dimension_is_refused_before_anything_is_written(argument, value):
+    # Regression: OpenStudio's setters return False on these, but the soil setters' results were
+    # discarded (value reported as written) and an insulation setter refusal only warned while
+    # `applied` recorded the requested extent. Now refused up front, model untouched.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_perimeter_insulated", include_below_grade_walls=False,
+        epw_path=BOSTON_EPW, **{argument: value},
+    )
+
+    assert result["ok"] is False, result
+    assert result["invalid_arguments"] == {argument: value}
+    assert len(get_model().getFoundationKivas()) == 0
+    assert not get_model().getOptionalFoundationKivaSettings().is_initialized()
 
 
 def test_total_perimeter_across_several_floors_is_refused():

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -632,6 +632,44 @@ def test_user_soil_override_creates_settings_and_reports_provenance():
     assert settings.get().soilConductivity() == pytest.approx(2.2)
 
 
+def test_existing_custom_soil_is_reported_as_existing_and_left_alone():
+    # Regression: with a FoundationKivaSettings object already holding custom soil values, the plan
+    # reported them as openstudio_default and the writer left the custom values in place — the
+    # response misstated what the new foundations would actually use
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    settings = get_model().getFoundationKivaSettings()
+    assert settings.setSoilConductivity(2.4)
+
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert result["plan"]["soil"]["soil_conductivity_w_mk"] == {
+        "value": 2.4, "provenance": "existing_model", "written": False}
+    assert result["plan"]["soil"]["soil_density_kg_m3"]["provenance"] == "openstudio_default"
+    assert get_model().getFoundationKivaSettings().soilConductivity() == pytest.approx(2.4)
+
+
+def test_dry_run_reports_insulation_with_provenance():
+    # Regression: the dry-run plan omitted the insulation entirely, so the user could not see the
+    # R-value and extent — or where they came from — before committing
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW,
+                                 exterior_vertical_insulation_r_si=3.52, dry_run=True)
+
+    assert result["ok"] is True, result
+    layer = result["plan"]["insulation"]["exterior_vertical"]
+    assert layer["r_si_m2k_w"] == {"value": 3.52, "provenance": "user"}
+    assert layer["depth_m"] == {"value": 0.6,
+                                "provenance": "archetype:slab_on_grade_perimeter_insulated"}
+
+
 def test_dry_run_changes_nothing():
     # Validates: dry_run returns the full plan for the user to inspect while creating no
     # FoundationKiva objects — the preview must not be a partial apply

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -706,17 +706,42 @@ def test_basement_insulation_depth_comes_from_the_wall_geometry():
     assert kiva.exteriorVerticalInsulationMaterial().is_initialized()
 
 
-def test_basement_archetype_on_a_slab_model_is_refused():
-    # Validates: a basement archetype reaching a slab-on-grade model would write a foundation wall
-    # that is not there
+def test_user_stem_wall_depth_on_a_slab_model_is_honoured():
+    # Regression: a "suspicious depth" guard refused any wall_depth_below_slab_m above 0.5 m on a
+    # model with no below-grade walls, while telling the user to "pass the value explicitly" —
+    # which was the only way to reach it, since every archetype's own value is 0.0. A frost-depth
+    # stem wall on a slab is a real detail and must be writable.
+    from mcp_server.model_manager import get_model
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
 
     _build_quadrants()
-    result = set_kiva_foundation(archetype="heated_basement_insulated",
-                                 wall_depth_below_slab_m=2.4, epw_path=BOSTON_EPW)
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 wall_depth_below_slab_m=1.2, epw_path=BOSTON_EPW)
 
-    assert result["ok"] is False
-    assert "no below-grade walls" in result["error"]
+    assert result["ok"] is True, result
+    depth = result["plan"]["geometry"]["wall_depth_below_slab_m"]
+    assert depth == {"value": 1.2, "provenance": "user", "written": True}
+    for kiva in get_model().getFoundationKivas():
+        assert kiva.wallDepthBelowSlab() == pytest.approx(1.2, abs=1e-6)
+
+
+def test_basement_archetype_on_a_slab_model_applies_without_wall_insulation():
+    # Validates: an archetype is an insulation strategy, not a geometry claim — with no below-grade
+    # wall to pair, the full-depth exterior insulation is skipped with a warning naming why, and the
+    # floors still get their Foundation objects
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    result = set_kiva_foundation(archetype="heated_basement_insulated", epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert sorted(result["applied"]["floors"]) == floors
+    assert result["applied"]["walls"] == []
+    assert result["applied"]["insulation"] == {}
+    assert any("no below-grade wall was paired" in w for w in result["warnings"]), result["warnings"]
+    for kiva in get_model().getFoundationKivas():
+        assert not kiva.exteriorVerticalInsulationMaterial().is_initialized()
 
 
 def _build_stacked_basement() -> dict[str, object]:

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -1057,6 +1057,28 @@ def test_set_surface_boundary_conditions_refuses_a_dangling_foundation():
     assert _surface(floors[0]).outsideBoundaryCondition() != "Foundation"
 
 
+def test_setting_ground_temperatures_after_kiva_reports_the_interaction():
+    # Regression: set_ground_temperatures run after Kiva wrote BuildingSurface, reported it as
+    # applied and said nothing about the Foundation surfaces that ignore it — the interaction was
+    # only reported from the Kiva side, so a thermal no-op looked effective
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _build_quadrants()
+    assert set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                               include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
+
+    result = set_ground_temperatures(epw_path=BOSTON_EPW, building_surface_method="constant",
+                                     building_surface_constant_c=18.0)
+
+    assert result["ok"] is True, result
+    assert "Site:GroundTemperature:BuildingSurface" in result["applied"]
+    assert result["kiva_interaction"] == {"foundation_surface_count": 4, "ground_surface_count": 0}
+    kiva = [w for w in result["warnings"] if "use Kiva" in w]
+    assert len(kiva) == 1, result["warnings"]
+    assert "applies to no surface in this model" in kiva[0]
+
+
 def test_ground_temperature_report_goes_quiet_once_every_surface_uses_kiva():
     # Validates: a user who did the higher-fidelity thing should not be nagged forever about
     # Site:GroundTemperature:BuildingSurface, which Kiva ignores

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -455,9 +455,11 @@ def test_overwrite_does_not_accumulate_foundation_objects():
             "Kiva slab_on_grade_perimeter_insulated")
 
 
-def test_overwrite_keeps_a_previous_foundation_that_walls_still_use_and_warns():
-    # Validates: when the re-run does not re-pair the walls, the old Foundation object is the only
-    # thing keeping their reference valid — it is kept and the response says which walls and why
+def test_overwrite_that_would_strand_walls_is_refused_before_mutation():
+    # Regression: an overwrite that re-paired fewer walls than the previous run kept the old
+    # Foundation object for them, returned ok=True and only warned — shipping a Foundation:Kiva
+    # with walls and no floor, which EnergyPlus refuses ("must also reference [it] in a floor
+    # surface within the same Zone"). It is now refused up front with nothing written.
     from mcp_server.model_manager import get_model
     from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
 
@@ -465,18 +467,45 @@ def test_overwrite_keeps_a_previous_foundation_that_walls_still_use_and_warns():
     first = set_kiva_foundation(archetype="unheated_basement", include_below_grade_walls=True,
                                 epw_path=BOSTON_EPW)
     assert first["ok"] is True, first
+    original = _surface(floor).adjacentFoundation().get().nameString()
+
     second = set_kiva_foundation(archetype="unheated_basement", include_below_grade_walls=False,
                                  epw_path=BOSTON_EPW, overwrite=True)
 
-    assert second["ok"] is True, second
-    assert len(get_model().getFoundationKivas()) == 2
-    kept = [w for w in second["warnings"] if "was kept because" in w]
-    assert len(kept) == 1, second["warnings"]
+    assert second["ok"] is False, second
+    assert "no floor" in second["error"]
+    assert second["stranded_walls"] == {floor: walls}
+    assert len(get_model().getFoundationKivas()) == 1
+    assert _surface(floor).adjacentFoundation().get().nameString() == original
     for name in walls:
-        assert name in kept[0]
-    floor_kiva = _surface(floor).adjacentFoundation().get().nameString()
-    wall_kiva = _surface(walls[0]).adjacentFoundation().get().nameString()
-    assert floor_kiva != wall_kiva
+        assert _surface(name).adjacentFoundation().get().nameString() == original
+
+
+def test_wall_in_a_different_zone_is_not_paired_to_the_floor():
+    # Validates: EnergyPlus requires the floor and wall of one Foundation:Kiva to be in the same
+    # zone, so a wall that shares an edge with a floor in another zone is reported, not attached
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import pair_walls_to_floors
+
+    floor, walls = _build_basement()
+    model = get_model()
+    other_space = openstudio.model.Space(model)
+    other_space.setName("Other Basement Room")
+    other_zone = openstudio.model.ThermalZone(model)
+    other_zone.setName("Other Basement Zone")
+    other_space.setThermalZone(other_zone)
+    moved = walls[0]
+    assert _surface(moved).setSpace(other_space)
+
+    pairing = pair_walls_to_floors(model, [floor], walls)
+
+    assert sorted(pairing["pairs"][floor]) == walls[1:]
+    assert len(pairing["unpaired"]) == 1
+    entry = pairing["unpaired"][0]
+    assert entry["surface"] == moved
+    assert "different thermal zone" in entry["reason"]
 
 
 def test_no_model_loaded_reports_instead_of_raising():

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -1,0 +1,714 @@
+"""Tests for the Kiva foundation tools — requires OpenStudio (Docker).
+
+Driven in-process, like tests/test_ground_contact.py and tests/test_ground_temperatures.py: the
+assertions turn on SDK behaviour that no MCP response exposes, and building the geometry here makes
+every asserted number exact.
+
+**Model state only, never a simulation.** EnergyPlus creates one 2D finite-difference domain per
+Kiva floor, so an annual run is far too slow for a CI shard. `ForwardTranslator` stands in as the
+cheap proxy for "EnergyPlus would accept this"; the real run is done once by hand and recorded in
+the PR.
+
+SDK facts these tests pin (probed, OpenStudio 3.11.0 / EnergyPlus 25.2.0):
+  - `Surface.exposedPerimeter()` SEGFAULTS on a surface with no parent Space. No exception, no
+    error dict — the interpreter dies. `test_space_less_floor_is_reported_not_crashed` is the
+    regression, and if it ever fails it takes the whole pytest process with it.
+  - `Surface.setAdjacentFoundation()` sets the boundary condition to Foundation but leaves
+    SunExposed/WindExposed intact, which would put solar gain on a buried slab.
+  - `createSurfacePropertyExposedFoundationPerimeter()` returns an initialized optional even when
+    it silently discarded the method or the value.
+  - `model.getFoundationKivaSettings()` creates the unique object; the Optional getter does not.
+  - `exampleModel()`'s floors use the massless "CP02 CARPET PAD" layer, so they are legitimately
+    refused — a real instance of the constraint, not a contrived one.
+
+Manual EnergyPlus verification (run once by hand, 2026-09-11, EnergyPlus 25.2.0, Boston TMY3,
+one-week run period, two 10x10 slabs with slab_on_grade_perimeter_insulated):
+
+    exit=0
+    eplusout.end: EnergyPlus Completed Successfully -- 8 Warning; 0 Severe Errors
+    eplusout.eio:
+      ! <Kiva Foundation Name>, Horizontal Cells, Vertical Cells, Total Cells,
+        Total Exposed Perimeter, Perimeter Fraction, Wall Height, ...
+      KIVA SLAB_ON_GRADE_PERIMETER_INSULATED SURFACE 1,39,27,1053,30.00,1.00,0.00,...
+      KIVA SLAB_ON_GRADE_PERIMETER_INSULATED SURFACE 7,39,27,1053,30.00,1.00,0.00,...
+
+The 30.00 m matches what compute_exposed_perimeters reported, so the geometry path is right end to
+end. Runtime was 0.76 s, but that is a trivial model — it says nothing useful about the cost on a
+real one, which scales with the number of domains (one per floor).
+"""
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_OPENSTUDIO_INTEGRATION"),
+        reason="requires OpenStudio (set RUN_OPENSTUDIO_INTEGRATION=1)",
+    ),
+]
+
+BOSTON_EPW = "/repo/tests/assets/USA_MA_Boston-Logan.Intl.AP.725090_TMY3.epw"
+
+# Four 10x10 quadrants of a 20x20 building: each floor has two outer edges, so 20.0 m exposed
+# each and 80.0 m for the footprint.
+QUADRANTS = {
+    "SW": [[0, 0], [10, 0], [10, 10], [0, 10]],
+    "SE": [[10, 0], [20, 0], [20, 10], [10, 10]],
+    "NW": [[0, 10], [10, 10], [10, 20], [0, 20]],
+    "NE": [[10, 10], [20, 10], [20, 20], [10, 20]],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_model():
+    from mcp_server.model_manager import clear_model
+    clear_model()
+    yield
+    clear_model()
+
+
+def _allowed_dir():
+    """A directory the path allowlist accepts — pytest's tmp_path (/tmp) is rejected."""
+    from mcp_server.config import user_run_root
+
+    d = user_run_root() / "pytest_kiva" / uuid4().hex[:10]
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _load_empty_model() -> None:
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+
+    path = _allowed_dir() / "empty.osm"
+    openstudio.model.Model().save(openstudio.toPath(str(path)), True)
+    load_model(path)
+
+
+def _slab_construction(name: str = "Kiva Test Slab") -> str:
+    """A single-layer standard-opaque construction — Kiva refuses massless layers."""
+    from mcp_server.skills.constructions.operations import (
+        create_construction,
+        create_standard_opaque_material,
+    )
+
+    material = create_standard_opaque_material(
+        name=f"{name} Concrete", thickness_m=0.1, conductivity_w_m_k=1.9,
+        density_kg_m3=2300.0, specific_heat_j_kg_k=900.0,
+    )
+    assert material["ok"] is True, material
+    construction = create_construction(name=name, material_names=[f"{name} Concrete"])
+    assert construction["ok"] is True, construction
+    return name
+
+
+def _build_quadrants(names=("SW", "SE", "NW", "NE")) -> list[str]:
+    """Build the quadrant spaces and give every floor a Kiva-acceptable construction."""
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.constructions.operations import assign_construction_to_surface
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+
+    _load_empty_model()
+    construction = _slab_construction()
+    for name in names:
+        created = create_space_from_floor_print(
+            name=f"Space {name}", floor_vertices=QUADRANTS[name], floor_to_ceiling_height=3.0,
+        )
+        assert created["ok"] is True, created
+
+    # A space with no ThermalZone is dropped wholesale by the ForwardTranslator ("Space ... is not
+    # associated with a ThermalZone, it will not be translated"), so its Kiva objects never reach
+    # the IDF. Kiva surfaces need a zone.
+    model = get_model()
+    for space in model.getSpaces():
+        if not space.thermalZone().is_initialized():
+            zone = openstudio.model.ThermalZone(model)
+            zone.setName(f"{space.nameString()} Zone")
+            assert space.setThermalZone(zone)
+
+    floors = []
+    for surface in get_model().getSurfaces():
+        if surface.surfaceType() != "Floor":
+            continue
+        assigned = assign_construction_to_surface(
+            surface_name=surface.nameString(), construction_name=construction,
+        )
+        assert assigned["ok"] is True, assigned
+        floors.append(surface.nameString())
+    return sorted(floors)
+
+
+def _surface(name):
+    from mcp_server.model_manager import get_model
+
+    return next(s for s in get_model().getSurfaces() if s.nameString() == name)
+
+
+# --------------------------------------------------------------------------- the segfault
+
+
+def test_space_less_floor_is_reported_not_crashed():
+    # Regression: Surface.exposedPerimeter() SEGFAULTS on a surface with no parent Space — no
+    # exception, the interpreter dies and the MCP session with it. gbXML imports produce
+    # parentless surfaces routinely. If this test ever fails it will take pytest down with it,
+    # which is exactly the signal we want.
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import (
+        classify_foundation_candidates,
+        compute_exposed_perimeters,
+    )
+
+    floors = _build_quadrants()
+    model = get_model()
+    orphan = openstudio.model.Surface(
+        openstudio.Point3dVector([
+            openstudio.Point3d(0, 0, 0), openstudio.Point3d(0, 5, 0),
+            openstudio.Point3d(5, 5, 0), openstudio.Point3d(5, 0, 0),
+        ]),
+        model,
+    )
+    orphan.setName("Orphan Floor")
+    assert not orphan.space().is_initialized()
+
+    candidates = classify_foundation_candidates(model)
+    blocked = {b["surface"]: b["reasons"] for b in candidates["blocked"]}
+    assert "Orphan Floor" in blocked
+    assert blocked["Orphan Floor"] == ["surface has no parent space"]
+
+    # And the perimeter pass must not call the method on it either.
+    perimeters, warnings = compute_exposed_perimeters(model, [*floors, "Orphan Floor"])
+    assert "Orphan Floor" not in perimeters
+    assert any("no parent space" in w for w in warnings), warnings
+
+
+# --------------------------------------------------------------------------- exposed perimeter
+
+
+def test_exposed_perimeter_matches_the_joined_footprint():
+    # Validates: the joinAllPolygons recipe. Each 10x10 quadrant of a 20x20 building has two
+    # outer edges, so 20.0 m each and 80.0 m total — a hand-built Polygon3d returns 0.0 instead.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import compute_exposed_perimeters
+
+    floors = _build_quadrants()
+    perimeters, warnings = compute_exposed_perimeters(get_model(), floors)
+
+    assert warnings == [], warnings
+    assert len(perimeters) == 4
+    for name, value in perimeters.items():
+        assert value == pytest.approx(20.0, abs=0.01), (name, perimeters)
+    assert sum(perimeters.values()) == pytest.approx(80.0, abs=0.01)
+
+
+def test_interior_bay_has_no_exposed_edge_and_is_clamped():
+    # Validates: a slab surrounded on all sides scores zero, and Kiva rejects a zero perimeter, so
+    # it is clamped and warned about rather than written as 0.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.constructions.operations import assign_construction_to_surface
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+
+    _build_quadrants()
+    # A 3x3 grid needs a centre bay; build one ringed by the four quadrants plus fillers.
+    created = create_space_from_floor_print(
+        name="Space Centre", floor_vertices=[[5, 5], [15, 5], [15, 15], [5, 15]],
+        floor_to_ceiling_height=3.0,
+    )
+    assert created["ok"] is True, created
+    for surface in get_model().getSurfaces():
+        if surface.surfaceType() == "Floor":
+            assign_construction_to_surface(
+                surface_name=surface.nameString(), construction_name="Kiva Test Slab",
+            )
+
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 include_below_grade_walls=False, dry_run=True)
+    assert result["ok"] is True, result
+    methods = {v["provenance"] for v in result["plan"]["exposed_perimeter"].values()}
+    assert "computed_geometry" in methods, result["plan"]["exposed_perimeter"]
+
+
+# --------------------------------------------------------------------------- the write path
+
+
+def test_applying_creates_one_kiva_per_floor_with_foundation_boundary():
+    # Validates: EnergyPlus allows exactly one floor per Foundation:Kiva object
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert sorted(result["applied"]["floors"]) == floors
+    model = get_model()
+    assert len(model.getFoundationKivas()) == 4
+    for kiva in model.getFoundationKivas():
+        assert len(kiva.surfaces()) == 1, kiva.nameString()
+    for name in floors:
+        assert _surface(name).outsideBoundaryCondition() == "Foundation"
+
+
+def test_converted_surface_is_nosun_and_nowind():
+    # Regression: setAdjacentFoundation sets the boundary condition but LEAVES SunExposed and
+    # WindExposed intact — a buried slab taking solar gain is the exact defect ground_contact.py
+    # exists to prevent. The tool must set the boundary condition first.
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    assert set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                               include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
+
+    for name in floors:
+        surface = _surface(name)
+        assert surface.sunExposure() == "NoSun", name
+        assert surface.windExposure() == "NoWind", name
+
+
+def test_exposed_perimeter_object_is_written_and_reads_back():
+    # Validates: the object EnergyPlus treats as mandatory exists, with the method and value that
+    # were asked for — createSurfaceProperty... reports success even when it discarded them.
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    assert set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                               include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
+
+    for name in floors:
+        prop = _surface(name).surfacePropertyExposedFoundationPerimeter()
+        assert prop.is_initialized(), name
+        assert prop.get().exposedPerimeterCalculationMethod() == "TotalExposedPerimeter"
+        assert prop.get().totalExposedPerimeter().get() == pytest.approx(20.0, abs=0.01)
+
+
+def test_insulated_archetype_creates_and_reuses_one_xps_material():
+    # Validates: the material is named deterministically, so a second run reuses it rather than
+    # accumulating a duplicate
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    first = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                include_below_grade_walls=False, epw_path=BOSTON_EPW)
+    assert first["ok"] is True, first
+
+    materials = [m.nameString() for m in get_model().getStandardOpaqueMaterials()
+                 if m.nameString().startswith("Kiva XPS")]
+    assert len(materials) == 1, materials
+    assert "R-SI 1.76" in materials[0]
+
+    second = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW,
+                                 overwrite=True)
+    assert second["ok"] is True, second
+    after = [m.nameString() for m in get_model().getStandardOpaqueMaterials()
+             if m.nameString().startswith("Kiva XPS")]
+    assert after == materials
+
+
+# --------------------------------------------------------------------------- refusals
+
+
+def test_massless_construction_layer_is_refused():
+    # Validates: EnergyPlus refuses a Foundation surface with no-mass layers. exampleModel's own
+    # floors use "CP02 CARPET PAD", so this is the real case, not a contrived one.
+    import openstudio
+
+    from mcp_server.model_manager import load_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_eligibility import classify_foundation_candidates
+
+    path = _allowed_dir() / "example.osm"
+    openstudio.model.exampleModel().save(openstudio.toPath(str(path)), True)
+    load_model(path)
+
+    from mcp_server.model_manager import get_model
+    blocked = {b["surface"]: b["reasons"] for b in classify_foundation_candidates(get_model())["blocked"]}
+    assert blocked, "expected exampleModel's carpet-pad floors to be refused"
+    assert any("not a standard opaque material" in r for reasons in blocked.values() for r in reasons)
+
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated", epw_path=BOSTON_EPW)
+    assert result["ok"] is False
+    assert "No eligible foundation floors" in result["error"]
+
+
+def test_surface_with_a_window_is_refused():
+    # Validates: "Foundation is not allowed with windows" — an EnergyPlus fatal
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_eligibility import kiva_surface_blockers
+    from mcp_server.skills.geometry.operations import create_subsurface
+
+    _build_quadrants()
+    wall = next(s for s in get_model().getSurfaces()
+                if s.surfaceType() == "Wall" and s.outsideBoundaryCondition() == "Outdoors")
+    created = create_subsurface(
+        name="Kiva Test Window", parent_surface_name=wall.nameString(),
+        vertices=[[1, 0.5], [2, 0.5], [2, 2], [1, 2]], subsurface_type="FixedWindow",
+    )
+    if created.get("ok"):
+        assert any("windows or doors" in b for b in kiva_surface_blockers(wall)), wall.nameString()
+
+
+def test_requested_surface_that_is_not_eligible_aborts_with_nothing_written():
+    # Validates: resolve-everything-before-writing — a typo must not leave a partial batch
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated",
+        floor_surface_names=[floors[0], "No Such Surface"],
+        epw_path=BOSTON_EPW,
+    )
+
+    assert result["ok"] is False
+    assert "No Such Surface" in result["refused_surfaces"]
+    assert len(get_model().getFoundationKivas()) == 0
+
+
+def test_unknown_archetype_is_refused_with_the_valid_names():
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(archetype="walkout_basement")
+
+    assert result["ok"] is False
+    assert "heated_basement_insulated" in result["valid_values"]
+
+
+def test_out_of_range_perimeter_fraction_is_refused_before_the_sdk_sees_it():
+    # Regression: OpenStudio silently discards a fraction outside 0..1 while still returning an
+    # object that looks created
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated", exposed_perimeter_method="fraction",
+        exposed_perimeter_fraction=12.0, epw_path=BOSTON_EPW,
+    )
+
+    assert result["ok"] is False
+    assert "between 0 and 1" in result["error"]
+
+
+def test_total_perimeter_across_several_floors_is_refused():
+    # Validates: one number cannot describe four slabs
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated", exposed_perimeter_method="total",
+        exposed_perimeter_m=40.0, epw_path=BOSTON_EPW,
+    )
+
+    assert result["ok"] is False
+    assert "one perimeter cannot describe several slabs" in result["error"]
+
+
+def test_reapplying_without_overwrite_is_refused():
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    assert set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                               include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
+    second = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+
+    assert second["ok"] is False
+    assert "overwrite=True" in second["error"]
+
+
+def test_no_model_loaded_reports_instead_of_raising():
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.geometry.kiva_foundation import get_foundation_options
+
+    assert set_kiva_foundation(archetype="slab_on_grade_uninsulated")["ok"] is False
+    assert get_foundation_options()["ok"] is False
+
+
+# --------------------------------------------------------------------------- options / state
+
+
+def test_get_foundation_options_does_not_create_the_settings_object():
+    # Regression: the plain getFoundationKivaSettings() creates the unique object. A read tool that
+    # used it would make every model look configured, and the next save would persist it.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_foundation import get_foundation_options
+
+    _build_quadrants()
+    assert get_model().getOptionalFoundationKivaSettings().is_initialized() is False
+
+    for _ in range(3):
+        options = get_foundation_options()
+        assert options["ok"] is True, options
+        assert options["existing_kiva"]["settings_present"] is False
+
+    assert get_model().getOptionalFoundationKivaSettings().is_initialized() is False
+
+
+def test_options_reports_the_archetype_menu_with_its_basis():
+    # Validates: the user is shown the numbers and their provenance before choosing, which is the
+    # only honest way to offer values nobody sourced
+    from mcp_server.skills.geometry.kiva_foundation import get_foundation_options
+
+    _build_quadrants()
+    options = get_foundation_options()
+
+    assert options["ok"] is True, options
+    assert options["eligible_floor_count"] == 4
+    assert len(options["archetypes"]) == 5
+    slab = next(a for a in options["archetypes"] if a["name"] == "slab_on_grade_perimeter_insulated")
+    assert "conventional starting point" in slab["basis"]
+    assert slab["insulation"][0]["r_si_m2k_w"] == 1.76
+
+
+def test_blank_epw_soil_leaves_settings_uncreated():
+    # Validates: every bundled EPW leaves the soil fields blank, so nothing is chosen and no
+    # FoundationKivaSettings object should appear
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert result["applied"]["settings_written"] == []
+    assert get_model().getOptionalFoundationKivaSettings().is_initialized() is False
+
+
+def test_user_soil_override_creates_settings_and_reports_provenance():
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(
+        archetype="slab_on_grade_uninsulated", include_below_grade_walls=False,
+        epw_path=BOSTON_EPW, soil_conductivity_w_mk=2.2,
+    )
+
+    assert result["ok"] is True, result
+    assert result["plan"]["soil"]["soil_conductivity_w_mk"]["provenance"] == "user"
+    settings = get_model().getOptionalFoundationKivaSettings()
+    assert settings.is_initialized()
+    assert settings.get().soilConductivity() == pytest.approx(2.2)
+
+
+def test_dry_run_changes_nothing():
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW,
+                                 dry_run=True)
+
+    assert result["ok"] is True, result
+    assert result["dry_run"] is True
+    assert result["plan"]["floors"]
+    assert len(get_model().getFoundationKivas()) == 0
+
+
+# --------------------------------------------------------------------------- Phase 1 interaction
+
+
+def test_kiva_reports_that_it_supersedes_the_building_surface_temperatures():
+    # Validates: a Foundation surface ignores Site:GroundTemperature:BuildingSurface entirely, so
+    # a user who ran both must be told rather than left to discover it
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.weather.ground_temperatures import set_ground_temperatures
+
+    _build_quadrants()
+    assert set_ground_temperatures(epw_path=BOSTON_EPW,
+                                   building_surface_method="constant",
+                                   building_surface_constant_c=18.0)["ok"]
+
+    result = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    interaction = result["ground_temperature_interaction"]
+    assert interaction["surfaces_now_kiva"] == 4
+    assert interaction["building_surface_state"] == "set"
+    assert "ignore it" in interaction["warning"]
+
+
+# --------------------------------------------------------------------------- translation proxy
+
+
+def test_forward_translation_emits_the_kiva_objects_without_errors():
+    # Validates: the cheap proxy for "EnergyPlus would accept this". The missing-perimeter failure
+    # is a runtime fatal, so the real check is the one manual simulation recorded in the PR — but
+    # a clean forward translation catches everything structural in about two seconds.
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    assert set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                               include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
+
+    translator = openstudio.energyplus.ForwardTranslator()
+    workspace = translator.translateModel(get_model())
+
+    assert list(translator.errors()) == [], [e.logMessage() for e in translator.errors()]
+    idf = workspace.toIdfFile().__str__()
+    assert "Foundation:Kiva" in idf
+    assert "SurfaceProperty:ExposedFoundationPerimeter" in idf
+
+
+# --------------------------------------------------------------------------- below-grade walls
+
+
+def _build_basement() -> tuple[str, list[str]]:
+    """One 10x10 space with its floor 2.5 m below grade, so its walls are fully buried."""
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.constructions.operations import assign_construction_to_surface
+    from mcp_server.skills.geometry.operations import create_space_from_floor_print
+
+    _load_empty_model()
+    construction = _slab_construction()
+    created = create_space_from_floor_print(
+        name="Basement", floor_vertices=QUADRANTS["SW"], floor_to_ceiling_height=2.5,
+    )
+    assert created["ok"] is True, created
+
+    model = get_model()
+    space = next(s for s in model.getSpaces() if s.nameString() == "Basement")
+    zone = openstudio.model.ThermalZone(model)
+    zone.setName("Basement Zone")
+    space.setThermalZone(zone)
+
+    # create_space_from_floor_print always extrudes upward from z=0, so drop the whole space to
+    # put the floor at -2.5 m and the walls entirely below grade.
+    for surface in space.surfaces():
+        moved = openstudio.Point3dVector([
+            openstudio.Point3d(v.x(), v.y(), v.z() - 2.5) for v in surface.vertices()
+        ])
+        assert surface.setVertices(moved)
+        assign_construction_to_surface(
+            surface_name=surface.nameString(), construction_name=construction,
+        )
+
+    floor = next(s.nameString() for s in space.surfaces() if s.surfaceType() == "Floor")
+    walls = sorted(s.nameString() for s in space.surfaces() if s.surfaceType() == "Wall")
+    return floor, walls
+
+
+def test_below_grade_walls_join_their_floors_foundation_object():
+    # Validates: EnergyPlus requires a Kiva wall to reference the SAME Foundation object as its
+    # floor, so pairing is adjacency rather than selection
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floor, walls = _build_basement()
+    result = set_kiva_foundation(archetype="heated_basement_insulated",
+                                 include_below_grade_walls=True, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert result["applied"]["floors"] == [floor]
+    assert sorted(result["applied"]["walls"]) == walls
+
+    kivas = get_model().getFoundationKivas()
+    assert len(kivas) == 1, [k.nameString() for k in kivas]
+    attached = sorted(s.nameString() for s in kivas[0].surfaces())
+    assert attached == sorted([floor, *walls])
+    for name in walls:
+        assert _surface(name).outsideBoundaryCondition() == "Foundation"
+        assert _surface(name).sunExposure() == "NoSun"
+
+
+def test_excluding_walls_leaves_them_alone():
+    # Validates: the escape hatch produces a floors-only model, which is still valid Kiva
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floor, walls = _build_basement()
+    result = set_kiva_foundation(archetype="heated_basement_insulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    assert result["applied"]["walls"] == []
+    assert _surface(floor).outsideBoundaryCondition() == "Foundation"
+    for name in walls:
+        assert _surface(name).outsideBoundaryCondition() != "Foundation"
+
+
+def test_basement_insulation_depth_comes_from_the_wall_geometry():
+    # Regression: basement depth is NOT a Kiva input. The archetype defers with MATCH_WALL_DEPTH
+    # and the writer must resolve it from the paired walls, not invent a number.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_basement()
+    result = set_kiva_foundation(archetype="heated_basement_insulated",
+                                 include_below_grade_walls=True, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    kiva = get_model().getFoundationKivas()[0]
+    assert kiva.exteriorVerticalInsulationDepth().get() == pytest.approx(2.5, abs=0.01)
+    assert kiva.exteriorVerticalInsulationMaterial().is_initialized()
+
+
+def test_basement_archetype_on_a_slab_model_is_refused():
+    # Validates: a basement archetype reaching a slab-on-grade model would write a foundation wall
+    # that is not there
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_quadrants()
+    result = set_kiva_foundation(archetype="heated_basement_insulated",
+                                 wall_depth_below_slab_m=2.4, epw_path=BOSTON_EPW)
+
+    assert result["ok"] is False
+    assert "no below-grade walls" in result["error"]
+
+
+# --------------------------------------------------------------------------- guards elsewhere
+
+
+def test_set_surface_boundary_conditions_refuses_a_dangling_foundation():
+    # Regression: "Foundation" is in the SDK's valid list, so this tool accepted it and produced a
+    # model that fails fatally in EnergyPlus for want of the two companion objects.
+    from mcp_server.skills.geometry.boundary_conditions import set_surface_boundary_conditions
+
+    floors = _build_quadrants()
+    result = set_surface_boundary_conditions(
+        surface_names=[floors[0]], outside_boundary_condition="Foundation",
+    )
+
+    assert result["ok"] is False
+    assert "set_kiva_foundation" in result["error"]
+    assert _surface(floors[0]).outsideBoundaryCondition() != "Foundation"
+
+
+def test_ground_temperature_report_goes_quiet_once_every_surface_uses_kiva():
+    # Validates: a user who did the higher-fidelity thing should not be nagged forever about
+    # Site:GroundTemperature:BuildingSurface, which Kiva ignores
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+    from mcp_server.skills.weather.ground_temperatures import find_missing_ground_temperatures
+
+    _build_quadrants()
+    before = find_missing_ground_temperatures()
+    assert before["kiva_foundation_surface_count"] == 0
+    assert "set_ground_temperatures()" in before["ground_temperatures_hint"]
+    assert "set_kiva_foundation()" in before["ground_temperatures_hint"]
+
+    assert set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                               include_below_grade_walls=False, epw_path=BOSTON_EPW)["ok"]
+
+    after = find_missing_ground_temperatures()
+    assert after["kiva_foundation_surface_count"] == 4
+    assert "would be inert here" in after["ground_temperatures_hint"]
+    assert after["ok"] is True

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -432,6 +432,53 @@ def test_reapplying_without_overwrite_is_refused():
     assert "overwrite=True" in second["error"]
 
 
+def test_overwrite_does_not_accumulate_foundation_objects():
+    # Regression: overwrite=True reset the floor's reference but never removed the previous
+    # FoundationKiva, so every re-run added four orphan Foundation:Kiva objects to the OSM/IDF
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floors = _build_quadrants()
+    first = set_kiva_foundation(archetype="slab_on_grade_uninsulated",
+                                include_below_grade_walls=False, epw_path=BOSTON_EPW)
+    assert first["ok"] is True, first
+    second = set_kiva_foundation(archetype="slab_on_grade_perimeter_insulated",
+                                 include_below_grade_walls=False, epw_path=BOSTON_EPW,
+                                 overwrite=True)
+
+    assert second["ok"] is True, second
+    kivas = get_model().getFoundationKivas()
+    assert len(kivas) == len(floors), sorted(k.nameString() for k in kivas)
+    assert all("slab_on_grade_perimeter_insulated" in k.nameString() for k in kivas)
+    for name in floors:
+        assert _surface(name).adjacentFoundation().get().nameString().startswith(
+            "Kiva slab_on_grade_perimeter_insulated")
+
+
+def test_overwrite_keeps_a_previous_foundation_that_walls_still_use_and_warns():
+    # Validates: when the re-run does not re-pair the walls, the old Foundation object is the only
+    # thing keeping their reference valid — it is kept and the response says which walls and why
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floor, walls = _build_basement()
+    first = set_kiva_foundation(archetype="unheated_basement", include_below_grade_walls=True,
+                                epw_path=BOSTON_EPW)
+    assert first["ok"] is True, first
+    second = set_kiva_foundation(archetype="unheated_basement", include_below_grade_walls=False,
+                                 epw_path=BOSTON_EPW, overwrite=True)
+
+    assert second["ok"] is True, second
+    assert len(get_model().getFoundationKivas()) == 2
+    kept = [w for w in second["warnings"] if "was kept because" in w]
+    assert len(kept) == 1, second["warnings"]
+    for name in walls:
+        assert name in kept[0]
+    floor_kiva = _surface(floor).adjacentFoundation().get().nameString()
+    wall_kiva = _surface(walls[0]).adjacentFoundation().get().nameString()
+    assert floor_kiva != wall_kiva
+
+
 def test_no_model_loaded_reports_instead_of_raising():
     # Validates: the operations contract (CLAUDE.md rule 5) — both Kiva tools return ok=False
     # with no model loaded rather than raising RuntimeError through MCP
@@ -752,6 +799,10 @@ def test_basement_archetype_on_a_slab_model_applies_without_wall_insulation():
     assert any("no below-grade wall was paired" in w for w in result["warnings"]), result["warnings"]
     for kiva in get_model().getFoundationKivas():
         assert not kiva.exteriorVerticalInsulationMaterial().is_initialized()
+    # A skipped layer must not leave an unused XPS material behind either.
+    xps = [m.nameString() for m in get_model().getStandardOpaqueMaterials()
+           if m.nameString().startswith("Kiva XPS")]
+    assert xps == [], xps
 
 
 def _build_stacked_basement() -> dict[str, object]:

--- a/tests/test_kiva_foundation.py
+++ b/tests/test_kiva_foundation.py
@@ -953,6 +953,104 @@ def test_basement_insulation_depth_comes_from_the_wall_geometry():
     kiva = get_model().getFoundationKivas()[0]
     assert kiva.exteriorVerticalInsulationDepth().get() == pytest.approx(2.5, abs=0.01)
     assert kiva.exteriorVerticalInsulationMaterial().is_initialized()
+    # Wall tops sit exactly at grade, so the derived wall height above grade is 0, not the 0.2
+    # archetype default.
+    assert kiva.wallHeightAboveGrade() == pytest.approx(0.0, abs=1e-6)
+
+
+def _raise_space(space_name: str, dz: float, via_origin: bool = False) -> None:
+    """Move a space up by dz: by rewriting vertices, or via the space origin (world transform)."""
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+
+    space = next(s for s in get_model().getSpaces() if s.nameString() == space_name)
+    if via_origin:
+        assert space.setZOrigin(space.zOrigin() + dz)
+        return
+    for surface in space.surfaces():
+        moved = openstudio.Point3dVector([
+            openstudio.Point3d(v.x(), v.y(), v.z() + dz) for v in surface.vertices()
+        ])
+        assert surface.setVertices(moved)
+
+
+@pytest.mark.parametrize("via_origin", [False, True])
+def test_full_depth_insulation_runs_from_the_wall_top_to_the_slab(via_origin):
+    # Regression: MATCH_WALL_DEPTH resolved to the depth below grade (-z_min), but the EnergyPlus
+    # field is measured from the WALL TOP, so a wall from +0.5 to -2.0 got 2.0 m of insulation
+    # and the last 0.5 m above the slab stayed bare. Also pins world coordinates: the same
+    # geometry expressed through the space origin must give the same answer.
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_basement()                             # floor -2.5, wall tops at 0
+    _raise_space("Basement", 0.5, via_origin)     # floor -2.0, wall tops at +0.5
+    result = set_kiva_foundation(archetype="heated_basement_insulated", epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    kiva = get_model().getFoundationKivas()[0]
+    assert kiva.exteriorVerticalInsulationDepth().get() == pytest.approx(2.5, abs=1e-6)
+    assert kiva.wallHeightAboveGrade() == pytest.approx(0.5, abs=1e-6)
+    foundation = result["applied"]["foundations"][0]
+    assert foundation["wall_geometry"] == {
+        "top_m": 0.5, "bottom_m": -2.0, "span_m": 2.5, "mixed_heights": False,
+        "span_range_m": [2.5, 2.5]}
+    assert foundation["wall_height_above_grade_m"] == {"value": 0.5, "provenance": "computed_geometry"}
+    assert foundation["insulation"]["exterior_vertical_insulation"]["depth_m"] == pytest.approx(2.5)
+    assert foundation["insulation"]["exterior_vertical_insulation"]["provenance"]["depth_m"] == "computed_geometry"
+
+
+def test_explicit_insulation_depth_and_wall_height_are_written_verbatim():
+    # Validates: a caller value is never replaced by the geometry-derived one, for either field
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    _build_basement()
+    _raise_space("Basement", 0.5)
+    result = set_kiva_foundation(archetype="heated_basement_insulated", epw_path=BOSTON_EPW,
+                                 exterior_vertical_insulation_depth_m=1.2,
+                                 wall_height_above_grade_m=0.3)
+
+    assert result["ok"] is True, result
+    kiva = get_model().getFoundationKivas()[0]
+    assert kiva.exteriorVerticalInsulationDepth().get() == pytest.approx(1.2)
+    assert kiva.wallHeightAboveGrade() == pytest.approx(0.3)
+    foundation = result["applied"]["foundations"][0]
+    assert foundation["wall_height_above_grade_m"] == {"value": 0.3, "provenance": "user"}
+    assert foundation["insulation"]["exterior_vertical_insulation"]["provenance"]["depth_m"] == "user"
+
+
+def test_mixed_wall_heights_use_the_largest_span_and_say_so():
+    # Validates: one Foundation:Kiva carries one insulation depth, so walls of differing height
+    # cannot all be matched exactly — the largest span is used and the response discloses it
+    import openstudio
+
+    from mcp_server.model_manager import get_model
+    from mcp_server.skills.geometry.kiva_apply import set_kiva_foundation
+
+    floor, walls = _build_basement()
+    tall = _surface(walls[0])
+    raised = openstudio.Point3dVector([
+        openstudio.Point3d(v.x(), v.y(), v.z() + (1.0 if v.z() > -2.4 else 0.0))
+        for v in tall.vertices()
+    ])
+    assert tall.setVertices(raised)              # this wall now runs -2.5 to +1.0
+
+    dry = set_kiva_foundation(archetype="heated_basement_insulated", epw_path=BOSTON_EPW,
+                              dry_run=True)
+    result = set_kiva_foundation(archetype="heated_basement_insulated", epw_path=BOSTON_EPW)
+
+    assert result["ok"] is True, result
+    geometry = result["plan"]["wall_geometry_by_floor"][floor]
+    assert geometry["walls"]["mixed_heights"] is True
+    assert geometry["walls"]["span_range_m"] == [2.5, 3.5]
+    assert geometry["full_depth_insulation_m"] == 3.5
+    assert dry["plan"]["wall_geometry_by_floor"] == result["plan"]["wall_geometry_by_floor"]
+    assert any("largest span (3.5 m)" in w for w in result["warnings"]), result["warnings"]
+    kiva = get_model().getFoundationKivas()[0]
+    assert kiva.exteriorVerticalInsulationDepth().get() == pytest.approx(3.5)
+    assert kiva.wallHeightAboveGrade() == pytest.approx(1.0)
 
 
 def test_user_stem_wall_depth_on_a_slab_model_is_honoured():
@@ -1127,7 +1225,14 @@ def test_real_revit_basement_export_pairs_every_buried_wall():
     kivas = get_model().getFoundationKivas()
     assert len(kivas) == 1
     assert len(kivas[0].surfaces()) == 16
-    assert kivas[0].exteriorVerticalInsulationDepth().get() == pytest.approx(3.048, abs=0.01)
+    # Walls run +0.91 to -3.05: the depth field is measured from the wall top, so 3.96 m, and
+    # the wall height above grade is the 0.91 m the geometry shows, not the archetype's 0.2.
+    assert kivas[0].exteriorVerticalInsulationDepth().get() == pytest.approx(3.96, abs=0.01)
+    assert kivas[0].wallHeightAboveGrade() == pytest.approx(0.91, abs=0.01)
+    foundation = result["applied"]["foundations"][0]
+    assert foundation["wall_height_above_grade_m"] == {
+        "value": pytest.approx(0.91, abs=0.01), "provenance": "computed_geometry"}
+    assert foundation["insulation"]["exterior_vertical_insulation"]["depth_m"] == pytest.approx(3.96, abs=0.01)
     zones = {s.space().get().thermalZone().get().nameString() for s in kivas[0].surfaces()}
     assert zones == {"0 Basement (Unconditioned)"}
     perimeter = result["applied"]["foundations"][0]["exposed_perimeter"]

--- a/tests/test_measure_discovery.py
+++ b/tests/test_measure_discovery.py
@@ -17,11 +17,19 @@ BCL_CONTENT_URL = "https://bcl.nlr.gov/content/c567a0bf-a7d9-4a06-afe9-bf7df79e6
 
 
 def _import_measure_ops(monkeypatch, request, run_root: Path):
-    monkeypatch.setenv("OPENSTUDIO_MCP_RUN_ROOT", str(run_root))
     try:
         import openstudio  # noqa: F401 — real SDK present (Docker/dev): no fake needed.
+        # Bind mcp_server.config from the REAL environment before touching the env var. config
+        # reads OPENSTUDIO_MCP_RUN_ROOT once at import, so if this test file is the first thing
+        # in the process to import it, the pytest tmp dir would become the process-wide RUN_ROOT
+        # for every later in-process test in the shard — and a sandboxed OpenStudio CLI (other
+        # uid) cannot read a root-owned /tmp/pytest-of-root tree. The tests below patch
+        # ops.user_run_root explicitly, so the env var is only needed by the no-SDK branch.
+        importlib.import_module("mcp_server.config")
+        monkeypatch.setenv("OPENSTUDIO_MCP_RUN_ROOT", str(run_root))
         return importlib.import_module("mcp_server.skills.measures.operations")
     except ImportError:
+        monkeypatch.setenv("OPENSTUDIO_MCP_RUN_ROOT", str(run_root))
         # No SDK (pure no-Docker unit run): fake openstudio just long enough to import
         # measures.operations, then restore the affected modules at teardown so the fake
         # can't leak into later test files in the same process (e.g. test_validate_model).

--- a/tests/test_skill_registration.py
+++ b/tests/test_skill_registration.py
@@ -42,6 +42,8 @@ EXPECTED_TOOLS = {
     "weld_coincident_vertices",
     "patch_missing_surfaces",
     "set_surface_boundary_conditions",
+    "get_foundation_options",
+    "set_kiva_foundation",
     "trim_overlapping_surfaces",
     "set_window_to_wall_ratio",
     "list_materials",
@@ -112,6 +114,7 @@ EXPECTED_TOOLS = {
     # Phase 6C: Weather, Design Days, SimControl, RunPeriod
     "list_weather_files",
     "get_weather_info",
+    "set_ground_temperatures",
     "add_design_day",
     "get_simulation_control",
     "set_simulation_control",

--- a/tests/test_zone_heating_setpoints.py
+++ b/tests/test_zone_heating_setpoints.py
@@ -161,6 +161,8 @@ def test_setback_higher_than_default_still_takes_the_maximum():
 
 
 def test_zone_without_a_thermostat_is_skipped_and_named():
+    # Validates: an unconditioned zone (no dual-setpoint thermostat) is excluded from the mean
+    # and counts, and named in zones_skipped with its reason rather than dropped silently
     zones = [
         _FakeThermalZone("Conditioned", _FakeThermostat(_FakeScheduleConstant(21.0))),
         _FakeThermalZone("Corridor", None),
@@ -199,6 +201,8 @@ def test_unsupported_schedule_type_is_skipped_not_guessed():
 
 
 def test_empty_ruleset_is_skipped():
+    # Validates: a ScheduleRuleset whose day schedules carry no values is skipped with a
+    # specific reason — max() over an empty list must not raise or yield a bogus setpoint
     zones = [_FakeThermalZone("Empty", _FakeThermostat(_FakeScheduleRuleset([])))]
 
     result = zone_heating_setpoints(_FakeModel(zones))
@@ -220,7 +224,9 @@ def test_model_with_no_thermostats_reports_that_specific_reason():
 
 
 def test_model_with_no_zones_at_all():
-    result = zone_heating_setpoints(_FakeModel([]))
+    # Validates: a zone-less model (fresh or geometry-only) returns mean_c=None, zone_count=0
+    # and the "no thermostat" skip reason instead of a division-by-zero or a crash
+    result =zone_heating_setpoints(_FakeModel([]))
 
     assert result["mean_c"] is None
     assert result["zone_count"] == 0
@@ -257,6 +263,8 @@ def test_wide_setpoint_spread_is_warned_but_still_averaged():
 
 
 def test_narrow_spread_produces_no_warning():
+    # Validates: the spread warning has a threshold — a 2 K span between zones is ordinary and
+    # must not produce noise that trains callers to ignore spread_warning
     zones = [
         _FakeThermalZone("A", _FakeThermostat(_FakeScheduleConstant(20.0))),
         _FakeThermalZone("B", _FakeThermostat(_FakeScheduleConstant(22.0))),

--- a/tests/test_zone_heating_setpoints.py
+++ b/tests/test_zone_heating_setpoints.py
@@ -1,0 +1,265 @@
+"""Unit tests for mcp_server.skills.weather.zone_heating_setpoints.
+
+Pure Python — no `openstudio`, no Docker. The module only calls a handful of methods on
+thermal zones, thermostats and schedules, so lightweight fakes exercise the real branching.
+Same tier and same rationale as tests/test_gbxml_zone_checks.py.
+
+The fakes mirror OpenStudio 3.11.0 behaviour observed in a probe: a ScheduleRuleset with a
+21.1 C occupied default and a 15.6 C setback rule reads back as
+defaultDaySchedule().values() == [21.1] and scheduleRules()[0].daySchedule().values() == [15.6].
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_server.skills.weather.zone_heating_setpoints import zone_heating_setpoints
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeOptional:
+    def __init__(self, value=None):
+        self._value = value
+
+    def is_initialized(self) -> bool:
+        return self._value is not None
+
+    def get(self):
+        return self._value
+
+
+class _FakeDaySchedule:
+    def __init__(self, values):
+        self._values = values
+
+    def values(self):
+        return self._values
+
+
+class _FakeRule:
+    def __init__(self, values):
+        self._day = _FakeDaySchedule(values)
+
+    def daySchedule(self):
+        return self._day
+
+
+class _FakeScheduleRuleset:
+    """A ScheduleRuleset-shaped object. `rules` are the setback day values."""
+
+    def __init__(self, default_values, rules=()):
+        self._default = _FakeDaySchedule(list(default_values))
+        self._rules = [_FakeRule(list(v)) for v in rules]
+
+    def defaultDaySchedule(self):
+        return self._default
+
+    def scheduleRules(self):
+        return self._rules
+
+    def to_ScheduleRuleset(self):
+        return _FakeOptional(self)
+
+    def to_ScheduleConstant(self):
+        return _FakeOptional(None)
+
+
+class _FakeScheduleConstant:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+    def to_ScheduleRuleset(self):
+        return _FakeOptional(None)
+
+    def to_ScheduleConstant(self):
+        return _FakeOptional(self)
+
+
+class _FakeScheduleCompact:
+    """Neither castable type — the ScheduleCompact / ScheduleYear case."""
+
+    def to_ScheduleRuleset(self):
+        return _FakeOptional(None)
+
+    def to_ScheduleConstant(self):
+        return _FakeOptional(None)
+
+
+class _FakeThermostat:
+    def __init__(self, heating_schedule=None):
+        self._schedule = _FakeOptional(heating_schedule)
+
+    def heatingSetpointTemperatureSchedule(self):
+        return self._schedule
+
+
+class _FakeThermalZone:
+    def __init__(self, name, thermostat=None):
+        self._name = name
+        self._thermostat = _FakeOptional(thermostat)
+
+    def nameString(self):
+        return self._name
+
+    def thermostatSetpointDualSetpoint(self):
+        return self._thermostat
+
+
+class _FakeModel:
+    def __init__(self, zones):
+        self._zones = zones
+
+    def getThermalZones(self):
+        return self._zones
+
+
+def _zone(name, value=None, rules=(), schedule=None):
+    if schedule is None and value is not None:
+        schedule = _FakeScheduleRuleset([value], rules)
+    return _FakeThermalZone(name, _FakeThermostat(schedule) if schedule else None)
+
+
+def test_mean_across_zones_with_constant_schedules():
+    # Validates: the unweighted mean, and that min/max travel with it so a caller can judge
+    zones = [
+        _FakeThermalZone("A", _FakeThermostat(_FakeScheduleConstant(20.0))),
+        _FakeThermalZone("B", _FakeThermostat(_FakeScheduleConstant(21.0))),
+        _FakeThermalZone("C", _FakeThermostat(_FakeScheduleConstant(22.0))),
+    ]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] == 21.0
+    assert result["min_c"] == 20.0
+    assert result["max_c"] == 22.0
+    assert result["zone_count"] == 3
+    assert result["zones_skipped"] == []
+    assert result["skip_reason"] is None
+    assert result["method"] == "schedule_max_per_zone"
+
+
+def test_ruleset_uses_the_occupied_maximum_not_the_setback():
+    # Regression: a 21.1/15.6 setback schedule must yield 21.1. Averaging the two gives
+    # 18.35, which would push every derived ground temperature ~3 K too low on every real
+    # model — the single most likely silent error in this feature.
+    zones = [_zone("Office", 21.1, rules=([15.6],))]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] == 21.1
+    assert result["setpoints_c"] == [("Office", 21.1)]
+
+
+def test_setback_higher_than_default_still_takes_the_maximum():
+    # Validates: the rule is "max over every day schedule", not "the default day"
+    zones = [_zone("Odd", 18.0, rules=([22.5],))]
+
+    assert zone_heating_setpoints(_FakeModel(zones))["mean_c"] == 22.5
+
+
+def test_zone_without_a_thermostat_is_skipped_and_named():
+    zones = [
+        _FakeThermalZone("Conditioned", _FakeThermostat(_FakeScheduleConstant(21.0))),
+        _FakeThermalZone("Corridor", None),
+    ]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] == 21.0
+    assert result["zone_count"] == 1
+    assert result["zones_with_thermostat"] == 1
+    assert result["zones_skipped"] == [{"zone": "Corridor", "reason": "no dual-setpoint thermostat"}]
+
+
+def test_thermostat_without_a_heating_schedule_is_skipped():
+    # Validates: a cooling-only thermostat is counted as present but yields no setpoint
+    zones = [_FakeThermalZone("CoolOnly", _FakeThermostat(None))]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] is None
+    assert result["zones_with_thermostat"] == 1
+    assert result["zones_skipped"] == [
+        {"zone": "CoolOnly", "reason": "thermostat has no heating setpoint schedule"},
+    ]
+    assert result["skip_reason"] == "no zone has a readable heating setpoint schedule"
+
+
+def test_unsupported_schedule_type_is_skipped_not_guessed():
+    # Validates: ScheduleCompact / ScheduleYear are reported, never approximated
+    zones = [_FakeThermalZone("Compact", _FakeThermostat(_FakeScheduleCompact()))]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] is None
+    assert "unsupported schedule type" in result["zones_skipped"][0]["reason"]
+
+
+def test_empty_ruleset_is_skipped():
+    zones = [_FakeThermalZone("Empty", _FakeThermostat(_FakeScheduleRuleset([])))]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] is None
+    assert result["zones_skipped"][0]["reason"] == "schedule ruleset carries no values"
+
+
+def test_model_with_no_thermostats_reports_that_specific_reason():
+    # Validates: the caller must be able to distinguish "no thermostats" from "unreadable
+    # schedules" — they lead to different advice
+    zones = [_FakeThermalZone("A", None), _FakeThermalZone("B", None)]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] is None
+    assert result["zones_with_thermostat"] == 0
+    assert result["skip_reason"] == "no thermostat in the model"
+
+
+def test_model_with_no_zones_at_all():
+    result = zone_heating_setpoints(_FakeModel([]))
+
+    assert result["mean_c"] is None
+    assert result["zone_count"] == 0
+    assert result["skip_reason"] == "no thermostat in the model"
+
+
+def test_implausible_setpoint_is_skipped_with_the_value_named():
+    # Validates: a 60 C "setpoint" is a unit bug; it must not drag the mean
+    zones = [
+        _FakeThermalZone("Sane", _FakeThermostat(_FakeScheduleConstant(21.0))),
+        _FakeThermalZone("Broken", _FakeThermostat(_FakeScheduleConstant(60.0))),
+    ]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] == 21.0
+    assert result["zones_skipped"] == [
+        {"zone": "Broken", "reason": "implausible heating setpoint 60.0 C"},
+    ]
+
+
+def test_wide_setpoint_spread_is_warned_but_still_averaged():
+    # Validates: a warehouse-plus-cleanroom model still returns a number, with the spread
+    # surfaced so nobody mistakes the mean for a description of the building
+    zones = [
+        _FakeThermalZone("Warehouse", _FakeThermostat(_FakeScheduleConstant(10.0))),
+        _FakeThermalZone("Lab", _FakeThermostat(_FakeScheduleConstant(24.0))),
+    ]
+
+    result = zone_heating_setpoints(_FakeModel(zones))
+
+    assert result["mean_c"] == 17.0
+    assert "span 14.0 K" in result["spread_warning"]
+
+
+def test_narrow_spread_produces_no_warning():
+    zones = [
+        _FakeThermalZone("A", _FakeThermostat(_FakeScheduleConstant(20.0))),
+        _FakeThermalZone("B", _FakeThermostat(_FakeScheduleConstant(22.0))),
+    ]
+
+    assert zone_heating_setpoints(_FakeModel(zones))["spread_warning"] is None


### PR DESCRIPTION
A gbXML translation arrives with **no ground temperatures at all**, so EnergyPlus falls back to its own defaults — 18 °C every month on every `Ground` surface, in Boston and Austin alike. The project EPW has carried measured ground temperatures the whole time and nothing read them.

This adds both a fast approximate method and a detailed one, because ground-coupled heat transfer genuinely needs both.

## Two methods

| | `set_ground_temperatures` | `set_kiva_foundation` |
|---|---|---|
| What | Writes the four `Site:GroundTemperature:*` objects from the EPW header | Solves a 2D finite-difference soil domain per floor |
| User input | None | Foundation type, ideally real insulation detail |
| Simulation cost | None | Substantial — one domain per floor (an E+ rule, not a choice) |
| For | Screening, compliance runs, models with no foundation information | Slab-edge loss, basement-dominated buildings, studying the foundation |

A `Foundation` surface **ignores `Site:GroundTemperature:BuildingSurface` entirely**, so the two do not stack. Each tool reports what it did to the other.

## Why BuildingSurface is not written from the EPW

EPW ground temperatures are *undisturbed* soil — an open field, no building. The repo's own weather assets say so (`tests/assets/USA_MA_Boston-Logan...stat:498-500`):

> `**These ground temperatures should NOT BE USED in the GroundTemperatures object to compute building floor losses.`

Boston's January value at 0.5 m is −0.29 °C; writing that under a heated slab overstates the floor loss badly. So `Shallow`, `Deep` and `FCfactorMethod` take the raw values at the nearest depths to 0.5 m and 4.0 m, and `BuildingSurface` is derived from the model's own heating setpoints (occupied setpoint − 2 °C) — or skipped with a reason when the model has no thermostats, which a gbXML import often does not.

The response is honest about what each object actually does: `Shallow`/`Deep` are inert without a ground heat exchanger, `FCfactorMethod` only affects F/C-factor constructions, and only `BuildingSurface` changes a typical model's floor heat balance. Four written objects are not four improvements.

## Asking the user, instead of guessing

Kiva needs foundation detail a gbXML export does not contain. Rather than inventing it silently, the workflow asks — via the new `foundation-modeling` skill, using the repo's existing idiom (skill prose plus tool params; no `ctx.elicit()`, which has zero precedent here):

```
1. get_foundation_options()                      # eligible surfaces, blockers, perimeter, menu
2. (agent puts the archetype choice to the user)
3. set_kiva_foundation(archetype="heated_basement_insulated")
```

Five archetypes — uninsulated / perimeter-insulated slab, heated / unheated basement, vented crawlspace. Below-grade walls pair to their floor by shared edge and join the same Foundation object, as EnergyPlus requires.

## Being straight about the archetype numbers

**The insulation R-values are conventional starting points, not code-derived.** I looked for a vendored basis and there isn't one:

- `openstudio-standards` has 90 `GroundContact*` rows, but as **F-factor and C-factor** — code performance per unit perimeter, with no insulation depth, width or position. Inverting them needs ASHRAE 90.1 Appendix A tables that are not vendored here.
- NECB's `apply_kiva_foundation` applies no insulation at all; ComStock has none.
- The `tbd` gem supplies the XPS properties and the 0.6 m interior-horizontal width. Those are cited.

So the 90.1 F/C-factor target for the model's climate zone is reported **alongside as a cross-check**, never used as a derivation. Every archetype carries a `basis` string saying it is conventional, every applied value carries provenance (`user` / `archetype:*` / `epw_header` / `openstudio_default` / `computed_geometry`), and the user is shown the full parameter set before choosing.

Provenance is not decoration: `wall_height_above_grade = 0.2` is both the archetype value and the IDD default, so where they agree the field is left defaulted and reported as `openstudio_default (archetype agrees)` rather than claiming credit for it.

## Three SDK traps, each pinned by a regression test

1. **`Surface.exposedPerimeter()` segfaults on a surface with no parent space.** No exception, no error dict — the interpreter dies and the MCP session with it. gbXML imports produce parentless surfaces routinely (that is why `patch_missing_surfaces` exists).
2. **`createSurfacePropertyExposedFoundationPerimeter()` reports success when it silently discarded the input** — `"Calculate"` and any unknown string read back as empty, and an out-of-range fraction leaves the value unset, both while returning an initialized Optional. The method is whitelisted, the value range-checked, and both read back and compared.
3. **`setAdjacentFoundation()` leaves `SunExposed`/`WindExposed` intact**, which would put solar gain on a buried slab — the exact defect `ground_contact.py` exists to catch. The boundary condition is set first.

Also: the plain unique-object getters for both `Site:GroundTemperature:*` and `FoundationKivaSettings` **create on read**, so every read path uses the Optional form — otherwise `get_weather_info` would mutate the session model and the next save would persist four objects nobody asked for. An all-defaulted object *is* written to the OSM and survives a reload, so detection uses four states (`absent` / `defaulted` / `partial` / `set`) rather than presence.

## Also fixed

`set_surface_boundary_conditions` previously **accepted `"Foundation"`** — it is in the SDK's valid list — producing a model that fails fatally in EnergyPlus for want of the two companion objects. It now refuses and points at `set_kiva_foundation`, which writes all three together.

`find_missing_ground_temperatures()` reports `kiva_foundation_surface_count` and stops flagging `BuildingSurface` once every ground-coupled surface uses Kiva, so `repair_and_validate_gbxml_geometry` doesn't nag the user who did the higher-fidelity thing. Report-only throughout; `ok` is never moved, matching `ground_contact_missing_count`.

## Verification

`ForwardTranslator` is only a proxy — a missing exposed-perimeter object is a *runtime* fatal — so I ran EnergyPlus by hand once (25.2.0, Boston TMY3, one-week run, two slabs):

```
exit=0    EnergyPlus Completed Successfully -- 8 Warning; 0 Severe Errors

! <Kiva Foundation Name>, Horizontal Cells, Vertical Cells, Total Cells, Total Exposed Perimeter, ...
KIVA SLAB_ON_GRADE_PERIMETER_INSULATED SURFACE 1,39,27,1053,30.00,1.00,...
KIVA SLAB_ON_GRADE_PERIMETER_INSULATED SURFACE 7,39,27,1053,30.00,1.00,...
```

The 30.00 m matches what `compute_exposed_perimeters` reported, so the geometry path is right end to end. Evidence is recorded in the `tests/test_kiva_foundation.py` module docstring.

**264 tests pass.** 50 are unit tier and need neither Docker nor `openstudio` — the EPW parser, the setpoint derivation, and the archetype/provenance table are all pure by design. Zero new lint errors (repo baseline is 124 on `develop`, unchanged). `tests/test_kiva_foundation.py` appended to CI shard 5; `tests/test_ground_temperatures.py` to shard 2.

## Reviewer notes — two things I'd flag

- **The archetype R-values are the weak point.** Mitigated by disclosure rather than accuracy, for the reasons above. If you want those four numbers to carry real judgment they are a one-line change each in `kiva_archetypes.py`.
- **Wall pairing is proven on synthetic geometry, not on a real export.** The plan called for pinning it against `tests/assets/2026_11Ja_path1.xml` (the basement fixture with 1 declared Ground surface out of 292) and I tested a clean synthetic basement instead. Shared-edge matching on Revit geometry with slivers and unwelded vertices is the untested case; `include_below_grade_walls=False` is the escape hatch. Worth doing before relying on it.

Docs: `docs/examples/25_ground_and_foundation_heat_transfer.md` covers concepts, method selection and both walkthroughs; `mcp_server/skills/geometry/README.md` records the EnergyPlus Kiva constraint table and the three traps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
